### PR TITLE
feat: improve cli console logging

### DIFF
--- a/packages/nextalign/benchmarks/src/utils/getData.h
+++ b/packages/nextalign/benchmarks/src/utils/getData.h
@@ -14,7 +14,7 @@ constexpr const int NUM_SEQUENCES_VAR = 10;// Number of sequences to process per
 auto getData() {
   std::vector<AlgorithmInput> sequences;
   std::ifstream fastaFile("data/example/sequences.fasta");
-  const auto sequencesMap = parseSequences(fastaFile);
+  const auto sequencesMap = parseSequences(fastaFile, "data/example/sequences.fasta");
   std::copy(sequencesMap.cbegin(), sequencesMap.cend(), back_inserter(sequences));
 
   assert(sequences.size() >= NUM_SEQUENCES_VAR);
@@ -25,11 +25,11 @@ auto getData() {
     });
 
   std::ifstream refFile("data/example/reference.txt");
-  const auto refSeqs = parseSequences(refFile);
+  const auto refSeqs = parseSequences(refFile, "data/example/reference.txt");
   const auto ref = refSeqs.begin()->seq;
 
   std::ifstream genemapFile("data/example/genemap.gff");
-  const auto GENE_MAP = parseGeneMapGff(genemapFile);
+  const auto GENE_MAP = parseGeneMapGff(genemapFile, "data/example/genemap.gff");
 
   std::set<std::string> GENES;
   for (const auto& [geneName, _] : GENE_MAP) {

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -214,9 +214,9 @@ public:
 };
 
 /** Creates an instance of fasta stream, given a file or string stream */
-std::unique_ptr<FastaStream> makeFastaStream(std::istream& istream);
+std::unique_ptr<FastaStream> makeFastaStream(std::istream& istream, std::string filename);
 
 /** Parses all sequences of a given file or string stream */
-std::vector<AlgorithmInput> parseSequences(std::istream& istream);
+std::vector<AlgorithmInput> parseSequences(std::istream& istream, std::string filename);
 
 const char* getVersion();

--- a/packages/nextalign/src/io/parseSequences.cpp
+++ b/packages/nextalign/src/io/parseSequences.cpp
@@ -4,6 +4,7 @@
 #include <boost/algorithm/string.hpp>
 #include <map>
 #include <regex>
