### PR TITLE
fix: ensure isMatch handles ambiguous nucleotides in both reference a…

### DIFF
--- a/packages/web/src/algorithms/__tests__/nucleotideCodes.test.ts
+++ b/packages/web/src/algorithms/__tests__/nucleotideCodes.test.ts
@@ -1,24 +1,33 @@
 import { isMatch } from 'src/algorithms/nucleotideCodes'
 
 describe('isMatch', () => {
-  it('should match any with N', () => {
+  it('should match any canonical with N', () => {
     expect(isMatch('N', 'A')).toBeTrue()
-    expect(isMatch('N', 'C')).toBeTrue()
+    expect(isMatch('A', 'N')).toBeTrue()
+  })
+
+  it('should match any ambiguous with N', () => {
+    expect(isMatch('N', 'S')).toBeTrue()
+    expect(isMatch('S', 'N')).toBeTrue()
   })
 
   it('should match ambiguous R with A', () => {
     expect(isMatch('R', 'A')).toBeTrue()
+    expect(isMatch('A', 'R')).toBeTrue()
   })
 
   it('should NOT match ambiguous R with C', () => {
-    expect(isMatch('R', 'A')).toBeTrue()
+    expect(isMatch('R', 'C')).toBeFalse()
+    expect(isMatch('C', 'R')).toBeFalse()
   })
 
   it('should match ambiguous S with C', () => {
     expect(isMatch('S', 'C')).toBeTrue()
+    expect(isMatch('C', 'S')).toBeTrue()
   })
 
   it('should NOT match ambiguous S with A', () => {
-    expect(isMatch('S', 'C')).toBeTrue()
+    expect(isMatch('A', 'S')).toBeFalse()
+    expect(isMatch('S', 'A')).toBeFalse()
   })
 })

--- a/packages/web/src/algorithms/nucleotideCodes.ts
+++ b/packages/web/src/algorithms/nucleotideCodes.ts
@@ -25,8 +25,14 @@ export function isMatch(query: string, reference: string): boolean {
   }
 
   // match specific ambiguity codes
-  if (IUPACNucCodes[query]) {
-    return IUPACNucCodes[query].has(reference)
+  if (IUPACNucCodes[query] && IUPACNucCodes[reference]) {
+    const intersection = new Set()
+    for (const elem of IUPACNucCodes[query]) {
+      if (IUPACNucCodes[reference].has(elem)) {
+        intersection.add(elem)
+      }
+    }
+    return intersection.size > 0
   }
 
   return false

--- a/packages/web/src/algorithms/nucleotideCodes.ts
+++ b/packages/web/src/algorithms/nucleotideCodes.ts
@@ -1,3 +1,6 @@
+import { get } from 'lodash'
+import { intersection } from 'src/helpers/setOperations'
+
 const IUPACNucCodes: Record<string, Set<string>> = {
   A: new Set(['A']),
   C: new Set(['C']),
@@ -25,14 +28,10 @@ export function isMatch(query: string, reference: string): boolean {
   }
 
   // match specific ambiguity codes
-  if (IUPACNucCodes[query] && IUPACNucCodes[reference]) {
-    const intersection = new Set()
-    for (const elem of IUPACNucCodes[query]) {
-      if (IUPACNucCodes[reference].has(elem)) {
-        intersection.add(elem)
-      }
-    }
-    return intersection.size > 0
+  const queryNucs = get(IUPACNucCodes, query)
+  const refNucs = get(IUPACNucCodes, reference)
+  if (queryNucs && refNucs) {
+    return intersection(queryNucs, refNucs).size > 0
   }
 
   return false

--- a/packages/web/src/helpers/setOperations.ts
+++ b/packages/web/src/helpers/setOperations.ts
@@ -1,0 +1,3 @@
+export function intersection<T>(a: Set<T>, b: Set<T>) {
+  return new Set([...a].filter((i) => b.has(i)))
+}


### PR DESCRIPTION
…nd query

the `isMatch` function was previously assuming that the reference doesn't contain ambiguous nucleotides. 