### PR TITLE
feat: fetch input root sequence and input ref tree provided  URL params

### DIFF
--- a/packages/web/src/algorithms/defaults/sars-cov-2/rootSeq.ts
+++ b/packages/web/src/algorithms/defaults/sars-cov-2/rootSeq.ts
@@ -1,7 +1,5 @@
+import { sanitizeRootSeq } from 'src/helpers/sanitizeRootSeq'
+
 import DEFAULT_ROOT_SEQUENCE_RAW from './rootSeq.txt'
 
-function getRootSequence(): string {
-  return DEFAULT_ROOT_SEQUENCE_RAW.trim()
-}
-
-export const rootSeq = getRootSequence()
+export const rootSeq = sanitizeRootSeq(DEFAULT_ROOT_SEQUENCE_RAW)

--- a/packages/web/src/helpers/sanitizeRootSeq.ts
+++ b/packages/web/src/helpers/sanitizeRootSeq.ts
@@ -1,0 +1,3 @@
+export function sanitizeRootSeq(rootSeqDangerous: string): string {
+  return rootSeqDangerous.trim()
+}

--- a/packages/web/src/io/fetchInputsAndRunMaybe.ts
+++ b/packages/web/src/io/fetchInputsAndRunMaybe.ts
@@ -1,10 +1,12 @@
 import type { Router } from 'next/router'
 import type { Dispatch } from 'redux'
 import Axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { treeValidate } from 'src/algorithms/tree/treeValidate'
 
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
-import { algorithmRunAsync, setIsDirty } from 'src/state/algorithm/algorithm.actions'
+import { algorithmRunAsync, setIsDirty, setRootSeq, setTree } from 'src/state/algorithm/algorithm.actions'
 import { errorAdd } from 'src/state/error/error.actions'
+import { sanitizeRootSeq } from 'src/helpers/sanitizeRootSeq'
 
 export class HttpRequestError extends Error {
   public readonly request: AxiosRequestConfig
@@ -17,20 +19,51 @@ export class HttpRequestError extends Error {
   }
 }
 
