### PR TITLE
fix(cli): add missing preprocessing step for custom gene maps in CLI

### DIFF
--- a/packages/web/src/algorithms/defaults/sars-cov-2/geneMap.ts
+++ b/packages/web/src/algorithms/defaults/sars-cov-2/geneMap.ts
@@ -1,23 +1,5 @@
-import { get, pick } from 'lodash'
+import { getGeneMap } from 'src/io/getGeneMap'
 
-import type { Gene } from 'src/algorithms/types'
-import { GENOTYPE_COLORS } from 'src/constants'
+import geneMapJson from './geneMap.json'
 
-import geneMapRaw from './geneMap.json'
-
-function getGeneMap(): Gene[] {
-  const geneMap = get(geneMapRaw, 'genome_annotations')
-
-  if (!geneMap) {
-    throw new Error(`getGeneMap: the gene map data is corrupted`)
-  }
-
-  return Object.entries(geneMap).map(([name, geneDataRaw], i) => {
-    const color = GENOTYPE_COLORS[(i + 1) % GENOTYPE_COLORS.length]
-    const { start: begin, end } = pick(geneDataRaw, ['start', 'end'])
-    const geneWithoutColor = { name, range: { begin, end } }
-    return { ...geneWithoutColor, color }
-  })
-}
-
-export const geneMap = getGeneMap()
+export const geneMap = getGeneMap(geneMapJson)

--- a/packages/web/src/cli/cli.ts
+++ b/packages/web/src/cli/cli.ts
@@ -6,6 +6,7 @@ import yargs from 'yargs'
 
 import { AnalysisResult, Virus } from 'src/algorithms/types'
 import { getVirus } from 'src/algorithms/defaults/viruses'
+import { getGeneMap } from 'src/io/getGeneMap'
 import { parseCsv } from 'src/io/parseCsv'
 import { parseRootSeq } from 'src/io/parseRootSeq'
 
@@ -202,7 +203,7 @@ export async function readInputs({
   }
 
   if (inputGeneMap) {
-    const geneMap = validateGeneMap(await fs.readJson(inputGeneMap))
+    const geneMap = validateGeneMap(getGeneMap(await fs.readJson(inputGeneMap)))
     virus = { ...virus, geneMap }
   }
 

--- a/packages/web/src/io/getGeneMap.ts
+++ b/packages/web/src/io/getGeneMap.ts
@@ -1,0 +1,28 @@
+import { get, pick } from 'lodash'
+
+import type { Gene } from 'src/algorithms/types'
+import { GENOTYPE_COLORS } from 'src/constants'
+
+export interface GeneMapJsonEntry {
+  start: number
+  end: number
+}
+
+export interface GeneMapJson {
+  genome_annotations: Record<string, GeneMapJsonEntry> // eslint-disable-line camelcase
+}
+
+export function getGeneMap(geneMapJson: GeneMapJson): Gene[] {
+  const geneMap = get(geneMapJson, 'genome_annotations')
+
+  if (!geneMap) {
+    throw new Error(`getGeneMap: the gene map data is corrupted`)
+  }
+
+  return Object.entries(geneMap).map(([name, geneDataRaw], i) => {
+    const color = GENOTYPE_COLORS[(i + 1) % GENOTYPE_COLORS.length]
+    const { start: begin, end } = pick(geneDataRaw, ['start', 'end'])
+    const geneWithoutColor = { name, range: { begin, end } }
+    return { ...geneWithoutColor, color }
+  })
+}


### PR DESCRIPTION
Attempts to resolve #252

In CLI code path  we've been loading and trying to use the gene map JSON directly, while it requires some preprocessing first (which was first introduced in the web app). This PR adds the missing preprocessing step.
