### PR TITLE
Implement cli verbosity levels, print warnings to stderr

### DIFF
--- a/packages/nextalign_cli/CMakeLists.txt
+++ b/packages/nextalign_cli/CMakeLists.txt
@@ -64,6 +64,7 @@ target_include_directories(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} SYSTEM
   PRIVATE
   "${CMAKE_SOURCE_DIR}/3rdparty/boost/include"
+  "${CMAKE_SOURCE_DIR}/3rdparty/frozen/include"
   )
 
 target_link_libraries(${PROJECT_NAME}

--- a/packages/nextalign_cli/src/Logger.h
+++ b/packages/nextalign_cli/src/Logger.h
@@ -1,7 +1,14 @@
 #pragma once
 
-
 #include <fmt/format.h>
+#include <frozen/string.h>// NOLINT(modernize-deprecated-headers) // false positive
+
+#include <array>
+
+class ErrorVerbosityLevelInvalid : public std::runtime_error {
+public:
+  explicit ErrorVerbosityLevelInvalid(const std::string& verb);
+};
 
 
 class Logger {
@@ -14,10 +21,45 @@ public:
     debug = 4,
   };
 
+  static constexpr std::array<frozen::string, 5> VERBOSITY_LEVELS = {
+    "silent",
+    "error",
+    "warn",
+    "info",
+    "debug",
+  };
+
+  static constexpr frozen::string VERBOSITY_DEFAULT_STR = VERBOSITY_LEVELS[2];
+
   struct Options {
     Verbosity verbosity = Verbosity::warn;
   };
 
+  static inline std::string getVerbosityLevels() {
+    std::vector<std::string> quoted;
+    std::transform(VERBOSITY_LEVELS.cbegin(), VERBOSITY_LEVELS.cend(), std::back_inserter(quoted),
+      [](const frozen::string& x) { return fmt::format("\"{}\"", x.data()); });
+    return boost::algorithm::join(quoted, ", ");
+  }
+
+  static inline Logger::Verbosity convertVerbosity(const std::string& verbosityStr) {
+    const auto& found =
+      std::find_if(VERBOSITY_LEVELS.cbegin(), VERBOSITY_LEVELS.cend(), [&verbosityStr](const frozen::string& verb) {
+        std::string v{verb.data()};
+        return v == std::string{verbosityStr};
+      });
+
+    if (found == VERBOSITY_LEVELS.cend()) {
+      throw ErrorVerbosityLevelInvalid(verbosityStr);
+    }
+
+    auto verbInt = static_cast<int>(std::distance(VERBOSITY_LEVELS.cbegin(), found));
+    return Logger::Verbosity{verbInt};
+  }
+
+  static inline std::string getVerbosityDefaultLevel() {
+    return std::string{VERBOSITY_DEFAULT_STR.data()};
+  }
 
 private:
   Options options;
@@ -45,7 +87,7 @@ public:
   template<typename S, typename... Args>
   inline void warn(const S& format_str, Args&&... args) {
     if (options.verbosity >= Verbosity::warn) {
-      fmt::print(format_str, args...);
+      fmt::print(stderr, format_str, args...);
     }
   }
 
@@ -56,3 +98,7 @@ public:
     }
   }
 };
+
+ErrorVerbosityLevelInvalid::ErrorVerbosityLevelInvalid(const std::string& verb)
+    : std::runtime_error(fmt::format("Verbosity level is invalid: \"{:s}\". Possible verbosity levels are: {}", verb,
+        Logger::getVerbosityLevels())) {}

--- a/packages/nextclade_cli/CMakeLists.txt
+++ b/packages/nextclade_cli/CMakeLists.txt
@@ -64,6 +64,7 @@ target_include_directories(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} SYSTEM
   PRIVATE
   "${CMAKE_SOURCE_DIR}/3rdparty/boost/include"
+  "${CMAKE_SOURCE_DIR}/3rdparty/frozen/include"
   )
 
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
This PR introduces verbosity levels for Nextclade CLI and Nextalign CLI.

The amount of information printed to console can be changed using `--verbosity` flag. The following values are accepted (from least to most verbose):
 - silent
 - error
 - warn
 - info
 - debug

Additionally, `--silent` flag is an alias for `--verbosity=silent` and `--vebose` is an alias for `--verbosity=info`. 

The "silent" verbosity level guarantees that no console output is produced. This is handy when using `stdout` as output stream, e.g. with `--output-fasta /dev/stdout`, to avoid performance-costly file IO when "piping" output of Nextclade or Nextalign into the next stage of the processing pipeline which accepts inputs on `stdin`. 


Additionally, the messages of `warning` verbosity (all warnings, including the ones produced when sequence alignment fails) are not being written to `stderr` instead of `stdout`.

