### PR TITLE
Suggested edits to enable linking to CoVariants pages, others in the future

### DIFF
--- a/nextclade-dev.yml
+++ b/nextclade-dev.yml
@@ -1,0 +1,38 @@
+name: nextclade
+channels:
+  - conda-forge
+  - r
+  - bioconda
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=1_gnu
+  - c-ares=1.17.1=h36c2ea0_0
+  - ca-certificates=2020.12.5=ha878542_0
+  - curl=7.71.1=he644dc0_8
+  - expat=2.2.10=h9c3ff4c_0
+  - gettext=0.19.8.1=h0b5b191_1005
+  - git=2.30.0=pl5320h014a29a_0
+  - icu=68.1=h58526e2_0
+  - jq=1.6=h36c2ea0_1000
+  - krb5=1.17.2=h926e7f8_0
+  - libcurl=7.71.1=hcdd3856_8
+  - libedit=3.1.20191231=he28a2e2_2
+  - libev=4.33=h516909a_1
+  - libffi=3.3=h58526e2_2
+  - libgcc-ng=9.3.0=h2828fa1_18
+  - libgomp=9.3.0=h2828fa1_18
+  - libiconv=1.16=h516909a_0
+  - libnghttp2=1.43.0=h812cca2_0
+  - libssh2=1.9.0=hab1572f_5
+  - libstdcxx-ng=9.3.0=h6de172a_18
+  - libuv=1.40.0=h7f98852_0
+  - ncurses=6.2=h58526e2_4
+  - nodejs=15.3.0=h92b4a50_1
+  - oniguruma=6.9.3=h36c2ea0_0
+  - openssl=1.1.1j=h7f98852_0
+  - pcre=8.44=he1b5a44_0
+  - perl=5.32.0=h36c2ea0_0
+  - tk=8.6.10=h21135ba_1
+  - yarn=1.22.10=0
+  - zlib=1.2.11=h516909a_1010

