### PR TITLE
[nextalign] Prevent crashing when not enough good gene seed positions

### DIFF
--- a/packages/nextalign/src/align/alignPairwise.cpp
+++ b/packages/nextalign/src/align/alignPairwise.cpp
@@ -153,9 +153,11 @@ SeedAlignment seedAlignment(
 
   for (int ni = 0; ni < nSeeds; ++ni) {
 
-    const int qPos = mapToGoodPositions[details::round(margin + (kmerSpacing * ni))];
+    const auto goodPositionIndex = details::round(margin + (kmerSpacing * ni));
+    const int qPos = mapToGoodPositions[goodPositionIndex];
     // FIXME: query.substr() creates a new string. Use string view instead.
-    const auto tmpMatch = seedMatch(query.substr(qPos, options.seedLength), ref, start_pos, options.mismatchesAllowed);
+    const auto seed = query.substr(qPos, options.seedLength);
+    const auto tmpMatch = seedMatch(seed, ref, start_pos, options.mismatchesAllowed);
 
     // only use seeds with at most allowed_mismatches
     if (tmpMatch.score >= options.seedLength - options.mismatchesAllowed) {

--- a/packages/nextalign/src/align/alignPairwise.cpp
+++ b/packages/nextalign/src/align/alignPairwise.cpp
@@ -154,6 +154,7 @@ SeedAlignment seedAlignment(
   for (int ni = 0; ni < nSeeds; ++ni) {
 
     const auto goodPositionIndex = details::round(margin + (kmerSpacing * ni));
+    invariant_less(goodPositionIndex, mapToGoodPositions.size());
     const int qPos = mapToGoodPositions[goodPositionIndex];
     // FIXME: query.substr() creates a new string. Use string view instead.
     const auto seed = query.substr(qPos, options.seedLength);

--- a/packages/nextalign/src/align/alignPairwise.cpp
+++ b/packages/nextalign/src/align/alignPairwise.cpp
@@ -146,6 +146,11 @@ SeedAlignment seedAlignment(
   // generate kmers equally spaced on the query
   const auto seedCover = safe_cast<double>(nGoodPositions - 2 * margin);
   const double kmerSpacing = (seedCover - 1.0) / (nSeeds - 1.0);
+
+  if (seedCover < 0.0 || kmerSpacing < 0.0) {
+    throw ErrorAlignmentNoSeedMatches();
+  }
+
   for (int ni = 0; ni < nSeeds; ++ni) {
 
     const int qPos = mapToGoodPositions[details::round(margin + (kmerSpacing * ni))];


### PR DESCRIPTION
This avoids crash in  seed extraction (`substr()`), when `seedCover` is negative. This can happen during gene alignment, for sequences with low-quality fragments. In this case we cannot proceed with alignment, so we bail out early.