### PR TITLE
feat(cli): add possibility to override clades, primers and gene map

### DIFF
--- a/packages/web/src/algorithms/primers/validatePcrPrimers.ts
+++ b/packages/web/src/algorithms/primers/validatePcrPrimers.ts
@@ -1,6 +1,12 @@
+import type { PrimerEntries } from 'src/algorithms/primers/convertPcrPrimers'
 import type { PcrPrimer } from 'src/algorithms/types'
 
+export function validatePcrPrimerEntries(primersEntriesUnsafe: unknown) {
+  // TODO: validate PCR primers CSV entries
+  return primersEntriesUnsafe as PrimerEntries[]
+}
+
 export function validatePcrPrimers(primersUnsafe: unknown) {
-  // TODO
+  // TODO: validate PCR primers JSON
   return primersUnsafe as PcrPrimer[]
 }

--- a/packages/web/src/io/validateGeneMap.ts
+++ b/packages/web/src/io/validateGeneMap.ts
@@ -1,0 +1,6 @@
+import { Gene } from 'src/algorithms/types'
+
+export function validateGeneMap(geneMapUnsafe: unknown) {
+  // TODO: validate Gene Map
+  return geneMapUnsafe as Gene[]
+}


### PR DESCRIPTION
This adds new CLI parameters, for overriding the default clades, primers and gene map.
This now correctly resolves primer positions relative root sequence when a custom root sequence is provided.
 