### PR TITLE
fix: Correct Node.js version requirement for the Nextclade CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "dist/*.js.map"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "main": "dist/nextclade.js",
   "license": "MIT",


### PR DESCRIPTION
The README documents >=12, and indeed on Node.js 10 the Nextclade CLI
doesn't work because worker_threads is not available.