+export interface FetchParams {
+  url?: string
+  dispatch: Dispatch
+}
+
+export async function fetchMaybe<T>(url?: string) {
+  if (url) {
+    const { data } = await Axios.get<T | undefined>(url)
+    return data
+  }
+  return undefined
+}
+
 export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router) {
   const inputFastaUrl = takeFirstMaybe(router.query?.['input-fasta'])
-  if (inputFastaUrl) {
-    try {
-      const { data } = await Axios.get<string | undefined>(inputFastaUrl)
-      if (data) {
-        dispatch(setIsDirty(true))
-        dispatch(algorithmRunAsync.trigger(data))
-        await router.replace('/results')
-      }
-    } catch (error_) {
-      const error = new HttpRequestError(error_ as AxiosError)
-      console.error(error)
-      dispatch(errorAdd({ error }))
-    }
+  const inputRootSeqUrl = takeFirstMaybe(router.query?.['input-root-seq'])
+  const inputTreeUrl = takeFirstMaybe(router.query?.['input-tree'])
+
+  let inputFasta: string | undefined
+  let inputRootSeqDangerous: string | undefined
+  let inputTreeDangerous: string | undefined
+
+  try {
+    inputFasta = await fetchMaybe(inputFastaUrl)
+    inputRootSeqDangerous = await fetchMaybe(inputRootSeqUrl)
+    inputTreeDangerous = await fetchMaybe(inputTreeUrl)
+  } catch (error_) {
+    const error = new HttpRequestError(error_ as AxiosError)
+    console.error(error)
+    dispatch(errorAdd({ error }))
+  }
+
+  if (inputRootSeqDangerous) {
+    const inputRootSeq = sanitizeRootSeq(inputRootSeqDangerous)
+    dispatch(setRootSeq(inputRootSeq))
+  }
+
+  if (inputTreeDangerous) {
+    const inputTree = treeValidate(inputTreeDangerous)
+    dispatch(setTree(inputTree))
+  }
+
+  if (inputFasta) {
+    dispatch(setIsDirty(true))
+    dispatch(algorithmRunAsync.trigger(inputFasta))
+    await router.replace('/results')
   }
 }

--- a/packages/web/src/io/fetchInputsAndRunMaybe.ts
+++ b/packages/web/src/io/fetchInputsAndRunMaybe.ts
@@ -4,7 +4,7 @@ import Axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import { treeValidate } from 'src/algorithms/tree/treeValidate'
 
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
-import { algorithmRunAsync, setIsDirty, setRootSeq, setTree } from 'src/state/algorithm/algorithm.actions'
+import { algorithmRunAsync, setIsDirty, setInputRootSeq, setInputTree } from 'src/state/algorithm/algorithm.actions'
 import { errorAdd } from 'src/state/error/error.actions'
 import { sanitizeRootSeq } from 'src/helpers/sanitizeRootSeq'
 
@@ -53,12 +53,12 @@ export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router)
 
   if (inputRootSeqDangerous) {
     const inputRootSeq = sanitizeRootSeq(inputRootSeqDangerous)
-    dispatch(setRootSeq(inputRootSeq))
+    dispatch(setInputRootSeq(inputRootSeq))
   }
 
   if (inputTreeDangerous) {
     const inputTree = treeValidate(inputTreeDangerous)
-    dispatch(setTree(inputTree))
+    dispatch(setInputTree(inputTree))
   }
 
   if (inputFasta) {

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -13,8 +13,8 @@ const action = actionCreatorFactory('Algorithm')
 
 export const setInput = action<string>('setInput')
 export const setInputFile = action<InputFile>('setInputFile')
-export const setRootSeq = action<string>('setRootSeq')
-export const setTree = action<AuspiceJsonV2>('setTree')
+export const setInputRootSeq = action<string>('setRootSeq')
+export const setInputTree = action<AuspiceJsonV2>('setTree')
 export const setIsDirty = action<boolean>('setIsDirty')
 
 export const setAlgorithmGlobalStatus = action<AlgorithmGlobalStatus>('setAlgorithmGlobalStatus')

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -1,5 +1,6 @@
-import { actionCreatorFactory } from 'src/state/util/fsaActions'
+import type { AuspiceJsonV2 } from 'auspice'
 
+import { actionCreatorFactory } from 'src/state/util/fsaActions'
 import type { AnalysisParams, AnalysisResult } from 'src/algorithms/types'
 import type { AuspiceJsonV2Extended } from 'src/algorithms/tree/types'
 import type { LocateInTreeParams, LocateInTreeResults } from 'src/algorithms/tree/treeFindNearestNodes'
@@ -12,6 +13,8 @@ const action = actionCreatorFactory('Algorithm')
 
 export const setInput = action<string>('setInput')
 export const setInputFile = action<InputFile>('setInputFile')
+export const setRootSeq = action<string>('setRootSeq')
+export const setTree = action<AuspiceJsonV2>('setTree')
 export const setIsDirty = action<boolean>('setIsDirty')
 
 export const setAlgorithmGlobalStatus = action<AlgorithmGlobalStatus>('setAlgorithmGlobalStatus')

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -25,6 +25,8 @@ import {
   setShowErrors,
   setShowBad,
   setShowMediocre,
+  setInputRootSeq,
+  setInputTree,
 } from './algorithm.actions'
 import {
   algorithmDefaultState,
@@ -107,6 +109,14 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
   .icase(setInputFile, (draft, inputFile) => {
     draft.status = AlgorithmGlobalStatus.idling
     draft.inputFile = inputFile
+  })
+
+  .icase(setInputRootSeq, (draft, inputRootSeq) => {
+    draft.params.virus.rootSeq = inputRootSeq
+  })
+
+  .icase(setInputTree, (draft, inputTree) => {
+    draft.params.virus.auspiceData = inputTree
   })
 
   .icase(setIsDirty, (draft, isDirty) => {


### PR DESCRIPTION
This allows to provide custom root sequence and reference tree for the web app.

This PR adds processing for two new URL parameters: `input-root-seq` and `input-tree` (same names and functionality as in CLI)
When the application is loaded with one or both of these, as well as with `input-fasta` parameter, containing the URLs to corresponding files, instead of showing the main page, Nexclade will download these files and start analysis immediately, using the provided sequences, as well as the provided root sequence and/or reference tree.

Example URL (pointing to the default files hosted on GitHub):

> https://master.clades.nextsltrain.org/?input-fasta=https://raw.githubusercontent.com/nextstrain/nextclade/8767611a95b308ff33d26c73ff536fd999615e10/packages/web/src/algorithms/defaults/sars-cov-2/sequenceData.fasta&input-root-seq=https://raw.githubusercontent.com/nextstrain/nextclade/8767611a95b308ff33d26c73ff536fd999615e10/packages/web/src/algorithms/defaults/sars-cov-2/rootSeq.txt&input-tree=https://raw.githubusercontent.com/nextstrain/nextclade/8767611a95b308ff33d26c73ff536fd999615e10/packages/web/src/algorithms/defaults/sars-cov-2/ncov_small.json

(it won't work until this PR is merged to master, but you've got the idea)

and another one with a different tree, an older one, without 20A.EU1 and 20A.EU2 subclades:

> https://master.clades.nextsltrain.org/?input-fasta=https://raw.githubusercontent.com/nextstrain/nextclade/8767611a95b308ff33d26c73ff536fd999615e10/packages/web/src/algorithms/defaults/sars-cov-2/sequenceData.fasta&input-root-seq=https://raw.githubusercontent.com/nextstrain/nextclade/8767611a95b308ff33d26c73ff536fd999615e10/packages/web/src/algorithms/defaults/sars-cov-2/rootSeq.txt&input-tree=https://raw.githubusercontent.com/nextstrain/nextclade/920829a91c8963bae7f53892520912b203580936/packages/web/src/algorithms/defaults/sars-cov-2/ncov_small.json

(notice the difference in clades assigned to Switzerland/BE and Switzerland/VD, for example)