--- a/packages/web/src/algorithms/defaults/sars-cov-2/constellations.json
+++ b/packages/web/src/algorithms/defaults/sars-cov-2/constellations.json
@@ -1,19 +1,135 @@
 [
   {
-    "description": "transmissibility",
-    "url": "http://github.com/nodrogluap/pokay/pages/S:D614G",
+    "description": "20A.EU1 (S:A222V)",
+    "url": "https://covariants.org/variants/20A.EU1",
     "substitutions": 
       [
-        { "refAA": "D", "queryAA": "G", "codon": 614, "gene": "S", "nucRange": {"Range": { "begin": 23403, "end": 23403 }}, "refCodon": "GAU", "queryCodon": "GGU" }
+        { "refAA": "A", "queryAA": "V", "codon": 222, "gene": "S" },
+        { "refAA": "V", "queryAA": "L", "codon": 30, "gene": "ORF10" },
+        { "refAA": "A", "queryAA": "V", "codon": 220, "gene": "N" }
       ],
     "deletions": []
   },
   {
-    "description": "immune_evasion",
-    "url": "http://github.com/nodrogluap/pokay/pages/S:S477N",
+    "description": "20A.EU2 (S:477N)",
+    "url": "https://covariants.org/variants/20A.EU2",
     "substitutions":
       [
-        { "refAA": "S", "queryAA": "N", "codon": 477, "gene": "S", "nucRange": {"Range": { "begin": 22992, "end": 22992 }}, "refCodon": "AGC", "queryCodon": "AAC" } 
+        { "refAA": "S", "queryAA": "N", "codon": 477, "gene": "S" },
+        { "refAA": "M", "queryAA": "I", "codon": 234, "gene": "N" },
+        { "refAA": "A", "queryAA": "T", "codon": 376, "gene": "N" },
+        { "refAA": "A", "queryAA": "S", "codon": 176, "gene": "ORF1b" },
+        { "refAA": "V", "queryAA": "L", "codon": 767, "gene": "ORF1b" },
+        { "refAA": "K", "queryAA": "R", "codon": 1141, "gene": "ORF1b" },
+        { "refAA": "E", "queryAA": "D", "codon": 1184, "gene": "ORF1b" }
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:N501",
+    "url": "https://covariants.org/variants/S.N501",
+    "substitutions":
+      [
+        { "refAA": "N", "queryAA": "Y", "codon": 501, "gene": "S" } 
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:E484",
+    "url": "https://covariants.org/variants/S.E484",
+    "substitutions":
+      [
+        { "refAA": "E", "queryAA": "K", "codon": 484, "gene": "S" } 
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:H69-",
+    "url": "https://covariants.org/variants/S.H69-",
+    "substitutions": [], 
+    "deletions": 
+      [
+        { "refAA": "H", "codon": 69, "gene": "S"}
+      ]
+  },
+  {
+    "description": "S:N439K",
+    "url": "http://covariants.org/variants/S:N439K",
+    "substitutions":
+      [
+        { "refAA": "N", "queryAA": "K", "codon": 439, "gene": "S" },
+        { "refAA": "I", "queryAA": "T", "codon": 2501, "gene": "ORF1a" } 
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:Y453F",
+    "url": "http://covariants.org/variants/S:Y453F",
+    "substitutions":
+      [
+        { "refAA": "Y", "queryAA": "F", "codon": 453, "gene": "S" } 
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:S98F",
+    "url": "http://covariants.org/variants/S:S98F",
+    "substitutions":
+      [
+        { "refAA": "S", "queryAA": "F", "codon": 98, "gene": "S" },
+        { "refAA": "P", "queryAA": "L", "codon": 199, "gene": "N" },
+        { "refAA": "Q", "queryAA": "R", "codon": 38, "gene": "ORF3a" },
+        { "refAA": "G", "queryAA": "R", "codon": 172, "gene": "ORF3a" },
+        { "refAA": "V", "queryAA": "L", "codon": 202, "gene": "ORF3a" }
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:L452R",
+    "url": "http://covariants.org/variants/S:L452R",
+    "substitutions":
+      [
+        { "refAA": "S", "queryAA": "I", "codon": 13, "gene": "S" },
+        { "refAA": "W", "queryAA": "C", "codon": 152, "gene": "S" },
+        { "refAA": "L", "queryAA": "R", "codon": 452, "gene": "S" },
+        { "refAA": "I", "queryAA": "V", "codon": 4205, "gene": "ORF1a" },
+        { "refAA": "D", "queryAA": "Y", "codon": 1183, "gene": "ORF1b" }
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:D80Y",
+    "url": "http://covariants.org/variants/S:D80Y",
+    "substitutions":
+      [
+        { "refAA": "D", "queryAA": "Y", "codon": 80, "gene": "S" },
+        { "refAA": "S", "queryAA": "Y", "codon": 186, "gene": "N" },
+        { "refAA": "D", "queryAA": "Y", "codon": 377, "gene": "N" },
+        { "refAA": "T", "queryAA": "I", "codon": 945, "gene": "ORF1a" },
+        { "refAA": "T", "queryAA": "I", "codon": 1567, "gene": "ORF1a" },
+        { "refAA": "Q", "queryAA": "K", "codon": 3346, "gene": "ORF1a" },
+        { "refAA": "V", "queryAA": "F", "codon": 3475, "gene": "ORF1a" },
+        { "refAA": "M", "queryAA": "I", "codon": 3862, "gene": "ORF1a" },
+        { "refAA": "P", "queryAA": "T", "codon": 255, "gene": "ORF1b" },
+        { "refAA": "R", "queryAA": "I", "codon": 80, "gene": "ORF7a" }
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:A626S",
+    "url": "http://covariants.org/variants/S:A626S",
+    "substitutions":
+      [
+        { "refAA": "A", "queryAA": "S", "codon": 626, "gene": "S" } 
+      ],
+    "deletions": []
+  },
+  {
+    "description": "S:V1122L",
+    "url": "http://covariants.org/variants/S:V1122L",
+    "substitutions":
+      [
+        { "refAA": "V", "queryAA": "L", "codon": 1122, "gene": "S" } 
       ],
     "deletions": []
   }

--- a/packages/web/src/algorithms/defaults/sars-cov-2/constellations.json
+++ b/packages/web/src/algorithms/defaults/sars-cov-2/constellations.json
@@ -1,0 +1,20 @@
+[
+  {
+    "description": "transmissibility",
+    "url": "http://github.com/nodrogluap/pokay/pages/S:D614G",
+    "substitutions": 
+      [
+        { "refAA": "D", "queryAA": "G", "codon": 614, "gene": "S", "nucRange": {"Range": { "begin": 23403, "end": 23403 }}, "refCodon": "GAU", "queryCodon": "GGU" }
+      ],
+    "deletions": []
+  },
+  {
+    "description": "immune_evasion",
+    "url": "http://github.com/nodrogluap/pokay/pages/S:S477N",
+    "substitutions":
+      [
+        { "refAA": "S", "queryAA": "N", "codon": 477, "gene": "S", "nucRange": {"Range": { "begin": 22992, "end": 22992 }}, "refCodon": "AGC", "queryCodon": "AAC" } 
+      ],
+    "deletions": []
+  }
+]

--- a/packages/web/src/algorithms/defaults/sars-cov-2/index.ts
+++ b/packages/web/src/algorithms/defaults/sars-cov-2/index.ts
@@ -5,10 +5,12 @@ import { rootSeq } from 'src/algorithms/defaults/sars-cov-2/rootSeq'
 import auspiceDataRaw from 'src/algorithms/defaults/sars-cov-2/ncov_small.json'
 import sequenceData from 'src/algorithms/defaults/sars-cov-2/sequenceData.fasta'
 import pcrPrimers from 'src/algorithms/defaults/sars-cov-2/pcrPrimers.json'
+import constellationDefinitions from 'src/algorithms/defaults/sars-cov-2/constellations.json'
 
 import { treeValidate } from 'src/algorithms/tree/treeValidate'
 import { validatePcrPrimers } from 'src/algorithms/primers/validatePcrPrimers'
 import { convertGeneMap, getGeneMapJsonFromTree } from 'src/io/convertGeneMap'
+import { convertConstellationDefinitionObjects } from 'src/io/convertConstellationDefinitions'
 
 const auspiceData = treeValidate(auspiceDataRaw)
 const geneMap = convertGeneMap(getGeneMapJsonFromTree(auspiceData))
@@ -18,6 +20,7 @@ const virus: VirusRaw = {
   rootSeq,
   geneMap,
   pcrPrimers: validatePcrPrimers(pcrPrimers),
+  constellations: convertConstellationDefinitionObjects(constellationDefinitions),
   auspiceData,
   qcRulesConfig,
   minimalLength: 100,

--- a/packages/web/src/algorithms/getConstellations.ts
+++ b/packages/web/src/algorithms/getConstellations.ts
@@ -25,18 +25,7 @@ export function satistfiesMutationCriteria(
 export function satistfiesDeletionCriteria(constellationDefinition: Constellation, aaDeletions: AminoacidDeletion[]) {
   let isMissingDel = false
   for (const requiredDeletion of constellationDefinition.deletions) {
-    let requiredDelFound = false
-    for (const existingDel of aaDeletions) {
-      if (
-        /* TODO: check that the deleted bases are the same (i.e. the rootSeq is the same as the constellation definition's? */
-        requiredDeletion.gene === existingDel.gene &&
-        requiredDeletion.codon === existingDel.codon
-      ) {
-        requiredDelFound = true
-        break
-      }
-    }
-    if (!requiredDelFound) {
+    if (isEmpty(filter(aaDeletions, { gene: requiredDeletion.gene, codon: requiredDeletion.codon }))) {
       isMissingDel = true
       break
     }

--- a/packages/web/src/algorithms/getConstellations.ts
+++ b/packages/web/src/algorithms/getConstellations.ts
@@ -1,0 +1,75 @@
+import type { Constellation, AminoacidSubstitution, AminoacidDeletion } from 'src/algorithms/types'
+import { notUndefined } from 'src/helpers/notUndefined'
+/* import { isMatch } from 'lodash' */
+
+export function satistfiesMutationCriteria(
+  constellationDefinition: Constellation,
+  aaSubstitutions: AminoacidSubstitution[],
+) {
+  let isMissingSub = false
+  for (const requiredSubstitution of constellationDefinition.substitutions) {
+    let requiredSubFound = false
+    for (const existingSub of aaSubstitutions) {
+      if (
+        requiredSubstitution.gene === existingSub.gene &&
+        requiredSubstitution.codon === existingSub.codon &&
+        requiredSubstitution.queryAA === existingSub.queryAA
+      ) {
+        requiredSubFound = true
+        break
+      }
+    }
+    if (!requiredSubFound) {
+      isMissingSub = true
+      break
+    }
+  }
+
+  return !isMissingSub
+}
+
+/* TODO: implement deletions */
+export function satistfiesDeletionCriteria(constellationDefinition: Constellation, aaDeletions: AminoacidDeletion[]) {
+  let isMissingDel = false
+  for (const requiredDeletion of constellationDefinition.deletions) {
+    let requiredDelFound = false
+    for (const existingDel of aaDeletions) {
+      if (
+        /* TODO: check that the deleted bases are the same (i.e. the rootSeq is the same as the constellation definition's? */
+        requiredDeletion.nucRange.begin === existingDel.nucRange.end &&
+        requiredDeletion.nucRange.end === existingDel.nucRange.end
+      ) {
+        requiredDelFound = true
+        break
+      }
+    }
+    if (!requiredDelFound) {
+      isMissingDel = true
+      break
+    }
+  }
+
+  return !isMissingDel
+}
+
+/**
+ * Reduces a list of 'variant constellations' to those for which the provided mutations & deletions fulfill the criteria.
+ * A constellation is one or more variants that have information associated with them, e.g. co-evolution under selective pressure.
+ */
+export function getConstellations(
+  aaSubstitutions: AminoacidSubstitution[],
+  aaDeletions: AminoacidDeletion[],
+  constellations: Constellation[],
+): Constellation[] {
+  return constellations
+    .map((constellationDefinition) => {
+      if (
+        !satistfiesMutationCriteria(constellationDefinition, aaSubstitutions) ||
+        !satistfiesDeletionCriteria(constellationDefinition, aaDeletions)
+      ) {
+        return undefined
+      }
+      return constellationDefinition
+    })
+    .filter(notUndefined)
+}

--- a/packages/web/src/algorithms/getConstellations.ts
+++ b/packages/web/src/algorithms/getConstellations.ts
@@ -1,25 +1,18 @@
 import type { Constellation, AminoacidSubstitution, AminoacidDeletion } from 'src/algorithms/types'
 import { notUndefined } from 'src/helpers/notUndefined'
-/* import { isMatch } from 'lodash' */
+import { filter, isEmpty } from 'lodash'
 
 export function satistfiesMutationCriteria(
   constellationDefinition: Constellation,
   aaSubstitutions: AminoacidSubstitution[],
 ) {
   let isMissingSub = false
-  for (const requiredSubstitution of constellationDefinition.substitutions) {
-    let requiredSubFound = false
-    for (const existingSub of aaSubstitutions) {
-      if (
-        requiredSubstitution.gene === existingSub.gene &&
-        requiredSubstitution.codon === existingSub.codon &&
-        requiredSubstitution.queryAA === existingSub.queryAA
-      ) {
-        requiredSubFound = true
-        break
-      }
-    }
-    if (!requiredSubFound) {
+  for (const requiredSub of constellationDefinition.substitutions) {
+    if (
+      isEmpty(
+        filter(aaSubstitutions, { gene: requiredSub.gene, codon: requiredSub.codon, queryAA: requiredSub.queryAA }),
+      )
+    ) {
       isMissingSub = true
       break
     }
@@ -36,8 +29,8 @@ export function satistfiesDeletionCriteria(constellationDefinition: Constellatio
     for (const existingDel of aaDeletions) {
       if (
         /* TODO: check that the deleted bases are the same (i.e. the rootSeq is the same as the constellation definition's? */
-        requiredDeletion.nucRange.begin === existingDel.nucRange.end &&
-        requiredDeletion.nucRange.end === existingDel.nucRange.end
+        requiredDeletion.gene === existingDel.gene &&
+        requiredDeletion.codon === existingDel.codon
       ) {
         requiredDelFound = true
         break

--- a/packages/web/src/algorithms/getPcrPrimerChanges.ts
+++ b/packages/web/src/algorithms/getPcrPrimerChanges.ts
@@ -2,11 +2,13 @@ import { inRange } from 'lodash'
 
 import type {
   PcrPrimer,
+  Constellation,
   NucleotideSubstitution,
   PcrPrimerChange,
   SubstitutionsWithPrimers,
   NucleotideSubstitutionWithAminoacids,
 } from 'src/algorithms/types'
+import { getConstellations } from 'src/algorithms/getConstellations'
 import { notUndefined } from 'src/helpers/notUndefined'
 import { isMatch } from './nucleotideCodes'
 
@@ -54,9 +56,11 @@ export function getPcrPrimerChanges(
 export function getSubstitutionsWithPcrPrimerChanges(
   substitutions: NucleotideSubstitutionWithAminoacids[],
   primers: PcrPrimer[],
+  constellationDefinitions: Constellation[],
 ): SubstitutionsWithPrimers[] {
   return substitutions.map((mut) => {
     const pcrPrimersChanged = primers.filter((primer) => shouldReportPrimerMutation(mut, primer))
-    return { ...mut, pcrPrimersChanged }
+    const constellations = getConstellations(mut.aaSubstitutions, [], constellationDefinitions)
+    return { ...mut, pcrPrimersChanged, constellations }
   })
 }

--- a/packages/web/src/algorithms/run.ts
+++ b/packages/web/src/algorithms/run.ts
@@ -12,6 +12,7 @@ import { getAminoAcidChanges } from './getAminoAcidChanges'
 import { GOOD_NUCLEOTIDES, N } from './nucleotides'
 import { getNucleotideComposition } from './getNucleotideComposition'
 import { getPcrPrimerChanges, getSubstitutionsWithPcrPrimerChanges } from './getPcrPrimerChanges'
+import { getConstellations } from './getConstellations'
 
 export async function parse(input: string | File): Promise<ParseResult> {
   let newInput: string
@@ -29,6 +30,7 @@ export function analyze({
   rootSeq,
   minimalLength,
   pcrPrimers,
+  constellations,
   geneMap,
   auspiceData,
   qcRulesConfig,
@@ -64,9 +66,11 @@ export function analyze({
 
   const nucleotideComposition = getNucleotideComposition(alignedQuery)
 
-  const substitutions = getSubstitutionsWithPcrPrimerChanges(substitutionsWithAA, pcrPrimers)
+  const substitutions = getSubstitutionsWithPcrPrimerChanges(substitutionsWithAA, pcrPrimers, constellations)
   const pcrPrimerChanges = getPcrPrimerChanges(nucSubstitutions, pcrPrimers)
   const totalPcrPrimerChanges = pcrPrimerChanges.reduce((total, { substitutions }) => total + substitutions.length, 0)
+
+  const constellationsMatched = getConstellations(aaSubstitutions, aaDeletions, constellations)
 
   const deletions = deletionsWithAA
 
@@ -93,6 +97,7 @@ export function analyze({
     nucleotideComposition,
     pcrPrimerChanges,
     totalPcrPrimerChanges,
+    constellations: constellationsMatched,
   }
 
   const { match, privateMutations } = treeFindNearestNodes({ analysisResult, rootSeq, auspiceData })

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -102,8 +102,8 @@ export interface SubstitutionsWithPrimers extends NucleotideSubstitutionWithAmin
 }
 
 export interface Constellation {
-  description: string 
-  url: string 
+  description: string
+  url: string
   substitutions: AminoacidSubstitution[]
   deletions: AminoacidDeletion[]
 }

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -98,6 +98,14 @@ export interface PcrPrimerChange {
 
 export interface SubstitutionsWithPrimers extends NucleotideSubstitutionWithAminoacids {
   pcrPrimersChanged: PcrPrimer[]
+  constellations: Constellation[]
+}
+
+export interface Constellation {
+  description: string 
+  url: string 
+  substitutions: AminoacidSubstitution[]
+  deletions: AminoacidDeletion[]
 }
 
 export interface Virus {
@@ -108,6 +116,7 @@ export interface Virus {
   rootSeq: string
   auspiceData: AuspiceJsonV2
   pcrPrimers: PcrPrimer[]
+  constellations: Constellation[]
   qcRulesConfig: QCRulesConfig
 }
 
@@ -142,6 +151,7 @@ export interface AnalysisResultWithoutClade {
   nucleotideComposition: Record<string, number>
   pcrPrimerChanges: PcrPrimerChange[]
   totalPcrPrimerChanges: number
+  constellations: Constellation[]
 }
 
 export interface AnalysisResultWithClade extends AnalysisResultWithoutClade {
@@ -169,6 +179,7 @@ export interface AnalysisParams {
   rootSeq: string
   auspiceData: AuspiceJsonV2Extended
   pcrPrimers: PcrPrimer[]
+  constellations: Constellation[]
   qcRulesConfig: QCRulesConfig
 }
 

--- a/packages/web/src/cli/run.ts
+++ b/packages/web/src/cli/run.ts
@@ -13,7 +13,15 @@ import { treePreprocess } from 'src/algorithms/tree/treePreprocess'
 import { treePostProcess } from 'src/algorithms/tree/treePostprocess'
 
 export async function run(workers: WorkerPools, input: string, virus: Virus, shouldMakeTree: boolean) {
-  const { rootSeq, minimalLength, pcrPrimers, geneMap, auspiceData: auspiceDataReference, qcRulesConfig } = virus
+  const {
+    rootSeq,
+    minimalLength,
+    pcrPrimers,
+    constellations,
+    geneMap,
+    auspiceData: auspiceDataReference,
+    qcRulesConfig,
+  } = virus
   const auspiceData = treePreprocess(auspiceDataReference, rootSeq)
 
   const { threadParse, poolAnalyze, threadTreeFinalize } = workers
@@ -28,6 +36,7 @@ export async function run(workers: WorkerPools, input: string, virus: Virus, sho
           rootSeq,
           minimalLength,
           pcrPrimers,
+          constellations,
           geneMap,
           auspiceData,
           qcRulesConfig,

--- a/packages/web/src/components/Main/FilePickerAdvanced.tsx
+++ b/packages/web/src/components/Main/FilePickerAdvanced.tsx
@@ -10,6 +10,7 @@ import {
   removeFasta,
   removeGeneMap,
   removePcrPrimers,
+  removeConstellationDefinitions,
   removeQcSettings,
   removeRootSeq,
   removeTree,
@@ -17,6 +18,7 @@ import {
   setGeneMap,
   setIsDirty,
   setPcrPrimers,
+  setConstellationDefinitions,
   setQcSettings,
   setRootSeq,
   setTree,
@@ -46,6 +48,8 @@ export interface FilePickerAdvancedProps {
 
   setPcrPrimers(input: AlgorithmInput): void
 
+  setConstellationDefinitions(input: AlgorithmInput): void
+
   removeFasta(_0: unknown): void
 
   removeTree(_0: unknown): void
@@ -57,6 +61,8 @@ export interface FilePickerAdvancedProps {
   removeGeneMap(_0: unknown): void
 
   removePcrPrimers(_0: unknown): void
+
+  removeConstellationDefinitions(_0: unknown): void
 
   algorithmRunTrigger(_0: unknown): void
 
@@ -78,12 +84,14 @@ const mapDispatchToProps = {
   setQcSettings: setQcSettings.trigger,
   setGeneMap: setGeneMap.trigger,
   setPcrPrimers: setPcrPrimers.trigger,
+  setConstellationDefinitions: setConstellationDefinitions.trigger,
   removeFasta,
   removeTree,
   removeRootSeq,
   removeQcSettings,
   removeGeneMap,
   removePcrPrimers,
+  removeConstellationDefinitions,
   algorithmRunTrigger: algorithmRunAsync.trigger,
   setShowNewRunPopup,
 }
@@ -101,12 +109,14 @@ export function FilePickerAdvancedDisconnected({
   setQcSettings,
   setGeneMap,
   setPcrPrimers,
+  setConstellationDefinitions,
   removeFasta,
   removeTree,
   removeRootSeq,
   removeQcSettings,
   removeGeneMap,
   removePcrPrimers,
+  removeConstellationDefinitions,
   algorithmRunTrigger,
   setShowNewRunPopup,
 }: FilePickerAdvancedProps) {
@@ -181,6 +191,17 @@ export function FilePickerAdvancedDisconnected({
           errors={params.errors.pcrPrimers}
           onRemove={removePcrPrimers}
           onInput={setPcrPrimers}
+        />
+
+        <FilePicker
+          icon={<FileIconJson />}
+          text={t('Variant Constellations')}
+          exampleUrl="https://example.com/variant_constellations.csv"
+          pasteInstructions={t('Enter variant constellation data (e.g. sub-lineage defining SNPs) in CSV format')}
+          input={params.raw.constellations}
+          errors={params.errors.constellations}
+          onRemove={removeConstellationDefinitions}
+          onInput={setConstellationDefinitions}
         />
       </Col>
     </Row>

--- a/packages/web/src/components/Results/ColumnMutations.tsx
+++ b/packages/web/src/components/Results/ColumnMutations.tsx
@@ -7,11 +7,20 @@ import { Tooltip } from 'src/components/Results/Tooltip'
 import { ListOfAminoacidSubstitutions } from 'src/components/SequenceView/ListOfAminoacidSubstitutions'
 import { ListOfAminoacidDeletions } from 'src/components/SequenceView/ListOfAminoacidDeletions'
 import { ListOfPcrPrimerChanges } from 'src/components/SequenceView/ListOfPcrPrimerChanges'
+import { ListOfConstellations } from 'src/components/SequenceView/ListOfConstellations'
 
 export function ColumnMutations({ sequence }: ColumnCladeProps) {
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const { seqName, substitutions, aaDeletions, aaSubstitutions, pcrPrimerChanges, totalPcrPrimerChanges } = sequence
+  const {
+    seqName,
+    substitutions,
+    aaDeletions,
+    aaSubstitutions,
+    pcrPrimerChanges,
+    totalPcrPrimerChanges,
+    constellations,
+  } = sequence
   const id = getSafeId('mutations-label', { seqName })
   const totalMutations = substitutions.length
 
@@ -23,6 +32,7 @@ export function ColumnMutations({ sequence }: ColumnCladeProps) {
         <ListOfAminoacidSubstitutions aminoacidSubstitutions={aaSubstitutions} />
         <ListOfAminoacidDeletions aminoacidDeletions={aaDeletions} />
         <ListOfPcrPrimerChanges pcrPrimerChanges={pcrPrimerChanges} totalPcrPrimerChanges={totalPcrPrimerChanges} />
+        <ListOfConstellations constellations={constellations} />
       </Tooltip>
     </div>
   )

--- a/packages/web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages/web/src/components/Results/ColumnNameTooltip.tsx
@@ -11,6 +11,7 @@ import { ListOfNonACGTNs } from 'src/components/Results/ListOfNonACGTNs'
 import { ListOfAminoacidSubstitutions } from 'src/components/SequenceView/ListOfAminoacidSubstitutions'
 import { ListOfAminoacidDeletions } from 'src/components/SequenceView/ListOfAminoacidDeletions'
 import { ListOfPcrPrimerChanges } from 'src/components/SequenceView/ListOfPcrPrimerChanges'
+import { ListOfConstellations } from 'src/components/SequenceView/ListOfConstellations'
 import { ListOfInsertions } from './ListOfInsertions'
 
 export interface ColumnNameTooltipProps {
@@ -35,6 +36,7 @@ export function ColumnNameTooltip({ sequence }: ColumnNameTooltipProps) {
     alignmentScore,
     pcrPrimerChanges,
     totalPcrPrimerChanges,
+    constellations,
   } = sequence
   const { t } = useTranslation()
 
@@ -70,6 +72,7 @@ export function ColumnNameTooltip({ sequence }: ColumnNameTooltipProps) {
           <ListOfAminoacidSubstitutions aminoacidSubstitutions={aaSubstitutions} />
           <ListOfAminoacidDeletions aminoacidDeletions={aaDeletions} />
           <ListOfPcrPrimerChanges pcrPrimerChanges={pcrPrimerChanges} totalPcrPrimerChanges={totalPcrPrimerChanges} />
+          <ListOfConstellations constellations={constellations} />
         </Col>
       </Row>
 

--- a/packages/web/src/components/SequenceView/ListOfConstellations.tsx
+++ b/packages/web/src/components/SequenceView/ListOfConstellations.tsx
@@ -21,7 +21,10 @@ export function ListOfConstellations({ constellations }: ListOfConstellationProp
   const items = constellations.map(({ description, url, substitutions, deletions }) => {
     return (
       <Li key={description}>
-        <a href={url}>{description}</a>:
+        <a target="_blank" rel="noreferrer noopener" href={url}>
+          {description}
+        </a>
+        :
         {substitutions.map((mut) => {
           const notation = formatAAMutation(mut)
           return `${notation} `

--- a/packages/web/src/components/SequenceView/ListOfConstellations.tsx
+++ b/packages/web/src/components/SequenceView/ListOfConstellations.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import type { DeepReadonly } from 'ts-essentials'
+import { useTranslation } from 'react-i18next'
+
+import type { Constellation } from 'src/algorithms/types'
+import { Li, Ul } from 'src/components/Common/List'
+import { formatAAMutation, formatAADeletion } from 'src/helpers/formatMutation'
+
+export interface ListOfConstellationProps {
+  readonly constellations: DeepReadonly<Constellation[]>
+}
+
+export function ListOfConstellations({ constellations }: ListOfConstellationProps) {
+  const { t } = useTranslation()
+
+  if (constellations === undefined || constellations.length === 0) {
+    return <div />
+  }
+
+  const items = constellations.map(({ description, url, substitutions, deletions }) => {
+    return (
+      <Li key={description}>
+        <a href={url}>{description}</a>:
+        {substitutions.map((mut) => {
+          const notation = formatAAMutation(mut)
+          return `${notation} `
+        })}
+        {deletions.map((del) => {
+          const notation = formatAADeletion(del)
+          return `${notation} `
+        })}
+      </Li>
+    )
+  })
+
+  return (
+    <div>
+      {t(`Documented variant constellation effect(s):`)}
+      <Ul>{items}</Ul>
+    </div>
+  )
+}

--- a/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
@@ -13,6 +13,7 @@ import { Tooltip } from 'src/components/Results/Tooltip'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { ListOfAminoacidSubstitutions } from 'src/components/SequenceView/ListOfAminoacidSubstitutions'
 import { ListOfPcrPrimersChanged } from 'src/components/SequenceView/ListOfPcrPrimersChanged'
+import { ListOfConstellations } from 'src/components/SequenceView/ListOfConstellations'
 
 export interface SequenceMarkerMutationProps extends SVGProps<SVGRectElement> {
   seqName: string
@@ -30,7 +31,7 @@ function SequenceMarkerMutationUnmemoed({
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const { pos, queryNuc, refNuc, aaSubstitutions, pcrPrimersChanged } = substitution
+  const { pos, queryNuc, refNuc, aaSubstitutions, pcrPrimersChanged, constellations } = substitution
   const id = getSafeId('mutation-marker', { seqName, ...substitution })
 
   const mut = formatMutation({ pos, queryNuc, refNuc })
@@ -55,6 +56,7 @@ function SequenceMarkerMutationUnmemoed({
         <div>{t('Nucleotide mutation: {{mutation}}', { mutation: mut })}</div>
         <ListOfAminoacidSubstitutions aminoacidSubstitutions={aaSubstitutions} />
         <ListOfPcrPrimersChanged pcrPrimersChanged={pcrPrimersChanged} />
+        <ListOfConstellations constellations={constellations} />
       </Tooltip>
     </rect>
   )

--- a/packages/web/src/helpers/formatConstellation.ts
+++ b/packages/web/src/helpers/formatConstellation.ts
@@ -1,0 +1,9 @@
+import type { Constellation } from 'src/algorithms/types'
+import { formatAAMutation, formatAADeletion } from 'src/helpers/formatMutation'
+
+export function formatConstellation(constellation: Constellation) {
+  const { description, url } = constellation
+  const muts = constellation.substitutions.map(formatAAMutation).join(';')
+  const dels = constellation.deletions.map(formatAADeletion).join(';')
+  return `${url} ${description} ${muts};${dels}`
+}

--- a/packages/web/src/io/convertConstellationDefinitions.ts
+++ b/packages/web/src/io/convertConstellationDefinitions.ts
@@ -1,9 +1,9 @@
 import type { Constellation } from 'src/algorithms/types'
 import { sanitizeError } from 'src/helpers/sanitizeError'
 
-export function convertConstellationDefinitionObjects(constellationsSpec: Object[]): Constellation[] {
+export function convertConstellationDefinitionObjects(constellationsSpecDangerous: unknown): Constellation[] {
   const itemsNotConstellation = []
-  const constellations = constellationsSpec as Constellation[]
+  const constellations = constellationsSpecDangerous as Constellation[]
   constellations.forEach(function f(item) {
     if (
       !Object.prototype.hasOwnProperty.call(item, 'description') ||

--- a/packages/web/src/io/convertConstellationDefinitions.ts
+++ b/packages/web/src/io/convertConstellationDefinitions.ts
@@ -1,0 +1,47 @@
+import type { Constellation } from 'src/algorithms/types'
+import { sanitizeError } from 'src/helpers/sanitizeError'
+
+export function convertConstellationDefinitionObjects(constellationsSpec: Object[]): Constellation[] {
+  const itemsNotConstellation = []
+  const constellations = constellationsSpec as Constellation[]
+  constellations.forEach(function f(item) {
+    if (
+      !Object.prototype.hasOwnProperty.call(item, 'description') ||
+      !Object.prototype.hasOwnProperty.call(item, 'url') ||
+      !Object.prototype.hasOwnProperty.call(item, 'substitutions') ||
+      !Object.prototype.hasOwnProperty.call(item, 'deletions')
+    ) {
+      itemsNotConstellation.push(item)
+    }
+    /* TODO: deep check of substitution fields */
+    /* Massage the input data codon position down one, because internally NextClade uses zero-based codoin numbering :-P */
+    item.substitutions.forEach(function s(aaSub) {
+      aaSub.codon -= 1
+    })
+  })
+  if (itemsNotConstellation.length > 0) {
+    const len = itemsNotConstellation.length
+    throw new Error(`Variant constellation data array contains non-constellation object(s): ${len}`)
+  }
+  return constellations
+}
+
+export function convertConstellationDefinitions(content: string): Constellation[] {
+  if (!content) {
+    return []
+  }
+  let constellations
+  try {
+    constellations = JSON.parse(content) as Constellation[]
+  } catch (error_: unknown) {
+    const error = sanitizeError(error_)
+    throw new Error(`Variant constellation data format not recognized. JSON parsing error: ${error.message}`)
+  }
+  if (constellations.length === 0) {
+    throw new Error(
+      `Variant constellation data is a JSON formatted array, but is empty. The expected way to provide no variant constellation input is a blank file`,
+    )
+  }
+
+  return convertConstellationDefinitionObjects(constellations)
+}

--- a/packages/web/src/io/serializeResults.ts
+++ b/packages/web/src/io/serializeResults.ts
@@ -9,6 +9,7 @@ import { formatRange } from 'src/helpers/formatRange'
 import { formatInsertion } from 'src/helpers/formatInsertion'
 import { formatNonAcgtn } from 'src/helpers/formatNonAcgtn'
 import { formatPrimer } from 'src/helpers/formatPrimer'
+import { formatConstellation } from 'src/helpers/formatConstellation'
 import { formatSnpCluster } from 'src/helpers/formatSnpCluster'
 
 const CSV_EOL = '\r\n'
@@ -30,6 +31,7 @@ const headers = [
   'missing',
   'nonACGTNs',
   'pcrPrimerChanges',
+  'constyellations',
   'aaSubstitutions',
   'totalAminoacidSubstitutions',
   'aaDeletions',
@@ -100,6 +102,7 @@ export function prepareResultCsv(datum: Exportable) {
     missing: datum.missing.map(({ begin, end }) => formatRange(begin, end)).join(','),
     nonACGTNs: datum.nonACGTNs.map((nacgtn) => formatNonAcgtn(nacgtn)).join(','),
     pcrPrimerChanges: datum.pcrPrimerChanges.map(formatPrimer).join(','),
+    constellations: datum.constellations.map(formatConstellation).join(','),
   }
 }
 

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -3,7 +3,7 @@ import type { AuspiceJsonV2 } from 'auspice'
 import type { Sorting } from 'src/helpers/sortResults'
 import { actionCreatorFactory } from 'src/state/util/fsaActions'
 
-import type { AnalysisParams, AnalysisResult, Gene, PcrPrimer } from 'src/algorithms/types'
+import type { AnalysisParams, AnalysisResult, Gene, PcrPrimer, Constellation } from 'src/algorithms/types'
 import type { AuspiceJsonV2Extended } from 'src/algorithms/tree/types'
 import type { LocateInTreeParams, LocateInTreeResults } from 'src/algorithms/tree/treeFindNearestNodes'
 import type { FinalizeTreeParams } from 'src/algorithms/tree/treeAttachNodes'
@@ -21,6 +21,7 @@ export const setRootSeq = action.async<AlgorithmInput, { rootSeq: string }, Erro
 export const setQcSettings = action.async<AlgorithmInput, { qcRulesConfig: QCRulesConfig }, Error>('setQcSettings') // prettier-ignore
 export const setGeneMap = action.async<AlgorithmInput, { geneMap: Gene[] }, Error>('setGeneMap')
 export const setPcrPrimers = action.async<AlgorithmInput, { pcrPrimers: PcrPrimer[] }, Error>('setPcrPrimers') // prettier-ignore
+export const setConstellationDefinitions = action.async<AlgorithmInput, { constellations: Constellation[] }, Error>('setConstellationDefinitions') // prettier-ignore
 
 export const removeFasta = action('removeFasta')
 export const removeTree = action('removeTree')
@@ -28,6 +29,7 @@ export const removeRootSeq = action('removeRootSeq')
 export const removeQcSettings = action('removeQcSettings')
 export const removeGeneMap = action('removeGeneMap')
 export const removePcrPrimers = action('removePcrPrimers')
+export const removeConstellationDefinitions = action('removeConstellationDefinitions')
 
 export const setAlgorithmGlobalStatus = action<AlgorithmGlobalStatus>('setAlgorithmGlobalStatus')
 export const algorithmRunAsync = action.async<void, void, Error>('algorithmRunAsync')

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -31,8 +31,10 @@ import {
   setQcSettings,
   setRootSeq,
   setPcrPrimers,
+  setConstellationDefinitions,
   removeGeneMap,
   removePcrPrimers,
+  removeConstellationDefinitions,
   removeFasta,
   removeTree,
   removeQcSettings,
@@ -141,6 +143,11 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
     draft.params.errors.pcrPrimers = []
   })
 
+  .icase(setConstellationDefinitions.started, (draft, input) => {
+    draft.params.raw.constellations = input
+    draft.params.errors.constellations = []
+  })
+
   .icase(setFasta.done, (draft, { result: { seqData } }) => {
     draft.params.seqData = seqData
   })
@@ -167,6 +174,10 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
     draft.params.virus.pcrPrimers = pcrPrimers
   })
 
+  .icase(setConstellationDefinitions.done, (draft, { result: { constellations } }) => {
+    draft.params.virus.constellations = constellations
+  })
+
   .icase(setFasta.failed, (draft, { params: input, error }) => {
     draft.params.errors.seqData = [error]
   })
@@ -189,6 +200,10 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
 
   .icase(setPcrPrimers.failed, (draft, { params: input, error }) => {
     draft.params.errors.pcrPrimers = [error]
+  })
+
+  .icase(setConstellationDefinitions.failed, (draft, { params: input, error }) => {
+    draft.params.errors.constellations = [error]
   })
 
   .icase(removeFasta, (draft) => {
@@ -225,6 +240,12 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
     draft.params.raw.pcrPrimers = undefined
     draft.params.errors.pcrPrimers = []
     draft.params.virus.pcrPrimers = getVirus(draft.params.virus.name).pcrPrimers
+  })
+
+  .icase(removeConstellationDefinitions, (draft) => {
+    draft.params.raw.constellations = undefined
+    draft.params.errors.constellations = []
+    draft.params.virus.constellations = getVirus(draft.params.virus.name).constellations
   })
 
   .icase(setIsDirty, (draft, isDirty) => {

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -72,6 +72,7 @@ export interface AlgorithmParams {
     qcRulesConfig?: AlgorithmInput
     geneMap?: AlgorithmInput
     pcrPrimers?: AlgorithmInput
+    constellations?: AlgorithmInput
   }
   errors: {
     seqData: Error[]
@@ -80,6 +81,7 @@ export interface AlgorithmParams {
     qcRulesConfig: Error[]
     geneMap: Error[]
     pcrPrimers: Error[]
+    constellations: Error[]
   }
   seqData?: string
   virus: Virus
@@ -113,6 +115,7 @@ export const algorithmDefaultState: AlgorithmState = {
       qcRulesConfig: [],
       geneMap: [],
       pcrPrimers: [],
+      constellations: [],
     },
     seqData: undefined,
     virus: getVirus(),

--- a/packages/web/src/state/algorithm/algorithmInputs.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmInputs.sagas.ts
@@ -1,5 +1,6 @@
 import { convertPcrPrimers } from 'src/algorithms/primers/convertPcrPrimers'
 import { validatePcrPrimerEntries, validatePcrPrimers } from 'src/algorithms/primers/validatePcrPrimers'
+import { convertConstellationDefinitions } from 'src/io/convertConstellationDefinitions'
 import { parseCsv } from 'src/io/parseCsv'
 import { call, select, takeEvery } from 'typed-redux-saga'
 
@@ -15,6 +16,7 @@ import {
   setFasta,
   setGeneMap,
   setPcrPrimers,
+  setConstellationDefinitions,
   setQcSettings,
   setRootSeq,
   setTree,
@@ -79,6 +81,15 @@ export function* loadPcrPrimers(input: AlgorithmInput) {
   return { pcrPrimers }
 }
 
+export function* loadConstellationDefinitions(input: AlgorithmInput) {
+  // TODO: validate the correct root sequence is loaded corresponding to the aa mutation definitions
+  const content = yield* call([input, input.getContent])
+
+  const constellations = convertConstellationDefinitions(content)
+
+  return { constellations }
+}
+
 export default [
   takeEvery(setFasta.trigger, fsaSaga(setFasta, loadFasta)),
   takeEvery(setTree.trigger, fsaSaga(setTree, loadTree)),
@@ -86,4 +97,5 @@ export default [
   takeEvery(setQcSettings.trigger, fsaSaga(setQcSettings, loadQcSettings)),
   takeEvery(setGeneMap.trigger, fsaSaga(setGeneMap, loadGeneMap)),
   takeEvery(setPcrPrimers.trigger, fsaSaga(setPcrPrimers, loadPcrPrimers)),
+  takeEvery(setConstellationDefinitions.trigger, fsaSaga(setConstellationDefinitions, loadConstellationDefinitions)),
 ]

--- a/packages/web/src/state/algorithm/algorithmRun.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmRun.sagas.ts
@@ -117,7 +117,15 @@ export function* runAlgorithm() {
     throw new Error('No sequence data provided')
   }
 
-  const { rootSeq, minimalLength, pcrPrimers, geneMap, auspiceData: auspiceDataReference, qcRulesConfig } = virus
+  const {
+    rootSeq,
+    minimalLength,
+    pcrPrimers,
+    constellations,
+    geneMap,
+    auspiceData: auspiceDataReference,
+    qcRulesConfig,
+  } = virus
   const auspiceData = treePreprocess(copy(auspiceDataReference), rootSeq)
 
   const parseResult = yield* parse(seqData)
@@ -130,6 +138,7 @@ export function* runAlgorithm() {
     rootSeq,
     minimalLength,
     pcrPrimers,
+    constellations,
     geneMap,
     auspiceData,
     qcRulesConfig,

--- a/packages/web/src/state/util/withReduxDevTools.ts
+++ b/packages/web/src/state/util/withReduxDevTools.ts
@@ -101,6 +101,7 @@ export function sanitizeParams(params?: AlgorithmParams) {
       qcRulesConfig: truncateContent(params.raw?.qcRulesConfig),
       geneMap: truncateContent(params.raw?.geneMap),
       pcrPrimers: truncateContent(params.raw?.pcrPrimers),
+      constellations: truncateContent(params.raw?.constellations),
     },
     virus: {
       ...params.virus,
@@ -228,6 +229,7 @@ export function withReduxDevTools<StoreEnhancerIn, StoreEnhancerOut>(
             auspiceData: truncateTreeJson(action.payload.auspiceData),
             geneMap: TRUNCATED,
             pcrPrimers: TRUNCATED,
+            constellations: TRUNCATED,
           },
         }
       }
@@ -243,6 +245,7 @@ export function withReduxDevTools<StoreEnhancerIn, StoreEnhancerOut>(
               auspiceData: truncateTreeJson(action.payload.params.auspiceData),
               geneMap: TRUNCATED,
               pcrPrimers: TRUNCATED,
+              constellations: TRUNCATED,
             },
             result: sanitizeResult(action.payload.result),
           },


### PR DESCRIPTION
This PR generates an extra annotation in the tooltips after the PCR Primer changes, listing the CoVariants page(s) that correspond to the given sequence. The linking is done via variant constellation definitions in constellations.json
![Screen Shot 2021-02-10 at 9 54 48 PM](https://user-images.githubusercontent.com/2350759/107603652-a930d080-6bea-11eb-9d96-14d87a609e7f.png)


