### PR TITLE
Update CLI readme to install latest alpha

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,10 +26,10 @@ Having Node.js and npm available, install the latest release of the [`nextclade`
 npm install --global @neherlab/nextclade
 ```
 
-you may also try the cutting-edge beta version:
+you may also try the cutting-edge alpha version:
 
 ```bash
-npm install --global @neherlab/nextclade@beta
+npm install --global @neherlab/nextclade@alpha
 ```
 
 Explore available options:


### PR DESCRIPTION
As pointed out in #252 the current beta package in npm is quite old (0.4.0) so minor change to the documentation to point to the alpha version as that will install the latest non-stable package.

