### PR TITLE
fix: correct content of csv/tsv rows when processing ends up with error

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -362,7 +362,7 @@ namespace Nextclade {
 
     std::string addRow(const AnalysisResult& result);
 
-    std::string addErrorRow(const std::string& error);
+    std::string addErrorRow(const std::string& seqName, const std::string& errorFormatted);
   };
 
   class Tree {

--- a/packages/nextclade/src/io/CsvWriter.cpp
+++ b/packages/nextclade/src/io/CsvWriter.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "../utils/contains.h"
+#include "../utils/contract.h"
 #include "formatMutation.h"
 #include "formatQcStatus.h"
 
@@ -172,9 +173,15 @@ namespace Nextclade {
     return row;
   }
 
-  std::string CsvWriter::addErrorRow(const std::string& error) {
-    const auto columns = std::string{COLUMN_NAMES.size() - 1, options.delimiter};
-    auto row = columns + error;
+  std::string CsvWriter::addErrorRow(const std::string& seqName, const std::string& errorFormatted) {
+    precondition_greater(COLUMN_NAMES.size(), 2);
+
+    std::vector<std::string> columns{COLUMN_NAMES.size(), ""};
+    columns[0] = seqName;
+    columns[columns.size() - 1] = errorFormatted;// NOTE: Assumes that the "error" column is the last one
+
+    std::for_each(columns.begin(), columns.end(), maybeSurroundWithQuotes(options.delimiter));
+    auto row = boost::algorithm::join(columns, std::string{options.delimiter});
     outputStream << row << "\n";
     return row;
   }

--- a/packages/nextclade_cli/src/cli.cpp
+++ b/packages/nextclade_cli/src/cli.cpp
@@ -789,14 +789,14 @@ void run(
         try {
           std::rethrow_exception(error);
         } catch (const std::exception &e) {
-
-          const std::string errorFormatted = fmt::format("In sequence \"{:s}\": {:s}.\n", seqName, e.what());
-          logger.warn("Warning: {}. Note that this sequence will be excluded from results.\n", errorFormatted);
+          const std::string &errorMessage = e.what();
+          logger.warn("Warning: In sequence \"{:s}\": {:s}. Note that this sequence will be excluded from results.\n",
+            seqName, errorMessage);
           if (csv) {
-            csv->addErrorRow(errorFormatted);
+            csv->addErrorRow(seqName, errorMessage);
           }
           if (tsv) {
-            tsv->addErrorRow(errorFormatted);
+            tsv->addErrorRow(seqName, errorMessage);
           }
           return;
         }


### PR DESCRIPTION
This PR rectifies contents of rows in CSV and TSV output files for sequences that trigger errors during processing.

For these rows, the `seqName` column now correctly contains sequence name, the `errors` column contains human-readable description of encountered error(s), and all other columns are empty (column delimiters are preserved).
