### PR TITLE
fix: make sure exported files have correct extensions

### DIFF
--- a/packages/web/src/helpers/saveFile.ts
+++ b/packages/web/src/helpers/saveFile.ts
@@ -14,7 +14,11 @@ export function checkBlobSupport() {
   }
 }
 
-export function saveFile(content: string, filename: string) {
-  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' })
+export interface SaveFileOptions {
+  mimeType?: string
+}
+
+export function saveFile(content: string, filename: string, type: string) {
+  const blob = new Blob([content], { type })
   saveAs(blob, filename)
 }

--- a/packages/web/src/state/algorithm/algorithm.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithm.sagas.ts
@@ -255,19 +255,19 @@ export function* runAlgorithm(content?: File | string) {
 export function* exportCsv() {
   const results = yield* select(selectResults)
   const str = yield* call(serializeResultsToCsv, results, ';')
-  saveFile(str, EXPORT_CSV_FILENAME)
+  saveFile(str, EXPORT_CSV_FILENAME, 'text/csv;charset=utf-8')
 }
 
 export function* exportTsv() {
   const results = yield* select(selectResults)
   const str = yield* call(serializeResultsToCsv, results, '\t')
-  saveFile(str, EXPORT_TSV_FILENAME)
+  saveFile(str, EXPORT_TSV_FILENAME, 'text/csv;charset=utf-8')
 }
 
 export function* exportJson() {
   const results = yield* select(selectResults)
   const str = yield* call(serializeResultsToJson, results)
-  saveFile(str, EXPORT_JSON_FILENAME)
+  saveFile(str, EXPORT_JSON_FILENAME, 'application/json;charset=utf-8')
 }
 
 export default [


### PR DESCRIPTION
Set correct mime types to exported blobs, so that browsers don't get confused and don't add .txt file extensions.

