### PR TITLE
fix: properly serialize nucleotide sequences in primer results

### DIFF
--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -50,8 +50,8 @@ namespace Nextclade {
       j.emplace("name", pcrPrimer.name);
       j.emplace("target", pcrPrimer.target);
       j.emplace("source", pcrPrimer.source);
-      j.emplace("rootOligonuc", pcrPrimer.rootOligonuc);
-      j.emplace("primerOligonuc", pcrPrimer.primerOligonuc);
+      j.emplace("rootOligonuc", toString(pcrPrimer.rootOligonuc));
+      j.emplace("primerOligonuc", toString(pcrPrimer.primerOligonuc));
       j.emplace("range", serializeRange(pcrPrimer.range));
       j.emplace("nonACGTs", serializeArray(pcrPrimer.nonAcgts, serializeNucleotideLocation));
       return j;


### PR DESCRIPTION
This fixes values of `rootOligonuc` and `primerOligonuc` in detected PCR primer changes in Nextclade's JSON output file. They now correctly contain oligonucleotide sequences in ATGC alphabet, not in internal representation.
