### PR TITLE
fix: trim leading and trailing to void seed matching problems

### DIFF
--- a/packages/web/src/algorithms/alignPairwise.ts
+++ b/packages/web/src/algorithms/alignPairwise.ts
@@ -71,7 +71,7 @@ function seedMatch(kmer: string, ref: string): SeedMatch {
 function seedAlignment(query: string, ref: string): SeedAlignment {
   const nSeeds = 9
   const seedLength = 21
-  const margin = ref.length > 10000 ? 100 : Math.round(ref.length / 100)
+  const margin = ref.length > 3000 ? 30 : Math.round(ref.length / 100)
   const bandWidth = Math.min(ref.length, query.length)
 
   if (bandWidth < 2 * seedLength) {

--- a/packages/web/src/algorithms/parseSequences.ts
+++ b/packages/web/src/algorithms/parseSequences.ts
@@ -39,7 +39,7 @@ export function parseSequences(input: string) {
 
     if (line.startsWith('>')) {
       if (currentSeq.length > 0) {
-        addSequence(currentSeq, currentSeqName, seqs, seqNames)
+        addSequence(currentSeq.replace(/N+$/g, '').replace(/^N+/g, ''), currentSeqName, seqs, seqNames)
       }
       // eslint-disable-next-line unicorn/prefer-string-slice
       currentSeqName = line.substring(1, line.length)
@@ -52,7 +52,7 @@ export function parseSequences(input: string) {
   }
 
   if (currentSeq.length > 0) {
-    addSequence(currentSeq, currentSeqName, seqs, seqNames)
+    addSequence(currentSeq.replace(/N+$/g, '').replace(/^N+/g, ''), currentSeqName, seqs, seqNames)
   }
 
   return seqs

--- a/packages/web/src/algorithms/parseSequences.ts
+++ b/packages/web/src/algorithms/parseSequences.ts
@@ -1,3 +1,8 @@
+export function sanitizeSequence(seq: string) {
+  // Trim contiguous Ns in the beginning and end
+  return seq.replace(/N+$/g, '').replace(/^N+/g, '')
+}
+
 export function addSequence(
   currentSeq: string,
   currentSeqName: string,
@@ -22,7 +27,7 @@ export function addSequence(
   }
 
   allNames.push(currentSeqName)
-  seqs[currentSeqName + suffix] = currentSeq
+  seqs[currentSeqName + suffix] = sanitizeSequence(currentSeq)
 }
 
 export function parseSequences(input: string) {
@@ -39,7 +44,7 @@ export function parseSequences(input: string) {
 
     if (line.startsWith('>')) {
       if (currentSeq.length > 0) {
-        addSequence(currentSeq.replace(/N+$/g, '').replace(/^N+/g, ''), currentSeqName, seqs, seqNames)
+        addSequence(currentSeq, currentSeqName, seqs, seqNames)
       }
       // eslint-disable-next-line unicorn/prefer-string-slice
       currentSeqName = line.substring(1, line.length)
@@ -52,7 +57,7 @@ export function parseSequences(input: string) {
   }
 
   if (currentSeq.length > 0) {
-    addSequence(currentSeq.replace(/N+$/g, '').replace(/^N+/g, ''), currentSeqName, seqs, seqNames)
+    addSequence(currentSeq, currentSeqName, seqs, seqNames)
   }
 
   return seqs


### PR DESCRIPTION
This fixes #285 by trimming leading and trailing Ns before aligning. 

This doesn't chance interpretation or behavior. We classify missing data left and right as "unsequenced". `N`s at the left or right end are essentially unsequenced. 