### PR TITLE
feat: allow exporting Auspice tree json result again

### DIFF
--- a/packages/web/src/components/Results/ButtonExport.tsx
+++ b/packages/web/src/components/Results/ButtonExport.tsx
@@ -15,9 +15,15 @@ import styled from 'styled-components'
 
 import type { State } from 'src/state/reducer'
 import { ExportFormat } from 'src/state/ui/ui.state'
-import { exportCsvTrigger, exportTsvTrigger, exportJsonTrigger } from 'src/state/algorithm/algorithm.actions'
+import {
+  exportCsvTrigger,
+  exportTsvTrigger,
+  exportJsonTrigger,
+  exportTreeJsonTrigger,
+} from 'src/state/algorithm/algorithm.actions'
 import { setExportFormat } from 'src/state/ui/ui.actions'
-import { selectCanExport } from 'src/state/algorithm/algorithm.selectors'
+import { selectCanExport, selectOutputTree } from 'src/state/algorithm/algorithm.selectors'
+import { TreeIcon } from 'src/components/Tree/TreeIcon'
 
 const Button = styled(ReactstrapButton)`
   margin: 2px 2px;
@@ -45,21 +51,33 @@ export function ExportCSVIcon() {
   return <IoMdDocument className="mr-xl-2 mb-1" size={22} />
 }
 
+const TreeIconContainer = styled.span`
+  margin-right: 0.55rem;
+`
+
 export interface ExportButtonIconProps {
   exportFormat: ExportFormat
 }
 
 export interface ExportButtonProps {
   canExport: boolean
+  hasTree: boolean
   exportFormat: ExportFormat
+
   setExportFormat(exportType: ExportFormat): void
+
   exportCsvTrigger(_0: void): void
+
   exportTsvTrigger(_0: void): void
+
   exportJsonTrigger(_0: void): void
+
+  exportTreeJsonTrigger(_0: void): void
 }
 
 const mapStateToProps = (state: State) => ({
   exportFormat: state.ui.exportFormat,
+  hasTree: selectOutputTree(state) !== undefined,
   canExport: selectCanExport(state),
 })
 
@@ -67,6 +85,7 @@ const mapDispatchToProps = {
   exportCsvTrigger,
   exportJsonTrigger,
   exportTsvTrigger,
+  exportTreeJsonTrigger,
   setExportFormat,
 }
 
@@ -74,11 +93,13 @@ export const ButtonExport = connect(mapStateToProps, mapDispatchToProps)(ExportB
 
 export function ExportButtonDisconnected({
   canExport,
+  hasTree,
   exportFormat,
   setExportFormat,
   exportCsvTrigger,
   exportTsvTrigger,
   exportJsonTrigger,
+  exportTreeJsonTrigger,
 }: ExportButtonProps) {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
@@ -97,6 +118,11 @@ export function ExportButtonDisconnected({
   const handleTsvClick = () => {
     setExportFormat(ExportFormat.TSV)
     exportTsvTrigger()
+  }
+
+  const handleTreeJsonClick = () => {
+    setExportFormat(ExportFormat.TREE_JSON)
+    exportTreeJsonTrigger()
   }
 
   const handleButtonClick = exportFormat === ExportFormat.CSV ? handleCsvClick : handleJsonClick
@@ -122,6 +148,12 @@ export function ExportButtonDisconnected({
         <DropdownItem onClick={handleJsonClick}>
           <ExportJSONIcon />
           {t('Export to JSON')}
+        </DropdownItem>
+        <DropdownItem onClick={handleTreeJsonClick} disabled={!hasTree}>
+          <TreeIconContainer>
+            <TreeIcon />
+          </TreeIconContainer>
+          {t('Export to Auspice')}
         </DropdownItem>
       </DropdownMenu>
     </ButtonDropdown>

--- a/packages/web/src/components/Results/ButtonTree.tsx
+++ b/packages/web/src/components/Results/ButtonTree.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React from 'react'
 
 import styled from 'styled-components'
 import { connect } from 'react-redux'
@@ -6,22 +6,13 @@ import { Button, ButtonProps } from 'reactstrap'
 import { useTranslation } from 'react-i18next'
 import { push } from 'connected-next-router'
 
-import { RectangularTree } from 'auspice/src/components/framework/svg-icons'
-
 import { State } from 'src/state/reducer'
 import { AlgorithmGlobalStatus } from 'src/state/algorithm/algorithm.state'
+import { TreeIcon } from 'src/components/Tree/TreeIcon'
 
 const IconContainer = styled.span`
   margin-right: 0.5rem;
 `
-
-export function TreeIconRaw() {
-  const size = 20
-  const theme = { unselectedColor: '#222' }
-  return <RectangularTree theme={theme} width={size} />
-}
-
-const TreeIcon = memo(TreeIconRaw)
 
 export const ButtonStyled = styled(Button)<ButtonProps>`
   margin: 2px 2px;

