### PR TITLE
feat: don't output nucleotide composition to CSV

### DIFF
--- a/packages/web/src/cli/cli.ts
+++ b/packages/web/src/cli/cli.ts
@@ -241,19 +241,19 @@ export async function writeResults({
   }
 
   if (outputCsv) {
-    const data = results.map(prepareResultCsv)
+    const data = json.map(prepareResultCsv)
     const csv = await toCsvString(data, ';')
     await fs.writeFile(outputCsv, csv)
   }
 
   if (outputTsvCladesOnly) {
-    const data = results.map(prepareResultCsvCladesOnly)
+    const data = json.map(prepareResultCsvCladesOnly)
     const csv = await toCsvString(data, '\t')
     await fs.writeFile(outputTsvCladesOnly, csv)
   }
 
   if (outputTsv) {
-    const data = results.map(prepareResultCsv)
+    const data = json.map(prepareResultCsv)
     const tsv = await toCsvString(data, '\t')
     await fs.writeFile(outputTsv, tsv)
   }

--- a/packages/web/src/io/serializeResults.ts
+++ b/packages/web/src/io/serializeResults.ts
@@ -11,10 +11,10 @@ import { formatNonAcgtn } from 'src/helpers/formatNonAcgtn'
 import { formatPrimer } from 'src/helpers/formatPrimer'
 import { formatSnpCluster } from 'src/helpers/formatSnpCluster'
 
-export type Exportable = StrictOmit<AnalysisResult, 'alignedQuery'>
+export type Exportable = StrictOmit<AnalysisResult, 'alignedQuery' | 'nucleotideComposition'>
 
 export function prepareResultJson(result: AnalysisResult): Exportable {
-  return omit(result, ['alignedQuery'])
+  return omit(result, ['alignedQuery', 'nucleotideComposition'])
 }
 
 export function prepareResultsJson(results: SequenceAnalysisState[]) {


### PR DESCRIPTION
Due to different characters present or not in nucleotide composition, it makes CSV/TSV column number and order uncertain and makes row concatenation much harder, so we remove it from CSV/TSV export here.
