### PR TITLE
Improve "clade" column

### DIFF
--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -46,7 +46,7 @@ export const RESULTS_TABLE_FLEX_BASIS = {
   id: 50,
   seqName: 300,
   qc: 100,
-  clade: 110,
+  clade: 125,
   mut: 60,
   nonACGTN: 70,
   ns: 60,

--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -121,6 +121,11 @@ export const TableCellName = styled(TableCell)<{ basis?: string; grow?: number; 
   padding-left: 5px;
 `
 
+export const TableCellAlignedLeft = styled(TableCell)<{ basis?: string; grow?: number; shrink?: number }>`
+  text-align: left;
+  padding-left: 5px;
+`
+
 export const TableRowPending = styled(TableRow)`
   background-color: #d2d2d2;
   color: #818181;
@@ -203,9 +208,9 @@ function TableRowComponent({ index, style, data }: RowProps) {
         <ColumnQCStatus sequence={sequence} qc={qc} />
       </TableCell>
 
-      <TableCell basis={RESULTS_TABLE_FLEX_BASIS_PX.clade} grow={0} shrink={0}>
+      <TableCellAlignedLeft basis={RESULTS_TABLE_FLEX_BASIS_PX.clade} grow={0} shrink={0}>
         <ColumnClade sequence={sequence} />
-      </TableCell>
+      </TableCellAlignedLeft>
 
       <TableCell basis={RESULTS_TABLE_FLEX_BASIS_PX.mut} grow={0} shrink={0}>
         <ColumnMutations sequence={sequence} />

--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -46,7 +46,7 @@ export const RESULTS_TABLE_FLEX_BASIS = {
   id: 50,
   seqName: 300,
   qc: 100,
-  clade: 90,
+  clade: 110,
   mut: 60,
   nonACGTN: 70,
   ns: 60,


### PR DESCRIPTION
This attempts to improve readability of the "Clade" colnum in Nextclade web:

 - Increase width of the "Clade" column
 - Left-align clade names in "Clade" column

The longest versioned clade seem to be "20J (Gamma, V3)" currently and I made clade column to be 120px wide, so that even "22W (Omicron, V25)" fits if it ever happen to exist (please don't)

Before:
![before](https://user-images.githubusercontent.com/9403403/120979470-ee6aa680-c775-11eb-8920-697ed90a20b9.png)


After:
![after](https://user-images.githubusercontent.com/9403403/120979460-ec084c80-c775-11eb-8de2-8ce9ac62e86c.png)


Longer:
![longer](https://user-images.githubusercontent.com/9403403/120979863-49040280-c776-11eb-82f7-c031035c74f4.png)


