### PR TITLE
chore: fix list of genes being empty in benchmarks [skip ci]

### DIFF
--- a/packages/nextalign/benchmarks/src/AlignPairwise.benchmark.h
+++ b/packages/nextalign/benchmarks/src/AlignPairwise.benchmark.h
@@ -16,7 +16,7 @@
 
 class AlignPairwiseAverageBench : public benchmark::Fixture {
 protected:
-  const NextalignOptions options = {
+  NextalignOptions options = {
     .gapOpenInFrame = -5,
     .gapOpenOutOfFrame = -6,
     .genes = {},
@@ -29,11 +29,12 @@ protected:
   GeneMap geneMap;
 
   AlignPairwiseAverageBench() {
-    const auto [sequences, reference, geneMap, nNucs] = getData();
-    gapOpenClose = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
+    const auto [sequences, reference, GENE_MAP, TOTAL_NUCS, GENES] = getData();
     ref = toNucleotideSequence(reference);
-    totalNucs = nNucs;
-    this->geneMap = geneMap;
+    totalNucs = TOTAL_NUCS;
+    geneMap = GENE_MAP;
+    options.genes = GENES;
+    gapOpenClose = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
 
     const auto n = NUM_SEQUENCES_AVG;
     nucSequences.resize(n);

--- a/packages/nextalign/benchmarks/src/Nextalign.benchmark.h
+++ b/packages/nextalign/benchmarks/src/Nextalign.benchmark.h
@@ -17,12 +17,14 @@ protected:
   std::vector<NucleotideSequence> nucSequences;
   int totalNucs;
   GeneMap geneMap;
+  std::set<std::string> genes;
 
   NextalignAverageBench() {
-    const auto [sequences, reference, geneMap, nNucs] = getData();
+    const auto [sequences, reference, GENE_MAP, TOTAL_NUCS, GENES] = getData();
     ref = toNucleotideSequence(reference);
-    totalNucs = nNucs;
-    this->geneMap = geneMap;
+    totalNucs = TOTAL_NUCS;
+    geneMap = GENE_MAP;
+    genes = GENES;
 
     const auto n = NUM_SEQUENCES_AVG;
     nucSequences.resize(n);

--- a/packages/nextalign/benchmarks/src/utils/getData.h
+++ b/packages/nextalign/benchmarks/src/utils/getData.h
@@ -18,7 +18,7 @@ auto getData() {
   std::copy(sequencesMap.cbegin(), sequencesMap.cend(), back_inserter(sequences));
 
   assert(sequences.size() >= NUM_SEQUENCES_VAR);
-  const auto totalNucs = std::accumulate(
+  const auto TOTAL_NUCS = std::accumulate(
     sequences.cbegin(), sequences.cbegin() + NUM_SEQUENCES_VAR, 0, [](int total, const AlgorithmInput& input) {
       total += input.seq.size();
       return total;
@@ -29,7 +29,12 @@ auto getData() {
   const auto ref = refSeqs.begin()->seq;
 
   std::ifstream genemapFile("data/example/genemap.gff");
-  const auto geneMap = parseGeneMapGff(genemapFile);
+  const auto GENE_MAP = parseGeneMapGff(genemapFile);
 
-  return std::make_tuple(sequences, ref, geneMap, totalNucs);
+  std::set<std::string> GENES;
+  for (const auto& [geneName, _] : GENE_MAP) {
+    GENES.insert(geneName);
+  }
+
+  return std::make_tuple(sequences, ref, GENE_MAP, TOTAL_NUCS, GENES);
 }


### PR DESCRIPTION
Followup of #335
Fixes gene list being empty in benchmarks

