### PR TITLE
fix: don't attempt to create directories from empty paths

### DIFF
--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -747,8 +747,15 @@ int main(int argc, char *argv[]) {
     const auto paths = getPaths(cliParams, genes);
     logger.info(formatPaths(paths));
 
-    fs::create_directories(paths.outputFasta.parent_path());
-    fs::create_directories(paths.outputInsertions.parent_path());
+    const auto outputFastaParent = paths.outputFasta.parent_path();
+    if (!outputFastaParent.empty()) {
+      fs::create_directories(outputFastaParent);
+    }
+
+    const auto outputInsertionsParent = paths.outputInsertions.parent_path();
+    if (!outputInsertionsParent.empty()) {
+      fs::create_directories(outputInsertionsParent);
+    }
 
     std::ofstream outputFastaFile(paths.outputFasta);
     if (!outputFastaFile.good()) {


### PR DESCRIPTION
We were taking parent paths of named outputs and tried to create output directories from it.

When filename-only output flags were passed nextalign was crashing due to parent paths being empty.

This adds checks for empty paths to prevent that.

