### PR TITLE
feat(cli): stream fasta input

### DIFF
--- a/packages/web/config/webpack/webpack.cli.babel.ts
+++ b/packages/web/config/webpack/webpack.cli.babel.ts
@@ -47,7 +47,7 @@ module.exports = {
   bail: true,
   name: pkg.name,
   target: 'node',
-  devtool: 'cheap-module-source-map',
+  devtool: 'source-map',
   stats: {
     all: false,
     errors: true,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -95,6 +95,7 @@
     "autoprefixer": "9.8.6",
     "awesomplete": "1.1.5",
     "axios": "0.20.0",
+    "bionode-fasta": "0.5.6",
     "bootstrap": "4.5.2",
     "classnames": "2.2.6",
     "connected-next-router": "3.1.0",

--- a/packages/web/src/algorithms/parseSequences.ts
+++ b/packages/web/src/algorithms/parseSequences.ts
@@ -1,28 +1,33 @@
+/**
+ * Catches duplicate names and renames if needed (appends a counter)
+ */
+export function deduplicateSeqName(seqNameOrig: string, seqNames: Map<string, number>) {
+  let seqName = seqNameOrig
+  if (seqNameOrig === '') {
+    seqName = 'Untitled'
+  }
+
+  const nameCount = seqNames.get(seqName) ?? 0
+  if (nameCount > 0) {
+    seqName = `${seqName} (${nameCount})`
+  }
+  seqNames.set(seqName, nameCount + 1)
+
+  return seqName
+}
+
 export function addSequence(
   currentSeq: string,
   currentSeqName: string,
   seqs: Record<string, string>,
-  allNames: string[],
+  seqNames: Map<string, number>,
 ) {
-  if (currentSeqName === '') {
-    // eslint-disable-next-line no-param-reassign
-    currentSeqName = 'Untitled'
-  }
+  const seqName = deduplicateSeqName(currentSeqName, seqNames)
+  seqs[seqName] = currentSeq
+}
 
-  let nameCount = 0
-  for (let i = 0; i < allNames.length; ++i) {
-    if (allNames[i] === currentSeqName) {
-      ++nameCount
-    }
-  }
-
-  let suffix = ''
-  if (nameCount) {
-    suffix = ` (${nameCount})`
-  }
-
-  allNames.push(currentSeqName)
-  seqs[currentSeqName + suffix] = currentSeq
+export function sanitizeSequence(seq: string) {
+  return seq.toUpperCase().replace(/[^*.?A-Z]/g, '')
 }
 
 export function parseSequences(input: string) {
@@ -32,7 +37,7 @@ export function parseSequences(input: string) {
   let currentSeqName = ''
   let currentSeq = ''
   const seqs: Record<string, string> = {}
-  const seqNames: string[] = []
+  const seqNames = new Map<string, number>()
 
   for (let i = 0; i < lines.length; ++i) {
     const line = lines[i].trim()
@@ -46,7 +51,7 @@ export function parseSequences(input: string) {
       currentSeq = ''
     } else {
       // NOTE: Strip all characters except capital letters, asterisks, dots ans question marks
-      const seq = line.toUpperCase().replace(/[^*.?A-Z]/g, '')
+      const seq = sanitizeSequence(line)
       currentSeq += seq
     }
   }

--- a/packages/web/src/algorithms/tree/treeAttachNodes.ts
+++ b/packages/web/src/algorithms/tree/treeAttachNodes.ts
@@ -125,6 +125,13 @@ export function attach_to_tree(result: AnalysisResult, nearestRefNode: AuspiceTr
   }
 
   const children = nearestRefNode.children ?? []
+
+  // This is the line that prevents this algorithm from being parallel.
+  // All threads would write into this array simultaneously, creating a race condition.
+  // TODO(perf): we might use parallel map() to compute all children attachments per node,
+  // and then gather them into the final tree separately.
+  // However, in this case the implementation might become considerably more complex,
+  // with little gain, because this part is usually not a bottleneck.
   nearestRefNode.children = [new_node, ...children]
 }
 

--- a/packages/web/src/types/bionode-fasta.d.ts
+++ b/packages/web/src/types/bionode-fasta.d.ts
@@ -1,0 +1,12 @@
+declare module 'bionode-fasta' {
+  export declare interface FastaObject {
+    id: string
+    seq: string
+  }
+
+  declare function obj(filename: string): NodeJS.ReadableStream
+
+  const fasta = { obj }
+
+  export default fasta
+}

--- a/packages/web/yarn.lock
+++ b/packages/web/yarn.lock
@@ -3801,6 +3801,25 @@ binomial@^0.2.0:
   resolved "https://registry.yarnpkg.com/binomial/-/binomial-0.2.0.tgz#cf184a5389ce397f26b64c53f7c934399021c8f5"
   integrity sha1-zxhKU4nOOX8mtkxT98k0OZAhyPU=
 
+bionode-fasta@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/bionode-fasta/-/bionode-fasta-0.5.6.tgz#2f98ccb6041c58d2fe3b7b076f529dab9995541e"
+  integrity sha1-L5jMtgQcWNL+O3sHb1Kdq5mVVB4=
+  dependencies:
+    concat-stream "~1.6.0"
+    fasta-parser "0.1.0"
+    minimist "~1.2.0"
+    pumpify "~1.3.5"
+    split2 "^2.1.1"
+    through2 "~2.0.3"
+
+bl@^0.9.0:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-0.9.5.tgz#c06b797af085ea00bc527afc8efcf11de2232054"
+  integrity sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=
+  dependencies:
+    readable-stream "~1.0.26"
+
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -6151,7 +6170,7 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-duplexify@^3.4.2, duplexify@^3.6.0:
+duplexify@^3.4.2, duplexify@^3.5.3, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
   integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
@@ -7178,6 +7197,16 @@ fast-memoize@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
   integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
+fasta-parser@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fasta-parser/-/fasta-parser-0.1.0.tgz#aec80b3ef2f50cecf9c23ada74f648d3bb1a460b"
+  integrity sha1-rsgLPvL1DOz5wjradPZI07saRgs=
+  dependencies:
+    bl "^0.9.0"
+    pumpify "^1.3.0"
+    split "^0.3.0"
+    through2 "~0.6.0"
 
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
@@ -10789,7 +10818,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -12827,12 +12856,21 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-pumpify@^1.3.3, pumpify@^1.3.5:
+pumpify@^1.3.0, pumpify@^1.3.3, pumpify@^1.3.5:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
   integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
   dependencies:
     duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
+pumpify@~1.3.5:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.3.6.tgz#00d40e5ded0a3bf1e0788b1c0cf426a42882ab64"
+  integrity sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==
+  dependencies:
+    duplexify "^3.5.3"
     inherits "^2.0.3"
     pump "^2.0.0"
 
@@ -13357,7 +13395,7 @@ read-pkg@^5.2.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0":
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.26:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
@@ -14675,12 +14713,19 @@ split2@^0.2.1:
   dependencies:
     through2 "~0.6.1"
 
-split2@^2.0.0:
+split2@^2.0.0, split2@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
   integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
   dependencies:
     through2 "^2.0.2"
+
+split@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
 
 split@^1.0.0:
   version "1.0.1"
@@ -15715,7 +15760,7 @@ through2-filter@^3.0.0:
     through2 "~2.0.0"
     xtend "~4.0.0"
 
-through2@^0.6.1, through2@^0.6.3, through2@~0.6.1:
+through2@^0.6.1, through2@^0.6.3, through2@~0.6.0, through2@~0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=


### PR DESCRIPTION
This allows for input fasta file to be streamed, lifting Node.js's limit to 2 GBytes maximum file size.

We need streaming fasta parser for that, so we switched to using `bionode-fasta` instead of our handwritten one.


In order to implement streaming, the analysis itself, or at least the most time-consuming parts should be streamable, that is the operation performed on each element of the stream should be a pure transform, which can be ran on a separate thread, and independent on other elements of the stream.

This was moslty achieved by making `treeFindNearestNodes()` to operate on a single sequence and bubbling up the loop 
https://github.com/nextstrain/nextclade/blob/e0f64374c243e1013c21a0f8989210a45ca0d53a/packages/web/src/algorithms/tree/treeFindNearestNodes.ts#L93-L106

This allowed to move `treeFindNearestNodes()` itself, as well as clade assignment and qc under the same loop iteration, and then moving them all into the same webworker process. So now most of the algorithm is just a `map()` on a stream of sequences (or an array of sequences in case of web app).

The `treeAttachNodes()` step is however still serial and runs after the stream ends (or after the array `map()` in case of web app). This operation (on would-be-shared-object, the tree) prevents it from being parallel:
https://github.com/nextstrain/nextclade/blob/e0f64374c243e1013c21a0f8989210a45ca0d53a/packages/web/src/algorithms/tree/treeAttachNodes.ts#L129-L135

Because `treeFindNearestNodes()` (and resulting matches) is now in the worker process (one process per sequence) and the `treeAttachNodes()` is in the main thread, and the data between them is passed by copy, we loose the pointer stability we previously (ab)used in order to quickly attach the new sequences.

Therefore, we had to introduce an explicit ID for the nodes and then search the tree for a matching id in `treeAttachNodes()`:
https://github.com/nextstrain/nextclade/blob/e0f64374c243e1013c21a0f8989210a45ca0d53a/packages/web/src/algorithms/tree/treeAttachNodes.ts#L203-L219

which is a serious performance degradation, but is still nothing compared to the core analysis.

--

The code in this PR produces the same exact output as previous implementations.
