### PR TITLE
feat: force reset all users to English locale

### DIFF
--- a/packages/web/src/components/Common/SEO.tsx
+++ b/packages/web/src/components/Common/SEO.tsx
@@ -15,7 +15,7 @@ export interface SEOProps {
 }
 
 const mapStateToProps = (state: State) => ({
-  localeKey: state.settings.localeKey,
+  localeKey: state.settings.localeKeyV2,
 })
 
 const mapDispatchToProps = {}

--- a/packages/web/src/initialize.ts
+++ b/packages/web/src/initialize.ts
@@ -23,8 +23,8 @@ export async function initialize({ router }: InitializeParams) {
 
   const { persistor, store } = await configureStore({ router, workerPools })
 
-  const { localeKey } = store.getState().settings
-  store.dispatch(setLocale(localeKey))
+  const { localeKeyV2 } = store.getState().settings
+  store.dispatch(setLocale(localeKeyV2))
 
   await fetchInputsAndRunMaybe(store.dispatch, router)
 

--- a/packages/web/src/state/settings/settings.reducer.ts
+++ b/packages/web/src/state/settings/settings.reducer.ts
@@ -6,7 +6,7 @@ import { settingsDefaultState } from 'src/state/settings/settings.state'
 
 export const settingsReducer = reducerWithInitialState(settingsDefaultState)
   .icase(setLocale, (draft, localeKey) => {
-    draft.localeKey = localeKey
+    draft.localeKeyV2 = localeKey
   })
 
   .icase(setQcRulesConfig, (draft, qcRulesConfig) => {

--- a/packages/web/src/state/settings/settings.selectors.ts
+++ b/packages/web/src/state/settings/settings.selectors.ts
@@ -1,7 +1,7 @@
 import type { State } from 'src/state/reducer'
 import { LocaleKey, LocaleWithKey, getLocaleWithKey } from 'src/i18n/i18n'
 
-export const selectLocaleKey = (state: State): LocaleKey => state.settings.localeKey
+export const selectLocaleKey = (state: State): LocaleKey => state.settings.localeKeyV2
 
 export const selectLocale = (state: State): LocaleWithKey => getLocaleWithKey(selectLocaleKey(state))
 

--- a/packages/web/src/state/settings/settings.state.ts
+++ b/packages/web/src/state/settings/settings.state.ts
@@ -4,11 +4,11 @@ import { getVirus } from 'src/algorithms/defaults/viruses'
 import { DEFAULT_LOCALE_KEY, LocaleKey } from 'src/i18n/i18n'
 
 export interface SettingsState {
-  localeKey: LocaleKey
+  localeKeyV2: LocaleKey
   qcRulesConfig: QCRulesConfig
 }
 
 export const settingsDefaultState: SettingsState = {
-  localeKey: DEFAULT_LOCALE_KEY,
+  localeKeyV2: DEFAULT_LOCALE_KEY,
   qcRulesConfig: getVirus().qcRulesConfig,
 }


### PR DESCRIPTION
This resets the locale key value in local storage for every user of the web app. This will force everybody to English on next page load.

Our localizations are incomplete and ugly (e.g. some text does not fit and goes beyond buttons etc.). Language autodetection has been removed a while ago. However, users' browsers still persist the language setting. This will reset it to English. And if they want, they will switch manually.