--- a/packages/web/src/components/Tree/TreeIcon.tsx
+++ b/packages/web/src/components/Tree/TreeIcon.tsx
@@ -1,0 +1,11 @@
+import React, { memo } from 'react'
+
+import { RectangularTree } from 'auspice/src/components/framework/svg-icons'
+
+export function TreeIconRaw() {
+  const size = 20
+  const theme = { unselectedColor: '#222' }
+  return <RectangularTree theme={theme} width={size} />
+}
+
+export const TreeIcon = memo(TreeIconRaw)

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -26,10 +26,12 @@ export const treeBuildAsync = action.async<LocateInTreeParams, LocateInTreeResul
 export const setClades = action<CladeAssignmentResult[]>('setClades')
 export const setQcResults = action<QCResult[]>('setQcResults')
 export const treeFinalizeAsync = action.async<FinalizeTreeParams, AuspiceJsonV2Extended, Error>('treeFinalizeAsync')
+export const setOutputTree = action<string>('setOutputTree')
 
 export const exportCsvTrigger = action('exportCsvTrigger')
 export const exportTsvTrigger = action('exportTsvTrigger')
 export const exportJsonTrigger = action('exportJsonTrigger')
+export const exportTreeJsonTrigger = action('exportTreeJsonTrigger')
 
 export const setSeqNamesFilter = action<string | undefined>('setSeqNamesFilter')
 export const setMutationsFilter = action<string | undefined>('setMutationsFilter')

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -27,6 +27,7 @@ import {
   setShowMediocre,
   setInputRootSeq,
   setInputTree,
+  setOutputTree,
 } from './algorithm.actions'
 import {
   algorithmDefaultState,
@@ -207,4 +208,8 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
   .icase(setQcResults, (draft, qcResults) => {
     draft.results = mergeByWith(draft.results, qcResults, haveSameSeqName, mergeQcIntoResults)
     draft.resultsFiltered = runFilters(current(draft))
+  })
+
+  .icase(setOutputTree, (draft, auspiceData) => {
+    draft.outputTree = auspiceData
   })

--- a/packages/web/src/state/algorithm/algorithm.selectors.ts
+++ b/packages/web/src/state/algorithm/algorithm.selectors.ts
@@ -14,6 +14,8 @@ export const selectIsDirty = (state: State): boolean => state.algorithm.isDirty
 
 export const selectCanExport = (state: State): boolean => state.algorithm.status === AlgorithmGlobalStatus.allDone
 
+export const selectOutputTree = (state: State): string | undefined => state.algorithm.outputTree
+
 export function selectStatus(state: State) {
   const statusGlobal = state.algorithm.status
   const sequenceStatuses = state.algorithm.results.map(({ seqName, status }) => ({ seqName, status }))

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -65,6 +65,7 @@ export interface AlgorithmState {
   tree: AuspiceJsonV2
   errors: string[]
   filters: ResultsFilters
+  outputTree?: string
 }
 
 export interface CladeAssignmentResult {
@@ -89,4 +90,5 @@ export const algorithmDefaultState: AlgorithmState = {
     showBad: true,
     showErrors: true,
   },
+  outputTree: undefined,
 }

--- a/packages/web/src/state/ui/ui.state.ts
+++ b/packages/web/src/state/ui/ui.state.ts
@@ -2,6 +2,7 @@ export enum ExportFormat {
   CSV = 'CSV',
   TSV = 'TSV',
   JSON = 'JSON',
+  TREE_JSON = 'Auspice',
 }
 
 export interface UiState {

--- a/packages/web/src/state/util/withReduxDevTools.ts
+++ b/packages/web/src/state/util/withReduxDevTools.ts
@@ -153,6 +153,7 @@ export function withReduxDevTools<StoreEnhancerIn, StoreEnhancerOut>(
           params: sanitizeParams(state.algorithm.params),
           results: sanitizeResults(state.algorithm.results),
           resultsFiltered: sanitizeResults(state.algorithm.results),
+          outputTree: state.algorithm.outputTree?.slice(0, 128),
         },
         tree: sanitizeTree(state.tree),
         entropy: sanitizeEntropy(state.controls),


### PR DESCRIPTION
This adds an entry to the export dropdown called "Export to Auspice", which allows to download the resulting tree with user-provided sequences placed on it (the same tree as on tree page). This can be stored and processed or visualized in https://auspice.us, for instance.

Warning: before interpreting this result file, it is important to understand the limitations of the Nextclade placement algorithm, as opposed to full phylogenetic analysis with main Nextstrain toolchain.
