### PR TITLE
Add windows dev support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,18 @@ git clone https://github.com/nextstrain/nextclade
 cd nextclade/packages/web
 cp .env.example .env
 yarn install
-yarn dev
+```
 
+then start the development server with:
+
+```bash
+yarn dev
+```
+
+for Windows, (without Linux Subsystem), try:
+
+```bash
+yarn dev:start_win
 ```
 
 (on Windows, substitute `cp` with `copy`)

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -24,6 +24,8 @@
     "dev": "nodemon --config config/nodemon/dev.json",
     "dev:start": "yarn install && yarn run monkey-patch && yarn dev:nowatch || cd .",
     "dev:nowatch": "cross-env NODE_ENV=development BABEL_ENV=development NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- node_modules/.bin/next dev --hostname 0.0.0.0 --port 3000",
+    "dev:start_win": "yarn install && yarn run monkey-patch && yarn dev:nowatch_win || cd .",
+    "dev:nowatch_win": "cross-env NODE_ENV=development BABEL_ENV=development NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- node_modules/next/dist/bin/next dev --hostname 0.0.0.0 --port 3000",
     "dev:clean": "rimraf '.build/development/{*,.*}' 'node_modules/.cache'",
     "prod:build": "yarn run monkey-patch && yarn run next:build && yarn run next:export",
     "prod:build:ci": "yarn run prod:build",


### PR DESCRIPTION
Windows was previously not supported due to hardcoding to a Unix-specific file. This provides an alternative that works. See https://github.com/nextstrain/nextclade/issues/313 https://github.com/hodcroftlab/covariants/issues/18 https://github.com/hodcroftlab/covariants/pull/71. Tested that I can run a dev server successfully with `npm dev:start_win`.

Fixes #313