### PR TITLE
fix: remove black overlay above entropy panel when holding shift or alt

### DIFF
--- a/packages/web/src/styles/auspice.scss
+++ b/packages/web/src/styles/auspice.scss
@@ -7,6 +7,5 @@
 @import '../../node_modules/auspice/src/css/notifications';
 @import '../../node_modules/auspice/src/css/boxed';
 @import '../../node_modules/auspice/src/css/select';
-
-//@import '../../node_modules/auspice/src/css/entropy';
+@import '../../node_modules/auspice/src/css/entropy';
 //@import '../../node_modules/auspice/src/css/mapbox';


### PR DESCRIPTION
We've been missing a stylesheet from auspice for the entropy panel. This caused zoom overlay (triggered when holding <kbd>shift</kbd> or <kbd>alt</kbd> keys) to have an opaque black background, making the panel unusable.

This PR adds import for the missing stylesheet, this fixes this issue and probably many other small style-related issues with entropy panel.
