### PR TITLE
perf: avoid re-filtering gaps from mutations for every node every time

### DIFF
--- a/packages/web/src/algorithms/nucleotideCodes.ts
+++ b/packages/web/src/algorithms/nucleotideCodes.ts
@@ -23,11 +23,21 @@ export const canonicalNucleotides = new Set(['A', 'C', 'G', 'T'])
 
 export function isMatch(query: string, reference: string): boolean {
   // simple match or ambiguous
-  if (query === reference || query === 'N') {
+  if (query === reference || query === 'N' || reference === 'N') {
     return true
   }
 
-  // match specific ambiguity codes
+  // match ambiguity code in query
+  if (IUPACNucCodes[query] && IUPACNucCodes[query].has(reference)) {
+    return true
+  }
+
+  // match ambiguity code in reference
+  if (IUPACNucCodes[reference] && IUPACNucCodes[reference].has(query)) {
+    return true
+  }
+
+  // if none of the previous matched, match generic ambiguity
   const queryNucs = get(IUPACNucCodes, query)
   const refNucs = get(IUPACNucCodes, reference)
   if (queryNucs && refNucs) {

--- a/packages/web/src/algorithms/tree/treeFindNearestNodes.ts
+++ b/packages/web/src/algorithms/tree/treeFindNearestNodes.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import type { Nucleotide, NucleotideSubstitution, AnalysisResultWithoutClade } from 'src/algorithms/types'
-import type { AuspiceJsonV2Extended, AuspiceTreeNodeExtended, MutationMap } from 'src/algorithms/tree/types'
+import type { AuspiceJsonV2Extended, AuspiceTreeNodeExtended } from 'src/algorithms/tree/types'
 import { NodeType } from 'src/algorithms/tree/enums'
 
 export function isSequenced(pos: number, seq: AnalysisResultWithoutClade) {
@@ -12,15 +12,8 @@ export function calculate_distance(node: AuspiceTreeNodeExtended, seq: AnalysisR
   let shared_sites = 0
 
   // Filter-out gaps, to prevent double counting
-  const nodeSubstitutions: MutationMap = new Map<number, Nucleotide>()
-  node.mutations?.forEach((v, k) => {
-    if (v !== '-') {
-      nodeSubstitutions.set(k, v)
-    }
-  })
-
   for (const qmut of seq.substitutions) {
-    const der = nodeSubstitutions.get(qmut.pos)
+    const der = node.substitutions?.get(qmut.pos)
     if (der) {
       // position is also mutated in node
       if (qmut.queryNuc === der) {
@@ -33,14 +26,14 @@ export function calculate_distance(node: AuspiceTreeNodeExtended, seq: AnalysisR
   // determine the number of sites that are mutated in the node but missing in seq.
   // for these we can't tell whether the node agrees with seq
   let undetermined_sites = 0
-  for (const nmut of nodeSubstitutions) {
+  for (const nmut of node.substitutions ?? []) {
     const pos = nmut[0]
     if (!isSequenced(pos, seq)) {
       undetermined_sites += 1
     }
   }
 
-  const numMut = nodeSubstitutions.size ?? 0
+  const numMut = node.substitutions?.size ?? 0
   // calculate distance from set overlaps.
   return numMut + seq.substitutions.length - 2 * shared_differences - shared_sites - undetermined_sites
 }

--- a/packages/web/src/algorithms/tree/treePreprocess.ts
+++ b/packages/web/src/algorithms/tree/treePreprocess.ts
@@ -8,6 +8,7 @@ import { NodeType } from 'src/algorithms/tree/enums'
 
 import type { AuspiceJsonV2Extended, AuspiceTreeNodeExtended, MutationMap } from 'src/algorithms/tree/types'
 import { parseMutationOrThrow } from 'src/algorithms/tree/parseMutationOrThrow'
+import { Nucleotide } from '../types'
 
 export function setNodeTypes(node: AuspiceTreeNode) {
   set(node, `node_attrs['Node type']`, { value: NodeType.Reference })
@@ -46,6 +47,13 @@ export function mutations_on_tree(
   // Extend the node with out temporary parameters
   const nodeExtended = node as AuspiceTreeNodeExtended
   nodeExtended.mutations = tmp_muts
+  const tmp_subs: MutationMap = new Map<number, Nucleotide>()
+  tmp_muts?.forEach((v, k) => {
+    if (v !== '-') {
+      tmp_subs.set(k, v)
+    }
+  })
+  nodeExtended.substitutions = tmp_subs
   nodeExtended.id = id.value
 
   const { children } = nodeExtended

--- a/packages/web/src/algorithms/tree/types.ts
+++ b/packages/web/src/algorithms/tree/types.ts
@@ -6,6 +6,7 @@ export type MutationMap = Map<number, Nucleotide>
 export interface AuspiceTreeNodeExtended extends AuspiceTreeNode {
   id: number
   mutations?: MutationMap
+  substitutions?: MutationMap
   children?: AuspiceTreeNodeExtended[]
 }
 


### PR DESCRIPTION
this might speed up placement a bit. 