### PR TITLE
feat: remove uppercase text transform from buttons

### DIFF
--- a/packages/web/src/styles/_theme.scss
+++ b/packages/web/src/styles/_theme.scss
@@ -110,7 +110,6 @@
 @include btn(light, $light, $white);
 
 .btn {
-  text-transform: uppercase;
   border: 0;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
   transition: all 0.4s; // stylelint-disable-line declaration-property-value-blacklist


### PR DESCRIPTION
Let's not allow buttons to shout at our users. We don't strictly following Material Design, or, pretty much, any design system anyway.
