### PR TITLE
Add sequence view pan and zoom

### DIFF
--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { ChangeEvent, memo, useCallback } from 'react'
 
 import { sum } from 'lodash'
 import { connect } from 'react-redux'
@@ -14,6 +14,7 @@ import type { SequenceAnalysisState } from 'src/state/algorithm/algorithm.state'
 import type { Sorting } from 'src/helpers/sortResults'
 import { SortCategory, SortDirection } from 'src/helpers/sortResults'
 import { resultsSortTrigger } from 'src/state/algorithm/algorithm.actions'
+import { setSequenceViewPan, setSequenceViewZoom } from 'src/state/ui/ui.actions'
 
 import { SequenceView } from 'src/components/SequenceView/SequenceView'
 
@@ -103,6 +104,7 @@ export const TableRow = styled.div<{ even?: boolean; backgroundColor?: string }>
   align-items: stretch;
   background-color: ${(props) => props.backgroundColor};
   box-shadow: 1px 2px 2px 2px ${rgba('#212529', 0.25)};
+  user-select: none;
 `
 
 export const TableCell = styled.div<{ basis?: string; grow?: number; shrink?: number }>`
@@ -235,6 +237,8 @@ const TableRowMemo = memo(TableRowComponent, areEqual)
 const mapStateToProps = (state: State) => ({
   resultsFiltered: state.algorithm.resultsFiltered,
   filterPanelCollapsed: state.ui.filterPanelCollapsed,
+  sequenceViewZoom: state.ui.sequenceView.zoom,
+  sequenceViewPan: state.ui.sequenceView.pan,
 })
 
 const mapDispatchToProps = {
@@ -263,6 +267,9 @@ const mapDispatchToProps = {
 
   sortByTotalGapsAsc: () => resultsSortTrigger({ category: SortCategory.totalGaps, direction: SortDirection.asc }),
   sortByTotalGapsDesc: () => resultsSortTrigger({ category: SortCategory.totalGaps, direction: SortDirection.desc }),
+
+  setSequenceViewZoom,
+  setSequenceViewPan,
 }
 
 export const ResultsTable = React.memo(connect(mapStateToProps, mapDispatchToProps)(ResultsTableDisconnected))
@@ -286,6 +293,10 @@ export interface ResultProps {
   sortByTotalNsDesc(): void
   sortByTotalGapsAsc(): void
   sortByTotalGapsDesc(): void
+  sequenceViewZoom: number
+  setSequenceViewZoom(zoom: number): void
+  sequenceViewPan: number
+  setSequenceViewPan(zoom: number): void
 }
 
 export function ResultsTableDisconnected({
@@ -307,13 +318,56 @@ export function ResultsTableDisconnected({
   sortByTotalNsDesc,
   sortByTotalGapsAsc,
   sortByTotalGapsDesc,
+  sequenceViewZoom,
+  setSequenceViewZoom,
+  sequenceViewPan,
+  setSequenceViewPan,
 }: ResultProps) {
   const { t } = useTranslation()
-
   const data = resultsFiltered
+
+  const handleZoomChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const z = Number.parseInt(event.target.value, 10) / 100
+      setSequenceViewZoom(z)
+    },
+    [setSequenceViewZoom],
+  )
+
+  const handlePanChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const z = Number.parseInt(event.target.value, 10) / 100
+      setSequenceViewPan(z)
+    },
+    [setSequenceViewPan],
+  )
 
   return (
     <>
+      <div style={{ margin: '20px', width: '200px' }}>{sequenceViewZoom * 100}</div>
+      <div>
+        <input
+          type="range"
+          style={{ margin: '20px', width: '200px' }}
+          min={0}
+          max={100}
+          value={sequenceViewZoom * 100}
+          onChange={handleZoomChange}
+        />
+      </div>
+
+      <div style={{ margin: '20px', width: '200px' }}>{sequenceViewPan}</div>
+      <div>
+        <input
+          type="range"
+          style={{ margin: '20px', width: '200px' }}
+          min={0}
+          max={100}
+          value={sequenceViewPan * 100}
+          onChange={handlePanChange}
+        />
+      </div>
+
       <Table rounded={!filterPanelCollapsed}>
         <TableHeaderRow>
           <TableHeaderCell first basis={RESULTS_TABLE_FLEX_BASIS_PX.id} grow={0} shrink={0}>

--- a/packages/web/src/components/SequenceView/SequenceView.tsx
+++ b/packages/web/src/components/SequenceView/SequenceView.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { connect } from 'react-redux'
 import { ReactResizeDetectorDimensions, withResizeDetector } from 'react-resize-detector'
@@ -10,6 +10,7 @@ import { SequenceMarkerGap } from './SequenceMarkerGap'
 import { SequenceMarkerMissing } from './SequenceMarkerMissing'
 import { SequenceMarkerMutation } from './SequenceMarkerMutation'
 import { SequenceMarkerMissingEnds } from './SequenceMarkerMissingEnds'
+import { BASE_MIN_WIDTH_PX } from 'src/constants'
 
 export const SequenceViewWrapper = styled.div`
   display: flex;
@@ -25,25 +26,25 @@ export const SequenceViewWrapper = styled.div`
 export const SequenceViewSVG = styled.svg`
   padding: 0;
   margin: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
 `
 
 export interface SequenceViewProps extends ReactResizeDetectorDimensions {
   sequence: AnalysisResult
   genomeSize: number
+  zoom: number
+  pan: number
 }
 
 const mapStateToProps = (state: State) => ({
   genomeSize: state.algorithm.params.virus.genomeSize,
+  zoom: state.ui.sequenceView.zoom,
+  pan: state.ui.sequenceView.pan,
 })
 const mapDispatchToProps = {}
 
 export const SequenceViewUnsized = connect(mapStateToProps, mapDispatchToProps)(SequenceViewUnsizedDisconnected)
 
-export function SequenceViewUnsizedDisconnected({ sequence, width, genomeSize }: SequenceViewProps) {
+export function SequenceViewUnsizedDisconnected({ sequence, width, genomeSize, zoom, pan }: SequenceViewProps) {
   const { seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd } = sequence
 
   if (!width) {
@@ -55,6 +56,7 @@ export function SequenceViewUnsizedDisconnected({ sequence, width, genomeSize }:
   }
 
   const pixelsPerBase = width / genomeSize
+  const pixelPan = pan * width
 
   const mutationViews = substitutions.map((substitution) => {
     return (
@@ -100,7 +102,7 @@ export function SequenceViewUnsizedDisconnected({ sequence, width, genomeSize }:
 
   return (
     <SequenceViewWrapper>
-      <SequenceViewSVG viewBox={`0 0 ${width} 10`}>
+      <SequenceViewSVG width={width} height={30} viewBox={`${pixelPan} 0 ${width * zoom} 10`}>
         <rect fill="transparent" x={0} y={-10} width={genomeSize} height="30" />
         {missingEndViews}
         {mutationViews}

--- a/packages/web/src/state/ui/ui.actions.ts
+++ b/packages/web/src/state/ui/ui.actions.ts
@@ -13,3 +13,7 @@ export const setTreeFilterPanelCollapsed = action<boolean>('setTreeFilterPanelCo
 export const setShowWhatsnew = action<boolean>('setShowWhatsnew')
 
 export const setShowNewRunPopup = action<boolean>('setShowNewRunPopup')
+
+export const setSequenceViewZoom = action<number>('setSequenceViewZoom')
+
+export const setSequenceViewPan = action<number>('setSequenceViewPan')

--- a/packages/web/src/state/ui/ui.reducer.ts
+++ b/packages/web/src/state/ui/ui.reducer.ts
@@ -4,6 +4,8 @@ import { uiDefaultState } from 'src/state/ui/ui.state'
 import {
   setExportFormat,
   setFilterPanelCollapsed,
+  setSequenceViewPan,
+  setSequenceViewZoom,
   setShowNewRunPopup,
   setShowWhatsnew,
   setTreeFilterPanelCollapsed,
@@ -28,4 +30,12 @@ export const uiReducer = reducerWithInitialState(uiDefaultState)
 
   .icase(setShowNewRunPopup, (draft, showNewRunPopup) => {
     draft.showNewRunPopup = showNewRunPopup
+  })
+
+  .icase(setSequenceViewZoom, (draft, zoom) => {
+    draft.sequenceView.zoom = zoom
+  })
+
+  .icase(setSequenceViewPan, (draft, pan) => {
+    draft.sequenceView.pan = pan
   })

--- a/packages/web/src/state/ui/ui.state.ts
+++ b/packages/web/src/state/ui/ui.state.ts
@@ -6,6 +6,10 @@ export enum ExportFormat {
 }
 
 export interface UiState {
+  sequenceView: {
+    zoom: number
+    pan: number
+  }
   filterPanelCollapsed: boolean
   treeFilterPanelCollapsed: boolean
   exportFormat: ExportFormat
@@ -14,6 +18,10 @@ export interface UiState {
 }
 
 export const uiDefaultState: UiState = {
+  sequenceView: {
+    zoom: 1,
+    pan: 0,
+  },
   filterPanelCollapsed: true,
   treeFilterPanelCollapsed: true,
   exportFormat: ExportFormat.CSV,


### PR DESCRIPTION
Adds horizontal zoom and pan (horizontal scroll) in sequence view. It is useful, in particular, to see mutation markers that are close together.

Resolves #34 
