### PR TITLE
refactor: use ghc-filesystem as a replacement for std::filesystem

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,6 +4,7 @@ boost/1.75.0
 cxxopts/2.2.1
 fast-cpp-csv-parser/20191004
 fmt/7.1.3
+ghc-filesystem/1.4.0
 gtest/1.10.0
 ms-gsl/3.1.0
 tbb/2021.2.0-rc@local/stable

--- a/packages/nextalign/CMakeLists.txt
+++ b/packages/nextalign/CMakeLists.txt
@@ -7,7 +7,7 @@ include(Quiet)
 include(Sanitizers)
 
 project(nextalign DESCRIPTION "C++ library for viral genome reference alignment")
-file (STRINGS "VERSION" PROJECT_VERSION)
+file(STRINGS "VERSION" PROJECT_VERSION)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INSTALL_MESSAGE LAZY)

--- a/packages/nextalign_cli/CMakeLists.txt
+++ b/packages/nextalign_cli/CMakeLists.txt
@@ -7,7 +7,7 @@ include(Quiet)
 include(Sanitizers)
 
 project(nextalign_cli DESCRIPTION "Viral genome reference alignment")
-file (STRINGS "VERSION" PROJECT_VERSION)
+file(STRINGS "VERSION" PROJECT_VERSION)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INSTALL_MESSAGE LAZY)
@@ -18,19 +18,19 @@ find_package(fmt 7.1.0 REQUIRED)
 find_package(TBB REQUIRED)
 
 if (${NEXTALIGN_STATIC_BUILD} AND NOT APPLE)
-  if(MINGW)
+  if (MINGW)
     set(STATIC_BUILD_FLAGS "-static -static-libstdc++ -static-libgcc -lrt -ltbbmalloc -ltbbmalloc_proxy")
-  else()
+  else ()
     set(STATIC_BUILD_FLAGS "-static -static-libstdc++ -static-libgcc")
-  endif()
+  endif ()
 endif ()
 
 set(SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
 set(PROCESSOR_NAME ${CMAKE_SYSTEM_PROCESSOR})
 if (APPLE)
-  if(NOT DEFINED NEXTALIGN_MACOS_ARCH)
+  if (NOT DEFINED NEXTALIGN_MACOS_ARCH)
     set(NEXTALIGN_MACOS_ARCH "Unknown")
-  endif()
+  endif ()
 
   set(SYSTEM_NAME "MacOS")
   set(PROCESSOR_NAME "${NEXTALIGN_MACOS_ARCH}")
@@ -38,6 +38,7 @@ endif ()
 
 add_executable(${PROJECT_NAME}
   src/cli.cpp
+  src/filesystem.h
   )
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -7,8 +7,9 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <cxxopts.hpp>
-#include <filesystem>
 #include <fstream>
+
+#include "filesystem.h"
 
 
 struct CliParams {
@@ -24,9 +25,9 @@ struct CliParams {
 };
 
 struct Paths {
-  std::filesystem::path outputFasta;
-  std::filesystem::path outputInsertions;
-  std::map<std::string, std::filesystem::path> outputGenes;
+  fs::path outputFasta;
+  fs::path outputInsertions;
+  std::map<std::string, fs::path> outputGenes;
 };
 
 template<typename Result>
@@ -60,7 +61,8 @@ auto getParamRequiredDefaulted([[maybe_unused]] const cxxopts::Options &cxxOpts,
 
 CliParams parseCommandLine(int argc, char *argv[]) {// NOLINT(cppcoreguidelines-avoid-c-arrays)
   const std::string versionShort = PROJECT_VERSION;
-  const std::string versionDetailed = fmt::format("nextalign {:s}\nbased on libnextalign {:s}", PROJECT_VERSION, getVersion());
+  const std::string versionDetailed =
+    fmt::format("nextalign {:s}\nbased on libnextalign {:s}", PROJECT_VERSION, getVersion());
 
   cxxopts::Options cxxOpts("nextalign", fmt::format("{:s}\n\n{:s}\n", versionDetailed, PROJECT_DESCRIPTION));
 
@@ -158,7 +160,7 @@ CliParams parseCommandLine(int argc, char *argv[]) {// NOLINT(cppcoreguidelines-
     std::exit(0);
   }
 
-    if (cxxOptsParsed.count("version-detailed") > 0) {
+  if (cxxOptsParsed.count("version-detailed") > 0) {
     fmt::print(stdout, "{:s}\n", versionDetailed);
     std::exit(0);
   }
@@ -274,15 +276,15 @@ std::string formatCliParams(const CliParams &cliParams) {
 }
 
 Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
-  std::filesystem::path sequencesPath = cliParams.sequences;
+  fs::path sequencesPath = cliParams.sequences;
 
-  auto outDir = std::filesystem::canonical(std::filesystem::current_path());
+  auto outDir = fs::canonical(fs::current_path());
   if (cliParams.outputDir) {
     outDir = *cliParams.outputDir;
   }
 
   if (!outDir.is_absolute()) {
-    outDir = std::filesystem::current_path() / outDir;
+    outDir = fs::current_path() / outDir;
   }
 
   fmt::print("OUT PATH: \"{:<s}\"\n", outDir.string());
@@ -304,8 +306,8 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
     outputInsertions = *cliParams.outputInsertions;
   }
 
-  std::map<std::string, std::filesystem::path> outputGenes;
-  for (const auto& gene : genes) {
+  std::map<std::string, fs::path> outputGenes;
+  for (const auto &gene : genes) {
     auto outputGene = outDir / baseName;
     outputGene += fmt::format(".gene.{:s}.fasta", gene);
     outputGenes.emplace(gene, outputGene);
@@ -499,8 +501,8 @@ int main(int argc, char *argv[]) {
     const auto paths = getPaths(cliParams, options.genes);
     fmt::print(stdout, formatPaths(paths));
 
-    std::filesystem::create_directories(paths.outputFasta.parent_path());
-    std::filesystem::create_directories(paths.outputInsertions.parent_path());
+    fs::create_directories(paths.outputFasta.parent_path());
+    fs::create_directories(paths.outputInsertions.parent_path());
 
 
     std::ofstream outputFastaFile(paths.outputFasta);

--- a/packages/nextalign_cli/src/filesystem.h
+++ b/packages/nextalign_cli/src/filesystem.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || (defined(__cplusplus) && __cplusplus >= 201703L)) && \
+  defined(__has_include)
+#if __has_include(<filesystem>) && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500)
+#define GHC_USE_STD_FS
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+#endif
+#ifndef GHC_USE_STD_FS
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#endif


### PR DESCRIPTION
This switches nextalign CLI to use https://github.com/gulrak/filesystem as a drop-in replacement for `std::filesystem`.

Despite having C++17 enabled, there is a complication with Applce clang and macOS target version: we want to target older macOS versions (down to 10.12) which don't ship some of the features we need.

We solve the problem by using the replacement library.

There are also some minor formatting issues fixed.

