### PR TITLE
fix: format SNP clusters properly for export

### DIFF
--- a/packages/web/src/helpers/formatSnpCluster.ts
+++ b/packages/web/src/helpers/formatSnpCluster.ts
@@ -1,0 +1,8 @@
+import type { ClusteredSNPs } from 'src/algorithms/types'
+import { formatRange } from 'src/helpers/formatRange'
+
+export function formatSnpCluster(cluster: ClusteredSNPs) {
+  const { start, end, numberOfSNPs } = cluster
+  const range = formatRange(start, end)
+  return `${range}:${numberOfSNPs}`
+}

--- a/packages/web/src/io/serializeResults.ts
+++ b/packages/web/src/io/serializeResults.ts
@@ -9,6 +9,7 @@ import { formatRange } from 'src/helpers/formatRange'
 import { formatInsertion } from 'src/helpers/formatInsertion'
 import { formatNonAcgtn } from 'src/helpers/formatNonAcgtn'
 import { formatPrimer } from 'src/helpers/formatPrimer'
+import { formatSnpCluster } from 'src/helpers/formatSnpCluster'
 
 export type Exportable = StrictOmit<AnalysisResult, 'alignedQuery'>
 
@@ -34,6 +35,13 @@ export function serializeResultsToJson(results: SequenceAnalysisState[]) {
 export function prepareResultCsv(datum: Exportable) {
   return {
     ...datum,
+    qc: {
+      ...datum.qc,
+      snpClusters: {
+        ...(datum.qc?.snpClusters ?? {}),
+        clusteredSNPs: datum.qc?.snpClusters?.clusteredSNPs.map(formatSnpCluster).join(','),
+      },
+    },
     substitutions: datum.substitutions.map((mut) => formatMutation(mut)).join(','),
     aminoacidChanges: datum.aminoacidChanges.map((mut) => formatAAMutation(mut)).join(','),
     deletions: datum.deletions.map(({ start, length }) => formatRange(start, start + length)).join(','),


### PR DESCRIPTION
SNP clusters were creating multiple rows when exported to CSV/TSV.

This fixes this problem by formatting the clusters such that they fit into 1 column and row.
