### PR TITLE
feat: load results json

### DIFF
--- a/packages/web/src/components/Main/FilePicker.tsx
+++ b/packages/web/src/components/Main/FilePicker.tsx
@@ -163,6 +163,7 @@ export interface FilePickerProps {
   inputRef?: Ref<HTMLInputElement | null>
   canCollapse?: boolean
   defaultCollapsed?: boolean
+  showBadge?: boolean
 
   onInput(input: AlgorithmInput): void
 
@@ -184,6 +185,7 @@ export function FilePicker({
   inputRef,
   canCollapse = true,
   defaultCollapsed = true,
+  showBadge = true,
 }: FilePickerProps) {
   const { t } = useTranslationSafe()
 
@@ -222,7 +224,8 @@ export function FilePicker({
     [shouldCollapse, t],
   )
 
-  const badge = useMemo(() => (canCollapse ? <BadgeDefault /> : <BadgeRequired />), [canCollapse])
+  const badge = useMemo(() => showBadge && (canCollapse ? <BadgeDefault /> :
+    <BadgeRequired />), [showBadge, canCollapse]) // prettier-ignore
 
   if (input) {
     return (

--- a/packages/web/src/components/Main/MainSectionHeroControlsSimple.tsx
+++ b/packages/web/src/components/Main/MainSectionHeroControlsSimple.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import { delay } from 'lodash'
 import { connect } from 'react-redux'
@@ -91,6 +91,8 @@ export function MainSectionHeroControlsDisconnected({
 }: MainSectionHeroControlsProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const [showResultsImport, setShowResultsImport] = useState(false)
+  const toggleShowResultsImport = useCallback(() => setShowResultsImport(!showResultsImport), [showResultsImport])
 
   function loadDefaultData() {
     setIsDirty(true)
@@ -111,45 +113,58 @@ export function MainSectionHeroControlsDisconnected({
 
   return (
     <div>
-      <Row>
-        <Col>
-          <FilePickerSimple
-            canCollapse={false}
-            defaultCollapsed={false}
-            icon={<FileIconFasta />}
-            text={t('Sequences')}
-            exampleUrl="https://example.com/sequences.fasta"
-            pasteInstructions={t('Enter sequence data in FASTA or plain text format')}
-            input={params.raw.seqData}
-            onInput={onUpload}
-            errors={params.errors.seqData}
-            onRemove={removeFasta}
-            inputRef={inputRef}
-          />
-        </Col>
-      </Row>
+      {!showResultsImport && (
+        <Row>
+          <Col>
+            <FilePickerSimple
+              canCollapse={false}
+              defaultCollapsed={false}
+              icon={<FileIconFasta />}
+              text={t('Sequences')}
+              exampleUrl="https://example.com/sequences.fasta"
+              pasteInstructions={t('Enter sequence data in FASTA or plain text format')}
+              input={params.raw.seqData}
+              onInput={onUpload}
+              errors={params.errors.seqData}
+              onRemove={removeFasta}
+              showBadge={false}
+              inputRef={inputRef}
+            />
+          </Col>
+        </Row>
+      )}
+
+      {showResultsImport && (
+        <Row>
+          <Col>
+            <FilePickerSimple
+              canCollapse={false}
+              defaultCollapsed={false}
+              icon={<FileIconJson />}
+              text={t('Results import')}
+              exampleUrl="https://example.com/nextclade.json"
+              pasteInstructions={t('Enter Nextclade results data in JSON format')}
+              input={params.raw.resultsJson}
+              onInput={onResultsUpload}
+              errors={params.errors.resultsJson}
+              onRemove={removeResultsJson}
+              showBadge={false}
+            />
+          </Col>
+        </Row>
+      )}
 
       <Row>
-        <Col>
-          <FilePickerSimple
-            canCollapse={false}
-            defaultCollapsed={false}
-            icon={<FileIconJson />}
-            text={t('Results import')}
-            exampleUrl="https://example.com/nextclade.json"
-            pasteInstructions={t('Enter Nextclade results data in JSON format')}
-            input={params.raw.resultsJson}
-            onInput={onResultsUpload}
-            errors={params.errors.resultsJson}
-            onRemove={removeResultsJson}
-          />
+        <Col xs={6}>
+          {!showResultsImport && (
+            <Button color="link" onClick={loadDefaultData}>
+              <small>{t('Show me an Example')}</small>
+            </Button>
+          )}
         </Col>
-      </Row>
-
-      <Row>
-        <Col>
-          <Button color="link" onClick={loadDefaultData}>
-            <small>{t('Show me an Example')}</small>
+        <Col xs={6} className="d-flex">
+          <Button className="ml-auto" color="link" onClick={toggleShowResultsImport}>
+            <small>{showResultsImport ? t('Run a new analysis') : t('Load previous results')}</small>
           </Button>
         </Col>
       </Row>

--- a/packages/web/src/components/Main/MainSectionHeroControlsSimple.tsx
+++ b/packages/web/src/components/Main/MainSectionHeroControlsSimple.tsx
@@ -5,23 +5,26 @@ import { connect } from 'react-redux'
 import { push } from 'connected-next-router'
 import { useTranslation } from 'react-i18next'
 import { Button, Col, Row } from 'reactstrap'
-import { AlgorithmInputString } from 'src/io/AlgorithmInput'
 import styled from 'styled-components'
 
 import { getSequenceDatum } from 'src/algorithms/defaults/viruses'
 import { FilePicker } from 'src/components/Main/FilePicker'
 
 import type { State } from 'src/state/reducer'
+import { AlgorithmInputString } from 'src/io/AlgorithmInput'
 import type { AlgorithmInput, AlgorithmParams } from 'src/state/algorithm/algorithm.state'
 import {
   algorithmRunWithSequencesAsync,
   exportCsvTrigger,
   removeFasta,
+  removeResultsJson,
   setFasta,
   setIsDirty,
+  setResultsJson,
+  showResultsAsync,
 } from 'src/state/algorithm/algorithm.actions'
 import { selectCanExport, selectParams } from 'src/state/algorithm/algorithm.selectors'
-import { FileIconFasta } from './UploaderFileIcons'
+import { FileIconFasta, FileIconJson } from './UploaderFileIcons'
 
 export const FilePickerSimple = styled(FilePicker)`
   height: 100%;
@@ -30,6 +33,10 @@ export const FilePickerSimple = styled(FilePicker)`
 export interface MainSectionHeroControlsProps {
   params: AlgorithmParams
   canExport: boolean
+
+  setResultsJson(input: AlgorithmInput): void
+
+  removeResultsJson(_0: unknown): void
 
   setFasta(input: AlgorithmInput): void
 
@@ -40,6 +47,8 @@ export interface MainSectionHeroControlsProps {
   algorithmRunTrigger(_0: unknown): void
 
   algorithmRunWithSequencesTrigger(input: AlgorithmInput): void
+
+  showResultsTrigger(input: AlgorithmInput): void
 
   goToResults(): void
 }
@@ -53,8 +62,11 @@ const mapDispatchToProps = {
   setIsDirty,
   setFasta: setFasta.trigger,
   removeFasta,
+  setResultsJson: setResultsJson.trigger,
+  removeResultsJson,
   algorithmRunTrigger: algorithmRunWithSequencesAsync.trigger,
   algorithmRunWithSequencesTrigger: algorithmRunWithSequencesAsync.trigger,
+  showResultsTrigger: showResultsAsync.trigger,
   exportTrigger: () => exportCsvTrigger(),
   goToResults: () => push('/results'),
 }
@@ -70,9 +82,12 @@ export function MainSectionHeroControlsDisconnected({
   setIsDirty,
   algorithmRunTrigger,
   algorithmRunWithSequencesTrigger,
+  showResultsTrigger,
   goToResults,
   setFasta,
   removeFasta,
+  setResultsJson,
+  removeResultsJson,
 }: MainSectionHeroControlsProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -88,6 +103,10 @@ export function MainSectionHeroControlsDisconnected({
   async function onUpload(input: AlgorithmInput) {
     setIsDirty(true)
     algorithmRunWithSequencesTrigger(input)
+  }
+
+  async function onResultsUpload(input: AlgorithmInput) {
+    showResultsTrigger(input)
   }
 
   return (
@@ -106,6 +125,23 @@ export function MainSectionHeroControlsDisconnected({
             errors={params.errors.seqData}
             onRemove={removeFasta}
             inputRef={inputRef}
+          />
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <FilePickerSimple
+            canCollapse={false}
+            defaultCollapsed={false}
+            icon={<FileIconJson />}
+            text={t('Results import')}
+            exampleUrl="https://example.com/nextclade.json"
+            pasteInstructions={t('Enter Nextclade results data in JSON format')}
+            input={params.raw.resultsJson}
+            onInput={onResultsUpload}
+            errors={params.errors.resultsJson}
+            onRemove={removeResultsJson}
           />
         </Col>
       </Row>

--- a/packages/web/src/initialize.ts
+++ b/packages/web/src/initialize.ts
@@ -1,4 +1,5 @@
 import type { Router } from 'next/router'
+import { fetchResultsAndShowMaybe } from 'src/io/fetchResultsAndShowMaybe'
 
 import { configureStore } from 'src/state/store'
 import { createWorkerPools } from 'src/workers/createWorkerPools'
@@ -28,6 +29,8 @@ export async function initialize({ router }: InitializeParams) {
   store.dispatch(setLocale(localeKeyV2))
 
   showWhatsNewMaybe(lastVersionSeen, showWhatsnewOnUpdate, store.dispatch)
+
+  await fetchResultsAndShowMaybe(store.dispatch, router)
 
   await fetchInputsAndRunMaybe(store.dispatch, router)
 

--- a/packages/web/src/io/deserializeResults.ts
+++ b/packages/web/src/io/deserializeResults.ts
@@ -1,0 +1,34 @@
+import type { StrictOmit } from 'ts-essentials'
+
+import type { AnalysisResultWithMatch } from 'src/algorithms/types'
+import type { SequenceAnalysisState } from 'src/state/algorithm/algorithm.state'
+import { AlgorithmSequenceStatus } from 'src/state/algorithm/algorithm.state'
+
+export interface AnalysisResultSerialized
+  extends StrictOmit<AnalysisResultWithMatch, 'alignedQuery' | 'nucleotideComposition'> {
+  errors: string[]
+}
+
+export type NextcladeJson = AnalysisResultSerialized[]
+
+export function deserializeJsonToResults(json: NextcladeJson): SequenceAnalysisState[] {
+  return json.map((result, id) => {
+    const status =
+      result.errors.length > 0 ? AlgorithmSequenceStatus.analysisFailed : AlgorithmSequenceStatus.analysisDone
+
+    const resultInternal: AnalysisResultWithMatch = {
+      ...result,
+      alignedQuery: '',
+      nucleotideComposition: {},
+      qc: { ...result.qc, seqName: result.seqName },
+    }
+
+    return {
+      id,
+      seqName: result.seqName,
+      status,
+      result: resultInternal,
+      errors: result.errors,
+    }
+  })
+}

--- a/packages/web/src/io/fetchInputsAndRunMaybe.ts
+++ b/packages/web/src/io/fetchInputsAndRunMaybe.ts
@@ -1,19 +1,12 @@
-import Axios, { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 import type { Router } from 'next/router'
 import type { Dispatch } from 'redux'
 
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
 import { AlgorithmInputString, HttpRequestError } from 'src/io/AlgorithmInput'
-import { errorAdd } from 'src/state/error/error.actions'
+import { fetchMaybe } from 'src/io/fetchMaybe'
 import { algorithmRunWithSequencesAsync, setIsDirty, setRootSeq, setTree } from 'src/state/algorithm/algorithm.actions'
-
-export async function fetchMaybe(url?: string): Promise<string | undefined> {
-  if (url) {
-    const { data } = await Axios.get<string | undefined>(url, { transformResponse: [] })
-    return data
-  }
-  return undefined
-}
+import { errorAdd } from 'src/state/error/error.actions'
 
 export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router) {
   const inputFastaUrl = takeFirstMaybe(router.query?.['input-fasta'])

--- a/packages/web/src/io/fetchMaybe.ts
+++ b/packages/web/src/io/fetchMaybe.ts
@@ -1,0 +1,9 @@
+import Axios from 'axios'
+
+export async function fetchMaybe(url?: string): Promise<string | undefined> {
+  if (url) {
+    const { data } = await Axios.get<string | undefined>(url, { transformResponse: [] })
+    return data
+  }
+  return undefined
+}

--- a/packages/web/src/io/fetchResultsAndShowMaybe.ts
+++ b/packages/web/src/io/fetchResultsAndShowMaybe.ts
@@ -1,0 +1,34 @@
+import { AxiosError } from 'axios'
+import type { Router } from 'next/router'
+import type { Dispatch } from 'redux'
+
+import { AlgorithmInputString, HttpRequestError } from 'src/io/AlgorithmInput'
+import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
+import { fetchMaybe } from 'src/io/fetchMaybe'
+import { showResultsAsync } from 'src/state/algorithm/algorithm.actions'
+import { errorAdd } from 'src/state/error/error.actions'
+
+export async function fetchResultsAndShowMaybe(dispatch: Dispatch, router: Router) {
+  const inputResultsJsonUrl = takeFirstMaybe(router.query?.['results-json'])
+  let inputResultsJsonDangerous: string | undefined
+  let hasError = false
+
+  try {
+    inputResultsJsonDangerous = await fetchMaybe(inputResultsJsonUrl)
+  } catch (error_) {
+    const error = new HttpRequestError(error_ as AxiosError)
+    console.error(error)
+    dispatch(errorAdd({ error }))
+    hasError = true
+  }
+
+  if (hasError) {
+    return
+  }
+
+  if (inputResultsJsonDangerous) {
+    dispatch(showResultsAsync.trigger(new AlgorithmInputString(inputResultsJsonDangerous, inputResultsJsonUrl)))
+
+    await router.replace('/results')
+  }
+}

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -8,6 +8,7 @@ import type { AuspiceJsonV2Extended } from 'src/algorithms/tree/types'
 import type { LocateInTreeParams, LocateInTreeResults } from 'src/algorithms/tree/treeFindNearestNodes'
 import type { FinalizeTreeParams } from 'src/algorithms/tree/treeAttachNodes'
 import type { QCResult, QCRulesConfig } from 'src/algorithms/QC/types'
+import type { NextcladeJson } from 'src/io/deserializeResults'
 
 import type { AlgorithmGlobalStatus, AlgorithmInput, CladeAssignmentResult } from './algorithm.state'
 
@@ -15,6 +16,7 @@ const action = actionCreatorFactory('Algorithm')
 
 export const setIsDirty = action<boolean>('setIsDirty')
 
+export const setResultsJson = action.async<AlgorithmInput, { json: NextcladeJson }, Error>('setResultsJson')
 export const setFasta = action.async<AlgorithmInput, { seqData: string }, Error>('setFasta')
 export const setTree = action.async<AlgorithmInput, { auspiceData: AuspiceJsonV2, geneMap: Gene[] }, Error>('setTree') // prettier-ignore
 export const setRootSeq = action.async<AlgorithmInput, { rootSeq: string }, Error>('setRootSeq')
@@ -22,6 +24,7 @@ export const setQcSettings = action.async<AlgorithmInput, { qcRulesConfig: QCRul
 export const setGeneMap = action.async<AlgorithmInput, { geneMap: Gene[] }, Error>('setGeneMap')
 export const setPcrPrimers = action.async<AlgorithmInput, { pcrPrimers: PcrPrimer[] }, Error>('setPcrPrimers') // prettier-ignore
 
+export const removeResultsJson = action('removeResultsJson')
 export const removeFasta = action('removeFasta')
 export const removeTree = action('removeTree')
 export const removeRootSeq = action('removeRootSeq')
@@ -32,6 +35,7 @@ export const removePcrPrimers = action('removePcrPrimers')
 export const setAlgorithmGlobalStatus = action<AlgorithmGlobalStatus>('setAlgorithmGlobalStatus')
 export const algorithmRunAsync = action.async<void, void, Error>('algorithmRunAsync')
 export const algorithmRunWithSequencesAsync = action.async<AlgorithmInput, void, Error>('algorithmRunWithSequencesAsync') // prettier-ignore
+export const showResultsAsync = action.async<AlgorithmInput, void, Error>('showResultsAsync')
 
 export const parseAsync = action.async<string | File, string[], Error>('parse')
 export const analyzeAsync = action.async<AnalysisParams, AnalysisResult, Error>('analyze')

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -66,6 +66,7 @@ export interface AlgorithmInput {
 
 export interface AlgorithmParams {
   raw: {
+    resultsJson?: AlgorithmInput
     seqData?: AlgorithmInput
     auspiceData?: AlgorithmInput
     rootSeq?: AlgorithmInput
@@ -74,6 +75,7 @@ export interface AlgorithmParams {
     pcrPrimers?: AlgorithmInput
   }
   errors: {
+    resultsJson: Error[]
     seqData: Error[]
     auspiceData: Error[]
     rootSeq: Error[]
@@ -107,6 +109,7 @@ export const algorithmDefaultState: AlgorithmState = {
   params: {
     raw: {},
     errors: {
+      resultsJson: [],
       seqData: [],
       auspiceData: [],
       rootSeq: [],

--- a/packages/web/src/state/algorithm/algorithmInputs.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmInputs.sagas.ts
@@ -1,5 +1,6 @@
 import { convertPcrPrimers } from 'src/algorithms/primers/convertPcrPrimers'
 import { validatePcrPrimerEntries, validatePcrPrimers } from 'src/algorithms/primers/validatePcrPrimers'
+import { NextcladeJson } from 'src/io/deserializeResults'
 import { parseCsv } from 'src/io/parseCsv'
 import { call, select, takeEvery } from 'typed-redux-saga'
 
@@ -16,10 +17,17 @@ import {
   setGeneMap,
   setPcrPrimers,
   setQcSettings,
+  setResultsJson,
   setRootSeq,
   setTree,
 } from 'src/state/algorithm/algorithm.actions'
 import { State } from '../reducer'
+
+export function* loadResultsJson(input: AlgorithmInput) {
+  const str = yield* call([input, input.getContent])
+  const json = JSON.parse(str) as NextcladeJson // TODO: validate
+  return { json }
+}
 
 export function* loadFasta(input: AlgorithmInput) {
   const seqData = yield* call([input, input.getContent])
@@ -80,6 +88,7 @@ export function* loadPcrPrimers(input: AlgorithmInput) {
 }
 
 export default [
+  takeEvery(setResultsJson.trigger, fsaSaga(setResultsJson, loadResultsJson)),
   takeEvery(setFasta.trigger, fsaSaga(setFasta, loadFasta)),
   takeEvery(setTree.trigger, fsaSaga(setTree, loadTree)),
   takeEvery(setRootSeq.trigger, fsaSaga(setRootSeq, loadRootSeq)),

--- a/packages/web/src/state/store.ts
+++ b/packages/web/src/state/store.ts
@@ -1,4 +1,3 @@
-import { AlgorithmState } from 'src/state/algorithm/algorithm.state'
 import { format } from 'url'
 
 import type { Router } from 'next/router'

--- a/packages/web/src/state/store.ts
+++ b/packages/web/src/state/store.ts
@@ -1,3 +1,4 @@
+import { AlgorithmState } from 'src/state/algorithm/algorithm.state'
 import { format } from 'url'
 
 import type { Router } from 'next/router'


### PR DESCRIPTION
This allows to load previously exported Nextclade JSON file in the web app.

There is a new link "load previous results", which toggles the upload box into the JSON mode. Users can provide their file or URL to load the data from, or they can paste JSON string.

When this data is provided, Nextclade will load it and switch to the "Results" showing the data as if it was computed locally.


Additionally, there is a new URL parameter: `results-json`, which allows to hotlink the Nextclade JSON file as follows:
```
https://clade.nextslrain.org?results-json=https://example.com/nextclade.json
```

When this URL parameter is provided, Nextclade will download the file and display the results.


Note that Nextclade JSON does not contain the tree data, so the tree will not be available.

Resolves #211 