+#include <utility>
 
 namespace {
   using regex = std::regex;
@@ -13,15 +14,18 @@ namespace {
 
 class ErrorFastaStreamIllegalNextCall : public std::runtime_error {
 public:
-  ErrorFastaStreamIllegalNextCall()
-      : std::runtime_error("Fasta stream: stream is in non-readable state, the next item cannot be retrieved") {}
+  explicit ErrorFastaStreamIllegalNextCall(const std::string& filename)
+      : std::runtime_error(fmt::format("When parsing input sequences: Input stream (\"{:s}\") is in non-readable state,"
+                                       " the next line cannot be retrieved. Aborting.",
+          filename)) {}
 };
 
 
 class ErrorFastaStreamInvalidState : public std::runtime_error {
 public:
-  ErrorFastaStreamInvalidState()
-      : std::runtime_error("Fasta stream: stream reached an invalid state which should not be reached") {}
+  explicit ErrorFastaStreamInvalidState(const std::string& filename)
+      : std::runtime_error(fmt::format(
+          "When parsing input sequences: Input stream (\"{:s}\") is empty or corrupted. Aborting.", filename)) {}
 };
 
 
@@ -49,6 +53,7 @@ auto sanitizeSequence(std::string seq) {
 
 class FastaStreamImpl : public FastaStream {
   std::istream& istream;
+  std::string filename;
   std::map<std::string, int> seqNames;
 
   int currentIndex = 0;
@@ -80,7 +85,7 @@ class FastaStreamImpl : public FastaStream {
 public:
   FastaStreamImpl() = delete;
 
-  explicit FastaStreamImpl(std::istream& is) : istream(is) {}
+  explicit FastaStreamImpl(std::istream& is, std::string fileName) : istream(is), filename(std::move(fileName)) {}
 
   ~FastaStreamImpl() override = default;
 
@@ -100,7 +105,7 @@ public:
 
   AlgorithmInput next() override {
     if (!good()) {
-      throw ErrorFastaStreamIllegalNextCall();
+      throw ErrorFastaStreamIllegalNextCall(filename);
     }
 
     std::string line;
@@ -128,18 +133,18 @@ public:
       return prepareResult();
     }
 
-    throw ErrorFastaStreamInvalidState();
+    throw ErrorFastaStreamInvalidState(filename);
   }
 };
 
-std::unique_ptr<FastaStream> makeFastaStream(std::istream& istream) {
-  return std::make_unique<FastaStreamImpl>(istream);
+std::unique_ptr<FastaStream> makeFastaStream(std::istream& istream, std::string filename) {
+  return std::make_unique<FastaStreamImpl>(istream, std::move(filename));
 }
 
-std::vector<AlgorithmInput> parseSequences(std::istream& istream) {
+std::vector<AlgorithmInput> parseSequences(std::istream& istream, std::string filename) {
   std::vector<AlgorithmInput> seqs;
 
-  auto fastaStream = makeFastaStream(istream);
+  auto fastaStream = makeFastaStream(istream, std::move(filename));
   while (fastaStream->good()) {
     seqs.emplace_back(fastaStream->next());
   }

--- a/packages/nextalign/tests/parseSequences.test.cpp
+++ b/packages/nextalign/tests/parseSequences.test.cpp
@@ -43,7 +43,7 @@ X Y:)Z
   )"  ;
   // clang-format on
 
-  const auto results = parseSequences(input);
+  const auto results = parseSequences(input, "test std::stringstream");
 
   const ExpectedResults expected = {
     {0, "Hello/Sequence/ID1234", "ABC?DEF.GHL*MNOPXYZ"},
@@ -62,7 +62,7 @@ TEST(parseSequences, ConvertsSequencesToUppercase) {
   Cheers!
   )";
 
-  const auto results = parseSequences(input);
+  const auto results = parseSequences(input, "test std::stringstream");
 
   const ExpectedResults expected = {
     {0, "Some/Sequence", "HICANYOUMAKEITUPPERCASEPLEASE?CHEERS"},
@@ -91,7 +91,7 @@ TEST(parseSequences, DeduplicatesSequenceNames) {
     OPQRS
   )";
 
-  const auto results = parseSequences(input);
+  const auto results = parseSequences(input, "test std::stringstream");
 
   const ExpectedResults expected = {
     {0, "Hello", "ABCD"},
@@ -114,7 +114,7 @@ TEST(parseSequences, AssignsSequenceNameToUntitledSequences) {
     EFGH
   )";
 
-  const auto results = parseSequences(input);
+  const auto results = parseSequences(input, "test std::stringstream");
 
   const ExpectedResults expected = {
     {0, "Untitled", "ABCD"},
@@ -132,7 +132,7 @@ TEST(parseSequences, AllowsPlainText) {
     plain text!
   )";
 
-  const auto results = parseSequences(input);
+  const auto results = parseSequences(input, "test std::stringstream");
 
   const ExpectedResults expected = {
     {0, "Untitled", "THISISPLAINTEXT"},

--- a/packages/nextclade/src/__tests__/findPrivateMutations.test.cpp
+++ b/packages/nextclade/src/__tests__/findPrivateMutations.test.cpp
@@ -33,7 +33,7 @@ namespace {
         throw std::runtime_error(fmt::format("Error: unable to read \"{:s}\"\n", filename));
       }
 
-      const auto refSeqs = parseSequences(file);
+      const auto refSeqs = parseSequences(file, filename);
       if (refSeqs.size() != 1) {
         throw std::runtime_error(
           fmt::format("Error: {:d} sequences found in reference sequence file, expected 1", refSeqs.size()));
@@ -130,8 +130,7 @@ TEST_F(FindPrivateMutations, Returns_Set_Difference_In_General_Case) {
       "C679N",
     });
 
-  Nextclade::AnalysisResult
-    seq = makeQuery(//
+  Nextclade::AnalysisResult seq = makeQuery(//
     {
       "C679Y",
       "C123B",


### PR DESCRIPTION
This improves console logging messages of Nextclade CLi and Nextalign CLI.
The messages are not prefixed with message's log level (verbosity level) and the name of the application. Some of the error and warning messages have been reworded to better convey their meaning (but there are still some work to do here).

This should improve log readability and facilitate debugging when using Nextclade CLi and Nextalign CLI in complex pipelines.

Examples:

> [ WARN] Nextclade: Warning: in sequence "USA/UT-01231/2020": When processing gene "ORF7b": Unable to align: no seed matches. Note that this gene will not be included in the results of the sequence


> [ERROR] Nextclade: Error: when running the internal parallel pipeline: When parsing input sequences: Input stream ("path/to/an_empty_file.fasta") is empty or corrupted. Aborting.


