### PR TITLE
fix: make sure results table is displayed correctly on Safari 13

### DIFF
--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -131,6 +131,15 @@ export const TableRowError = styled(TableRow)<{ even?: boolean }>`
   color: #962d26;
 `
 
+const AutoSizerStyled = styled(AutoSizer)`
+  height: 100%; // Workaround for Safari
+`
+
+const FixedSizeListStyled = styled(FixedSizeList)`
+  min-height: 100%;
+  height: 100% !important; // Workaround for Safari
+`
+
 const highlightRowsWithIssues = true
 
 export interface RowProps extends ListChildComponentProps {
@@ -405,10 +414,11 @@ export function ResultsTableDisconnected({
           </TableHeaderCell>
         </TableHeaderRow>
 
-        <AutoSizer>
+        {/* style props is needed for Safari */}
+        <AutoSizerStyled style={{ minHeight: '100%', height: '100%' }}>
           {({ width, height }) => {
             return (
-              <FixedSizeList
+              <FixedSizeListStyled
                 overscanCount={10}
                 style={{ overflowY: 'scroll' }}
                 width={width}
@@ -418,10 +428,10 @@ export function ResultsTableDisconnected({
                 itemData={data}
               >
                 {TableRowMemo}
-              </FixedSizeList>
+              </FixedSizeListStyled>
             )
           }}
-        </AutoSizer>
+        </AutoSizerStyled>
       </Table>
     </>
   )


### PR DESCRIPTION
Safari flexbox bug requires setting explicit height, otherwise our table has a height of 0 pixels.

Resolves #138
