### PR TITLE
chore(infra): allow any host in connect-src csp

### DIFF
--- a/packages/web/infra/lambda-at-edge/modifyOutgoingHeaders.lambda.js
+++ b/packages/web/infra/lambda-at-edge/modifyOutgoingHeaders.lambda.js
@@ -25,7 +25,7 @@ function generateFeaturePolicyHeader(featurePoicyObject) {
 
 const NEW_HEADERS = {
   'Content-Security-Policy':
-    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.githubusercontent.com",
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.githubusercontent.com; connect-src *",
   'Referrer-Policy': 'no-referrer',
   'Strict-Transport-Security': 'max-age=15768000; includeSubDomains; preload',
   'X-Content-Type-Options': 'nosniff',


### PR DESCRIPTION
This was mistakenly removed in 8fe7158b39fafe3becaf0ec225f12c1c2f415eb8 and caused Nextclade data fetching to fail

