### PR TITLE
fix: ensure ref sequence is included into outputs

### DIFF
--- a/packages/nextalign/src/nextalign.cpp
+++ b/packages/nextalign/src/nextalign.cpp
@@ -59,31 +59,30 @@ NextalignResultInternal nextalignInternal(const NucleotideSequence& query, const
   const auto stripped = stripInsertions(alignment.ref, alignment.query);
   const auto refStripped = removeGaps(ref);
 
-  NextalignResultInternal result;
-  result.ref = refStripped;
-  result.query = stripped.queryStripped;
-  result.alignmentScore = alignment.alignmentScore;
-  result.refPeptides = refPeptides;
-  result.queryPeptides = queryPeptides;
-  result.insertions = stripped.insertions;
-  result.warnings = warnings;
-
-  return result;
+  return NextalignResultInternal{
+    .query = stripped.queryStripped,
+    .ref = refStripped,
+    .alignmentScore = alignment.alignmentScore,
+    .refPeptides = refPeptides,
+    .queryPeptides = queryPeptides,
+    .insertions = stripped.insertions,
+    .warnings = warnings,
+  };
 }
 
 NextalignResult nextalign(const NucleotideSequence& query, const NucleotideSequence& ref, const GeneMap& geneMap,
   const NextalignOptions& options) {
   const auto resultInternal = nextalignInternal(query, ref, geneMap, options);
 
-  NextalignResult result;
-  result.query = toString(resultInternal.query);
-  result.alignmentScore = resultInternal.alignmentScore;
-  result.refPeptides = toPeptidesExternal(resultInternal.refPeptides);
-  result.queryPeptides = toPeptidesExternal(resultInternal.queryPeptides);
-  result.insertions = toInsertionsExternal(resultInternal.insertions);
-  result.warnings = resultInternal.warnings;
-
-  return result;
+  return NextalignResult{
+    .ref = toString(resultInternal.ref),
+    .query = toString(resultInternal.query),
+    .alignmentScore = resultInternal.alignmentScore,
+    .refPeptides = toPeptidesExternal(resultInternal.refPeptides),
+    .queryPeptides = toPeptidesExternal(resultInternal.queryPeptides),
+    .insertions = toInsertionsExternal(resultInternal.insertions),
+    .warnings = resultInternal.warnings,
+  };
 }
 
 

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -697,7 +697,7 @@ void run(
       }
 
       // TODO: hoist ref sequence transforms - process and write results only once, outside of main loop
-      if (!refsHaveBeenWritten) {
+      if (!refsHaveBeenWritten && !error) {
         outputFastaStream << fmt::format(">{:s}\n{:s}\n", refName, refAligned);
         outputFastaStream.flush();
 


### PR DESCRIPTION
Reference sequence was not included into output fasta file, eve with `--include-reference` flag, due to variable was not passed into returned object. 

Resolves #402