### PR TITLE
fix: prevent app from crashing when a locale is missing

### DIFF
--- a/packages/web/src/i18n/i18n.auspice.ts
+++ b/packages/web/src/i18n/i18n.auspice.ts
@@ -1,7 +1,7 @@
 import i18nOriginal, { i18n as I18N } from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
-import { DEFAULT_LOCALE_KEY, I18NInitParams, LocaleKey } from 'src/i18n/i18n'
+import { DEFAULT_LOCALE_KEY, I18NInitParams, LocaleKey, localeKeys } from 'src/i18n/i18n'
 
 import enSidebar from 'auspice/src/locales/en/sidebar.json'
 import arSidebar from 'auspice/src/locales/ar/sidebar.json'
@@ -54,8 +54,12 @@ export function i18nAuspiceInit({ localeKey }: I18NInitParams) {
   return i18nAuspice
 }
 
-export function changeAuspiceLocale(i18nAuspice: I18N, localeKey: LocaleKey) {
-  return i18nAuspice.changeLanguage(localeKey)
+export async function changeAuspiceLocale(i18nAuspice: I18N, localeKey: LocaleKey) {
+  if (localeKeys.includes(localeKey)) {
+    await i18nAuspice.changeLanguage(localeKey)
+    return true
+  }
+  return false
 }
 
 const i18nAuspice = i18nAuspiceInit({ localeKey: DEFAULT_LOCALE_KEY })

--- a/packages/web/src/i18n/i18n.ts
+++ b/packages/web/src/i18n/i18n.ts
@@ -43,7 +43,6 @@ export type LocaleKey = keyof typeof translations
 
 export const DEFAULT_LOCALE_KEY: LocaleKey = 'en'
 export const resources = mapValues(translations, (value) => ({ translation: value }))
-export const localeKeys = Object.keys(translations) as LocaleKey[]
 
 export interface Locale {
   readonly full: string
@@ -67,6 +66,8 @@ export const locales: Record<LocaleKey, Locale> = {
   ru: { full: 'ru-RU', name: languages.ru.native, Flag: RU },
   zh: { full: 'zh-CN', name: languages.zh.native, Flag: CN },
 } as const
+
+export const localeKeys = Object.keys(locales)
 
 export const localesArray: LocaleWithKey[] = Object.entries(locales).map(([key, value]) => ({
   ...value,
@@ -110,10 +111,14 @@ export function getLocaleWithKey(key: LocaleKey) {
 }
 
 export async function changeLocale(i18n: I18N, localeKey: LocaleKey) {
-  const locale = locales[localeKey]
-  moment.locale(localeKey)
-  numbro.setLanguage(locale.full)
-  return i18n.changeLanguage(localeKey)
+  if (localeKeys.includes(localeKey)) {
+    const locale = locales[localeKey]
+    moment.locale(localeKey)
+    numbro.setLanguage(locale.full)
+    await i18n.changeLanguage(localeKey)
+    return true
+  }
+  return false
 }
 
 const i18n = i18nInit({ localeKey: DEFAULT_LOCALE_KEY })

--- a/packages/web/src/state/settings/settings.sagas.ts
+++ b/packages/web/src/state/settings/settings.sagas.ts
@@ -1,15 +1,20 @@
-import { takeEvery, call } from 'redux-saga/effects'
+import { takeEvery, call, put } from 'typed-redux-saga'
 
 import { Action } from 'src/state/util/fsaActions'
 
-import i18n, { changeLocale, LocaleKey } from 'src/i18n/i18n'
+import i18n, { changeLocale, DEFAULT_LOCALE_KEY, LocaleKey } from 'src/i18n/i18n'
 import i18nAuspice, { changeAuspiceLocale } from 'src/i18n/i18n.auspice'
 import { setLocale } from './settings.actions'
 
 export function* onSetLocale({ payload }: Action<LocaleKey>) {
   const localeKey = payload
-  yield call(changeLocale, i18n, localeKey)
-  yield call(changeAuspiceLocale, i18nAuspice, localeKey)
+
+  const localeChangedSuccessfully = yield* call(changeLocale, i18n, localeKey)
+  if (!localeChangedSuccessfully) {
+    yield* put(setLocale(DEFAULT_LOCALE_KEY))
+  }
+
+  yield* call(changeAuspiceLocale, i18nAuspice, localeKey)
 }
 
 export default [takeEvery(setLocale, onSetLocale)]

--- a/packages/web/src/state/settings/settings.state.ts
+++ b/packages/web/src/state/settings/settings.state.ts
@@ -1,8 +1,7 @@
 import type { QCRulesConfig } from 'src/algorithms/QC/types'
 import { getVirus } from 'src/algorithms/defaults/viruses'
 
-import { detectLocale } from 'src/i18n/detectLocale'
-import { DEFAULT_LOCALE_KEY, LocaleKey, localeKeys } from 'src/i18n/i18n'
+import { DEFAULT_LOCALE_KEY, LocaleKey } from 'src/i18n/i18n'
 
 export interface SettingsState {
   localeKey: LocaleKey
@@ -10,6 +9,6 @@ export interface SettingsState {
 }
 
 export const settingsDefaultState: SettingsState = {
-  localeKey: detectLocale({ defaultLanguage: DEFAULT_LOCALE_KEY, availableLocales: localeKeys }),
+  localeKey: DEFAULT_LOCALE_KEY,
   qcRulesConfig: getVirus().qcRulesConfig,
 }


### PR DESCRIPTION
This adds a check when setting locale: if locale is not present, the default locale is set.
Unchecked, missing locale could come from autodetection or from local storage.

This also disables autodetection. Users should, hopefully, find the language switcher on top of the page if they need locale to be changed.

