### PR TITLE
fix: avoid crash on filter badge removal

### DIFF
--- a/packages/web/src/components/Tree/FilterBadges.tsx
+++ b/packages/web/src/components/Tree/FilterBadges.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { uniq, get } from 'lodash'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
+import { removeUndefined } from 'src/helpers/removeUndefined'
 import { State } from 'src/state/reducer'
 import { FilterBadge } from 'src/components/Tree/FilterBadge'
-import { uniq, get } from 'lodash'
 
 export const FilterBadgeContainer = styled.ul`
   display: flex;
@@ -44,17 +45,21 @@ export function FilterBadgesDisconnected({ filters }: FilterBadgesProps) {
   const [badgesDisabled, setBadgesDisabled] = useState<Record<string, string[]>>({})
 
   const setBadgeDisabled = useCallback((trait: string, value: string) => {
-    setBadgesDisabled((badgesDisabled) => ({
-      ...badgesDisabled,
-      [trait]: uniq([...(get(badgesDisabled, trait) ?? []), value]),
-    }))
+    setBadgesDisabled((badgesDisabled) =>
+      removeUndefined({
+        ...badgesDisabled,
+        [trait]: uniq([...(get(badgesDisabled, trait) ?? []), value]),
+      }),
+    )
   }, [])
 
   const setBadgeEnabled = useCallback((trait: string, value: string) => {
-    setBadgesDisabled((badgesDisabled) => ({
-      ...badgesDisabled,
-      [trait]: get(badgesDisabled, trait)?.filter((val) => val !== value),
-    }))
+    setBadgesDisabled((badgesDisabled) =>
+      removeUndefined({
+        ...badgesDisabled,
+        [trait]: get(badgesDisabled, trait)?.filter((val) => val !== value),
+      }),
+    )
   }, [])
 
   const filterBadges = useMemo(() => {

--- a/packages/web/src/helpers/removeUndefined.ts
+++ b/packages/web/src/helpers/removeUndefined.ts
@@ -1,0 +1,8 @@
+import { pickBy, identity } from 'lodash'
+
+/**
+ * Removes object keys which have `undefined` value
+ */
+export function removeUndefined<T>(obj: Record<string, T | undefined>) {
+  return pickBy(obj, identity) as Record<string, T>
+}


### PR DESCRIPTION
Resolves #235

This was due to enable/disable callbacks (triggered on badge removal) were leaving object keys with `undefined` value. Subsequent iteration on these values would then cause a crash.

The type mismatch was somehow not caught by Typescript, probably due to lodash typings.

This PR adds removal of `undefined` values, as a last instruction in these callbacks.

