### PR TITLE
remove gaps from output of reference translations

### DIFF
--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -83,7 +83,7 @@ PeptidesInternal translateGenes(         //
 
       refPeptides.emplace_back(PeptideInternal{
         .name = geneName,                   //
-        .seq = std::move(geneAlignment.ref),//
+        .seq = std::move(refPeptide),       //
         .insertions = {}                    //
       });
 


### PR DESCRIPTION
query results are returned as alignment with insertions stripped, hence gap symbols in the reference should be stripped


