### PR TITLE
fix(cli): make sure the custom tree is used

### DIFF
--- a/packages/web/src/cli/cli.ts
+++ b/packages/web/src/cli/cli.ts
@@ -205,12 +205,14 @@ export async function main() {
     outputTree,
     inputQcConfig,
     inputRootSeq,
+    inputTree,
   } = await validateParams(params)
 
   const { input, rootSeq, qcRulesConfig, auspiceDataReference } = await readInputs({
     inputFasta,
     inputQcConfig,
     inputRootSeq,
+    inputTree,
   })
 
   const { results, auspiceData } = run(input, rootSeq, qcRulesConfig, auspiceDataReference)


### PR DESCRIPTION
This fixes a bug, when `--input-tree` was erroneously ignored, due to parameter not being passed properly between functions, so that the custom input tree was not used.
