### PR TITLE
Link aminoacid and nucleotide changes by position

### DIFF
--- a/packages/nextclade/CMakeLists.txt
+++ b/packages/nextclade/CMakeLists.txt
@@ -36,6 +36,8 @@ set(SOURCE_FILES
   src/analyze/isMatch.h
   src/analyze/isSequenced.cpp
   src/analyze/isSequenced.h
+  src/analyze/linkNucAndAaChangesInPlace.cpp
+  src/analyze/linkNucAndAaChangesInPlace.h
   src/analyze/nucleotide.cpp
   src/analyze/nucleotide.h
   src/io/CsvWriter.cpp

--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -134,13 +134,15 @@ namespace Nextclade {
   };
 
   struct AminoacidSubstitution;
+  struct AminoacidDeletion;
 
   struct NucleotideSubstitution {
     Nucleotide refNuc;
     int pos;
     Nucleotide queryNuc;
     std::vector<PcrPrimer> pcrPrimersChanged;
-    std::vector<AminoacidSubstitution> aaSubstitutions;// FIXME: unused and should be removed
+    std::vector<AminoacidSubstitution> aaSubstitutions;
+    std::vector<AminoacidDeletion> aaDeletions;
   };
 
   inline bool operator==(const NucleotideSubstitution& lhs, const NucleotideSubstitution& rhs) {
@@ -155,13 +157,11 @@ namespace Nextclade {
     );
   }
 
-  struct AminoacidDeletion;
-
   struct NucleotideDeletion {
     int start;
     int length;
-    std::vector<AminoacidSubstitution> aaSubstitutions;// FIXME: unused and should be removed
-    std::vector<AminoacidDeletion> aaDeletions;        // FIXME: unused and should be removed
+    std::vector<AminoacidSubstitution> aaSubstitutions;
+    std::vector<AminoacidDeletion> aaDeletions;
   };
 
   inline bool operator==(const NucleotideDeletion& lhs, const NucleotideDeletion& rhs) {
@@ -195,6 +195,8 @@ namespace Nextclade {
     NucleotideSequence refContext;
     NucleotideSequence queryContext;
     Range contextNucRange;
+    std::vector<NucleotideSubstitution> nucSubstitutions;
+    std::vector<NucleotideDeletion> nucDeletions;
   };
 
   inline bool operator==(const AminoacidSubstitution& left, const AminoacidSubstitution& right) {
@@ -225,6 +227,8 @@ namespace Nextclade {
     NucleotideSequence refContext;
     NucleotideSequence queryContext;
     Range contextNucRange;
+    std::vector<NucleotideSubstitution> nucSubstitutions;
+    std::vector<NucleotideDeletion> nucDeletions;
   };
 
   inline bool operator==(const AminoacidDeletion& left, const AminoacidDeletion& right) {
@@ -268,11 +272,16 @@ namespace Nextclade {
     std::vector<NucleotideSubstitution> substitutions;
   };
 
-  struct NucMutationsReport {
+  struct NucleotideChangesReport {
     std::vector<NucleotideSubstitution> substitutions;
     std::vector<NucleotideDeletion> deletions;
     int alignmentStart;
     int alignmentEnd;
+  };
+
+  struct AminoacidChangesReport {
+    std::vector<AminoacidSubstitution> aaSubstitutions;
+    std::vector<AminoacidDeletion> aaDeletions;
   };
 
   struct AnalysisResult {

--- a/packages/nextclade/src/analyze/findNucChanges.cpp
+++ b/packages/nextclade/src/analyze/findNucChanges.cpp
@@ -7,7 +7,7 @@
 
 
 namespace Nextclade {
-  NucMutationsReport findNucChanges(       //
+  NucleotideChangesReport findNucChanges(  //
     const NucleotideSequence& refStripped, //
     const NucleotideSequence& queryStripped//
   ) {

--- a/packages/nextclade/src/analyze/findNucChanges.h
+++ b/packages/nextclade/src/analyze/findNucChanges.h
@@ -3,7 +3,7 @@
 #include <nextclade/nextclade.h>
 
 namespace Nextclade {
-  NucMutationsReport findNucChanges(       //
+  NucleotideChangesReport findNucChanges(  //
     const NucleotideSequence& refStripped, //
     const NucleotideSequence& queryStripped//
   );                                       //

--- a/packages/nextclade/src/analyze/getAminoacidChanges.cpp
+++ b/packages/nextclade/src/analyze/getAminoacidChanges.cpp
@@ -124,7 +124,7 @@ namespace Nextclade {
    *
    * NOTE: Nucleotide sequences and peptides are required to be stripped from insertions
    */
-  GetAminoacidChangesResult getAminoacidChanges(      //
+  AminoacidChangesReport getAminoacidChanges(         //
     const NucleotideSequence& ref,                    //
     const NucleotideSequence& query,                  //
     const std::vector<PeptideInternal>& refPeptides,  //

--- a/packages/nextclade/src/analyze/getAminoacidChanges.h
+++ b/packages/nextclade/src/analyze/getAminoacidChanges.h
@@ -15,12 +15,7 @@ namespace Nextclade {
     ErrorGeneNotFound(const std::string& geneName, const GeneMap& geneMap);
   };
 
-  struct GetAminoacidChangesResult {
-    std::vector<AminoacidSubstitution> aaSubstitutions;
-    std::vector<AminoacidDeletion> aaDeletions;
-  };
-
-  GetAminoacidChangesResult getAminoacidChanges(      //
+  AminoacidChangesReport getAminoacidChanges(         //
     const NucleotideSequence& ref,                    //
     const NucleotideSequence& query,                  //
     const std::vector<PeptideInternal>& refPeptides,  //

--- a/packages/nextclade/src/analyze/linkNucAndAaChangesInPlace.cpp
+++ b/packages/nextclade/src/analyze/linkNucAndAaChangesInPlace.cpp
@@ -1,0 +1,56 @@
+#include "linkNucAndAaChangesInPlace.h"
+
+#include <nextclade/nextclade.h>
+
+#include "utils/range.h"
+
+namespace Nextclade {
+
+  /**
+   * Adds information about aminoacid changes into nucleotide changes data structures and vice versa.
+   * The relation is being decided purely by nucleotide and aminoacid positions. We don't necessarily argue that there
+   * is a causal link between each linked change, but just show the spatial locality of these changes.
+   *
+   * A given aminoacid change (substitution or deletion) is considered to be related to a given nucleotide mutation,
+   * if nucleotide mutation position falls into the aminoacid codon nucleotide range.
+   *
+   * A given aminoacid change (substitution or deletion) is considered to be related to a given nucleotide deletion,
+   * if nucleotide deletion range intersects aminoacid codon nucleotide range.
+   */
+  void linkNucAndAaChangesInPlace(NucleotideChangesReport& nucChanges, AminoacidChangesReport& aaChanges) {
+    for (auto& aaSub : aaChanges.aaSubstitutions) {
+      for (auto& nucSub : nucChanges.substitutions) {
+        if (inRange(nucSub.pos, aaSub.codonNucRange)) {
+          nucSub.aaSubstitutions.push_back(aaSub);
+          aaSub.nucSubstitutions.push_back(nucSub);
+        }
+      }
+
+      for (auto& nucDel : nucChanges.deletions) {
+        const Range nucDelRange{.begin = nucDel.start, .end = nucDel.start + nucDel.length};
+        if (hasIntersection(nucDelRange, aaSub.codonNucRange)) {
+          nucDel.aaSubstitutions.push_back(aaSub);
+          aaSub.nucDeletions.push_back(nucDel);
+        }
+      }
+    }
+
+    for (auto& aaDel : aaChanges.aaDeletions) {
+      for (auto& nucSub : nucChanges.substitutions) {
+        if (inRange(nucSub.pos, aaDel.codonNucRange)) {
+          nucSub.aaDeletions.push_back(aaDel);
+          aaDel.nucSubstitutions.push_back(nucSub);
+        }
+      }
+
+      for (auto& nucDel : nucChanges.deletions) {
+        const Range nucDelRange{.begin = nucDel.start, .end = nucDel.start + nucDel.length};
+        if (hasIntersection(nucDelRange, aaDel.codonNucRange)) {
+          nucDel.aaDeletions.push_back(aaDel);
+          aaDel.nucDeletions.push_back(nucDel);
+        }
+      }
+    }
+  }
+
+}// namespace Nextclade

--- a/packages/nextclade/src/analyze/linkNucAndAaChangesInPlace.h
+++ b/packages/nextclade/src/analyze/linkNucAndAaChangesInPlace.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <nextclade/nextclade.h>
+
+namespace Nextclade {
+  void linkNucAndAaChangesInPlace(NucleotideChangesReport& nucChanges, AminoacidChangesReport& aaChanges);
+}// namespace Nextclade

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -80,6 +80,8 @@ namespace Nextclade {
       auto j = json::object();
       j.emplace("start", del.start);
       j.emplace("length", del.length);
+      j.emplace("aaSubstitutions", serializeArray(del.aaSubstitutions, serializeAminoacidMutation));
+      j.emplace("aaDeletions", serializeArray(del.aaDeletions, serializeAminoacidDeletion));
       return j;
     }
 

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -61,11 +61,17 @@ namespace Nextclade {
       return serializeArray(pcrPrimers, serializePcrPrimer);
     }
 
+    json serializeAminoacidMutation(const AminoacidSubstitution& mut);
+
+    json serializeAminoacidDeletion(const AminoacidDeletion& del);
+
     json serializeMutation(const NucleotideSubstitution& mut) {
       auto j = json::object();
       j.emplace("refNuc", nucToString(mut.refNuc));
       j.emplace("pos", mut.pos);
       j.emplace("queryNuc", nucToString(mut.queryNuc));
+      j.emplace("aaSubstitutions", serializeArray(mut.aaSubstitutions, serializeAminoacidMutation));
+      j.emplace("aaDeletions", serializeArray(mut.aaDeletions, serializeAminoacidDeletion));
       j.emplace("pcrPrimersChanged", serializePcrPrimers(mut.pcrPrimersChanged));
       return j;
     }
@@ -115,6 +121,8 @@ namespace Nextclade {
       j.emplace("refContext", toString(mut.refContext));
       j.emplace("queryContext", toString(mut.queryContext));
       j.emplace("contextNucRange", serializeRange(mut.contextNucRange));
+      j.emplace("nucSubstitutions", serializeArray(mut.nucSubstitutions, serializeMutation));
+      j.emplace("nucDeletions", serializeArray(mut.nucDeletions, serializeDeletion));
       return j;
     }
 
@@ -127,6 +135,8 @@ namespace Nextclade {
       j.emplace("refContext", toString(del.refContext));
       j.emplace("queryContext", toString(del.queryContext));
       j.emplace("contextNucRange", serializeRange(del.contextNucRange));
+      j.emplace("nucSubstitutions", serializeArray(del.nucSubstitutions, serializeMutation));
+      j.emplace("nucDeletions", serializeArray(del.nucDeletions, serializeDeletion));
       return j;
     }
 

--- a/packages/nextclade/src/nextclade.cpp
+++ b/packages/nextclade/src/nextclade.cpp
@@ -1,4 +1,3 @@
-#include <analyze/getPcrPrimerChanges.h>
 #include <nextalign/nextalign.h>
 #include <nextalign/private/nextalign_private.h>
 #include <nextclade/nextclade.h>
@@ -10,6 +9,8 @@
 #include "analyze/findNucleotideRanges.h"
 #include "analyze/getAminoacidChanges.h"
 #include "analyze/getNucleotideComposition.h"
+#include "analyze/getPcrPrimerChanges.h"
+#include "analyze/linkNucAndAaChangesInPlace.h"
 #include "analyze/nucleotide.h"
 #include "qc/runQc.h"
 #include "tree/Tree.h"
@@ -64,6 +65,9 @@ namespace Nextclade {
       Range{.begin = nucChanges.alignmentStart, .end = nucChanges.alignmentEnd},//
       geneMap                                                                   //
     );
+
+    linkNucAndAaChangesInPlace(nucChanges, aaChanges);
+
     const auto totalAminoacidSubstitutions = safe_cast<int>(aaChanges.aaSubstitutions.size());
     const auto totalAminoacidDeletions = safe_cast<int>(aaChanges.aaDeletions.size());
 

--- a/packages/nextclade/src/utils/range.h
+++ b/packages/nextclade/src/utils/range.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nextclade/nextclade.h>
+
 #include <algorithm>
 #include <optional>
 #include <tuple>
@@ -12,6 +14,13 @@
  */
 inline constexpr bool inRange(int x, int from, int to) {
   return x >= from && x < to;
+}
+
+/**
+ * Checks is a number x belongs to a half-open range [from; to)
+ */
+inline constexpr bool inRange(int x, const Nextclade::Range& range) {
+  return x >= range.begin && x < range.end;
 }
 
 /**
@@ -45,4 +54,39 @@ inline std::optional<std::pair<int, int>> intersection(std::pair<int, int> x, st
   const auto& begin2 = y.first;
   const auto& end2 = y.second;
   return intersection(begin1, end1, begin2, end2);
+}
+
+/**
+ * Finds overlap of 2 half-open ranges [from; to)
+ * (version with 2 `Range`s)
+ *
+ * Returns an std::optional of std::pair containing half-open range [begin, end) of the overlap.
+ * If there's no overlap, returns std::nullopt.
+ */
+inline bool intersection(const Nextclade::Range& x, const Nextclade::Range& y) {
+  return static_cast<bool>(intersection(x.begin, x.end, y.begin, y.end));
+}
+
+/**
+ * Finds whether of 2 half-open ranges [from; to) intersect
+ * (version with 4 integers)
+ */
+inline bool hasIntersection(int begin1, int end1, int begin2, int end2) {
+  return static_cast<bool>(intersection(begin1, end1, begin2, end2));
+}
+
+/**
+ * Finds whether of 2 half-open ranges [from; to) intersect
+ * (version with 2 `std::pair`s)
+ */
+inline bool hasIntersection(std::pair<int, int> x, std::pair<int, int> y) {
+  return static_cast<bool>(intersection(x, y));
+}
+
+/**
+ * Finds whether of 2 half-open ranges [from; to) intersect
+ * (version with 2 `Range`s)
+ */
+inline bool hasIntersection(const Nextclade::Range& x, const Nextclade::Range& y) {
+  return static_cast<bool>(intersection(x, y));
 }

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -29,9 +29,14 @@ export interface NucleotideSubstitution {
   refNuc: Nucleotide
   queryNuc: Nucleotide
   pcrPrimersChanged: PcrPrimer[]
+  aaSubstitutions: AminoacidSubstitution[]
+  aaDeletions: AminoacidDeletion[]
 }
 
-export interface NucleotideDeletion extends Span {}
+export interface NucleotideDeletion extends Span {
+  aaSubstitutions: AminoacidSubstitution[]
+  aaDeletions: AminoacidDeletion[]
+}
 
 export interface NucleotideInsertion {
   pos: number
@@ -60,6 +65,8 @@ export interface AminoacidSubstitution {
   refContext: string
   queryContext: string
   contextNucRange: Range
+  nucSubstitutions: NucleotideSubstitution[]
+  nucDeletions: NucleotideDeletion[]
 }
 
 export interface AminoacidDeletion {
@@ -70,6 +77,8 @@ export interface AminoacidDeletion {
   refContext: string
   queryContext: string
   contextNucRange: Range
+  nucSubstitutions: NucleotideSubstitution[]
+  nucDeletions: NucleotideDeletion[]
 }
 
 export interface PcrPrimer {

--- a/packages/web/src/components/SequenceView/ListOfAminoacidDeletions.tsx
+++ b/packages/web/src/components/SequenceView/ListOfAminoacidDeletions.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import type { DeepReadonly } from 'ts-essentials'
 import { useTranslation } from 'react-i18next'
 
 import type { AminoacidDeletion } from 'src/algorithms/types'
@@ -10,7 +9,7 @@ import { truncateList } from 'src/components/Results/truncateList'
 const LIST_OF_AA_DELETIONS_MAX_ITEMS = 15 as const
 
 export interface ListOfAminoacidChangesProps {
-  readonly aminoacidDeletions: DeepReadonly<AminoacidDeletion[]>
+  readonly aminoacidDeletions: AminoacidDeletion[]
 }
 
 export function ListOfAminoacidDeletions({ aminoacidDeletions }: ListOfAminoacidChangesProps) {

--- a/packages/web/src/components/SequenceView/ListOfAminoacidSubstitutions.tsx
+++ b/packages/web/src/components/SequenceView/ListOfAminoacidSubstitutions.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import type { DeepReadonly } from 'ts-essentials'
 import { useTranslation } from 'react-i18next'
 
 import type { AminoacidSubstitution } from 'src/algorithms/types'
@@ -10,7 +9,7 @@ import { truncateList } from 'src/components/Results/truncateList'
 const LIST_OF_AA_MUTATIONS_MAX_ITEMS = 15 as const
 
 export interface ListOfAminoacidChangesProps {
-  readonly aminoacidSubstitutions: DeepReadonly<AminoacidSubstitution[]>
+  readonly aminoacidSubstitutions: AminoacidSubstitution[]
 }
 
 export function ListOfAminoacidSubstitutions({ aminoacidSubstitutions }: ListOfAminoacidChangesProps) {

--- a/packages/web/src/components/SequenceView/PeptideContext.tsx
+++ b/packages/web/src/components/SequenceView/PeptideContext.tsx
@@ -121,7 +121,7 @@ export function PeptideContextAminoacid({ aa }: PeptideContextAminoacidProps) {
       return { color, background }
     }
     return {}
-  }, [aa])
+  }, [aa, theme])
 
   return (
     <TdAa colSpan={3} $color={color} $background={background}>

--- a/packages/web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
@@ -11,6 +11,8 @@ import type { Gene } from 'src/algorithms/types'
 import type { State } from 'src/state/reducer'
 import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 import { getAminoacidColor } from 'src/helpers/getAminoacidColor'
+import { formatMutation } from 'src/helpers/formatMutation'
+import { formatRange } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 import type { AminoacidChange, AminoacidChangesGroup } from 'src/components/SequenceView/groupAdjacentAminoacidChanges'
 import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
@@ -69,10 +71,12 @@ function PeptideMarkerMutationGroupDisconnected({
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const { gene, changes, codonAaRange } = group
+  const { gene, changes, codonAaRange, nucSubstitutions, nucDeletions } = group
   const id = getSafeId('aa-mutation-group-marker', { seqName, gene, begin: codonAaRange.begin })
   const x = codonAaRange.begin * pixelsPerAa
   const width = changes.length * Math.max(AA_MIN_WIDTH_PX, pixelsPerAa)
+
+  const totalNucChanges = nucSubstitutions.length + nucDeletions.length
 
   return (
     <g id={id}>
@@ -106,6 +110,32 @@ function PeptideMarkerMutationGroupDisconnected({
                       <td>
                         <AminoacidMutationBadge mutation={change} geneMap={geneMap ?? []} />
                       </td>
+                    </tr>
+                  ))}
+                </>
+
+                {totalNucChanges > 0 && (
+                  <tr>
+                    <td colSpan={2}>
+                      <h6 className="mt-3">{t('Nucleotide changes nearby ({{count}})', { count: totalNucChanges })}</h6>
+                    </td>
+                  </tr>
+                )}
+
+                <>
+                  {nucSubstitutions.map((mut) => (
+                    <tr key={mut.pos}>
+                      <td>{t('Substitution')}</td>
+                      <td>{formatMutation(mut)}</td>
+                    </tr>
+                  ))}
+                </>
+
+                <>
+                  {nucDeletions.map((del) => (
+                    <tr key={del.start}>
+                      <td>{t('Deletion')}</td>
+                      <td>{formatRange(del.start, del.start + del.length)}</td>
                     </tr>
                   ))}
                 </>

--- a/packages/web/src/components/SequenceView/SequenceMarkerGap.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerGap.tsx
@@ -1,27 +1,60 @@
 import React, { SVGProps, useState } from 'react'
 
 import { useTranslation } from 'react-i18next'
+import { connect } from 'react-redux'
+import { Table as ReactstrapTable } from 'reactstrap'
+import styled from 'styled-components'
+
 import { BASE_MIN_WIDTH_PX, GAP } from 'src/constants'
 
-import type { NucleotideDeletion } from 'src/algorithms/types'
+import type { Gene, NucleotideDeletion } from 'src/algorithms/types'
+import type { State } from 'src/state/reducer'
+import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
+
 import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { formatRange } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 
+import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
+
 const gapColor = getNucleotideColor(GAP)
+
+export const Table = styled(ReactstrapTable)`
+  & td {
+    padding: 0 0.5rem;
+  }
+
+  & tr {
+    margin: 0;
+    padding: 0;
+  }
+`
 
 export interface MissingViewProps extends SVGProps<SVGRectElement> {
   seqName: string
   deletion: NucleotideDeletion
   pixelsPerBase: number
+  geneMap?: Gene[]
 }
 
-function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }: MissingViewProps) {
+const mapStateToProps = (state: State) => ({
+  geneMap: selectGeneMap(state),
+})
+
+const mapDispatchToProps = {}
+
+export const SequenceMarkerGapUnmemoed = connect(mapStateToProps, mapDispatchToProps)(SequenceMarkerGapDisconnected)
+
+function SequenceMarkerGapDisconnected({ seqName, deletion, pixelsPerBase, geneMap, ...rest }: MissingViewProps) {
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const { start: begin, length } = deletion
+  if (!geneMap) {
+    return null
+  }
+
+  const { start: begin, length, aaSubstitutions, aaDeletions } = deletion
   const end = begin + length
 
   const id = getSafeId('gap-marker', { seqName, ...deletion })
@@ -31,6 +64,8 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
   width = Math.max(width, BASE_MIN_WIDTH_PX)
 
   const rangeStr = formatRange(begin, end)
+
+  const totalAaChanges = aaSubstitutions.length + aaDeletions.length
 
   return (
     <rect
@@ -44,8 +79,47 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
     >
-      <Tooltip target={id} isOpen={showTooltip}>
-        {t('Gap: {{range}}', { range: rangeStr })}
+      <Tooltip target={id} isOpen={showTooltip} fullWidth>
+        <Table borderless className="mb-1">
+          <thead />
+          <tbody>
+            <tr>
+              <td colSpan={2}>
+                <h6>{t('Gap: {{range}}', { range: rangeStr })}</h6>
+              </td>
+            </tr>
+
+            {totalAaChanges > 0 && (
+              <tr>
+                <td colSpan={2}>
+                  <h6 className="mt-1">{t('Aminoacid changes nearby:')}</h6>
+                </td>
+              </tr>
+            )}
+
+            <>
+              {aaSubstitutions.map((mut) => (
+                <tr key={mut.codon}>
+                  <td>{t('Aminoacid substitution')}</td>
+                  <td>
+                    <AminoacidMutationBadge mutation={mut} geneMap={geneMap} />
+                  </td>
+                </tr>
+              ))}
+            </>
+
+            <>
+              {aaDeletions.map((del) => (
+                <tr key={del.queryContext}>
+                  <td>{t('Aminoacid deletion')}</td>
+                  <td>
+                    <AminoacidMutationBadge mutation={del} geneMap={geneMap} />
+                  </td>
+                </tr>
+              ))}
+            </>
+          </tbody>
+        </Table>
       </Tooltip>
     </rect>
   )

--- a/packages/web/src/components/SequenceView/SequenceMarkerGap.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerGap.tsx
@@ -92,7 +92,7 @@ function SequenceMarkerGapDisconnected({ seqName, deletion, pixelsPerBase, geneM
             {totalAaChanges > 0 && (
               <tr>
                 <td colSpan={2}>
-                  <h6 className="mt-1">{t('Aminoacid changes nearby:')}</h6>
+                  <h6 className="mt-1">{t('Affected codons:')}</h6>
                 </td>
               </tr>
             )}

--- a/packages/web/src/components/SequenceView/SequenceMarkerMissingEnds.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMissingEnds.tsx
@@ -3,7 +3,7 @@ import React, { SVGProps, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BASE_MIN_WIDTH_PX } from 'src/constants'
 
-import type { NucleotideDeletion } from 'src/algorithms/types'
+import type { Span } from 'src/algorithms/types'
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { formatRange } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
@@ -12,7 +12,7 @@ const missingEndColor = '#BBBBBB'
 
 export interface MissingEndsViewProps extends SVGProps<SVGRectElement> {
   seqName: string
-  deletion: NucleotideDeletion
+  deletion: Span
   pixelsPerBase: number
 }
 

--- a/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
@@ -99,7 +99,7 @@ function SequenceMarkerMutationDisconnected({
             {totalAaChanges > 0 && (
               <tr>
                 <td colSpan={2}>
-                  <h6 className="mt-1">{t('Aminoacid changes nearby:')}</h6>
+                  <h6 className="mt-1">{t('Affected codons:')}</h6>
                 </td>
               </tr>
             )}

--- a/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
@@ -1,10 +1,16 @@
 import React, { SVGProps, useState } from 'react'
 
 import { useTranslation } from 'react-i18next'
+import { Row, Col, Table as ReactstrapTable } from 'reactstrap'
+import styled from 'styled-components'
+import { connect } from 'react-redux'
 
 import { BASE_MIN_WIDTH_PX } from 'src/constants'
 
-import type { NucleotideSubstitution } from 'src/algorithms/types'
+import type { Gene, NucleotideSubstitution } from 'src/algorithms/types'
+import type { State } from 'src/state/reducer'
+
+import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 
 import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
 import { formatMutation } from 'src/helpers/formatMutation'
@@ -12,31 +18,61 @@ import { formatMutation } from 'src/helpers/formatMutation'
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { ListOfPcrPrimersChanged } from 'src/components/SequenceView/ListOfPcrPrimersChanged'
+import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
+
+export const Table = styled(ReactstrapTable)`
+  & td {
+    padding: 0 0.5rem;
+  }
+
+  & tr {
+    margin: 0;
+    padding: 0;
+  }
+`
 
 export interface SequenceMarkerMutationProps extends SVGProps<SVGRectElement> {
   seqName: string
   substitution: NucleotideSubstitution
   pixelsPerBase: number
+  geneMap?: Gene[]
 }
 
-function SequenceMarkerMutationUnmemoed({
+const mapStateToProps = (state: State) => ({
+  geneMap: selectGeneMap(state),
+})
+
+const mapDispatchToProps = {}
+
+export const SequenceMarkerMutationUnmemoed = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SequenceMarkerMutationDisconnected)
+
+function SequenceMarkerMutationDisconnected({
   seqName,
   substitution,
   pixelsPerBase,
-  onClick,
+  geneMap,
   ...rest
 }: SequenceMarkerMutationProps) {
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const { pos, queryNuc, pcrPrimersChanged } = substitution
+  if (!geneMap) {
+    return null
+  }
+
+  const { pos, queryNuc, aaSubstitutions, aaDeletions, pcrPrimersChanged } = substitution
   const id = getSafeId('mutation-marker', { seqName, ...substitution })
 
   const mut = formatMutation(substitution)
 
   const fill = getNucleotideColor(queryNuc)
   const x = pos * pixelsPerBase
-  const width = Math.max(BASE_MIN_WIDTH_PX, 1 * pixelsPerBase)
+  const width = Math.max(BASE_MIN_WIDTH_PX, pixelsPerBase)
+
+  const totalAaChanges = aaSubstitutions.length + aaDeletions.length
 
   return (
     <rect
@@ -50,9 +86,59 @@ function SequenceMarkerMutationUnmemoed({
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
     >
-      <Tooltip target={id} isOpen={showTooltip}>
-        <div>{t('Nucleotide mutation: {{mutation}}', { mutation: mut })}</div>
-        <ListOfPcrPrimersChanged pcrPrimersChanged={pcrPrimersChanged} />
+      <Tooltip target={id} isOpen={showTooltip} fullWidth>
+        <Table borderless className="mb-1">
+          <thead />
+          <tbody>
+            <tr>
+              <td colSpan={2}>
+                <h6>{t('Nucleotide substitution: {{mutation}}', { mutation: mut })}</h6>
+              </td>
+            </tr>
+
+            {totalAaChanges > 0 && (
+              <tr>
+                <td colSpan={2}>
+                  <h6 className="mt-1">{t('Aminoacid changes nearby:')}</h6>
+                </td>
+              </tr>
+            )}
+
+            <>
+              {aaSubstitutions.map((mut) => (
+                <tr key={mut.codon}>
+                  <td>{t('Aminoacid substitution')}</td>
+                  <td>
+                    <AminoacidMutationBadge mutation={mut} geneMap={geneMap} />
+                  </td>
+                </tr>
+              ))}
+            </>
+
+            <>
+              {aaDeletions.map((del) => (
+                <tr key={del.queryContext}>
+                  <td>{t('Aminoacid deletion')}</td>
+                  <td>
+                    <AminoacidMutationBadge mutation={del} geneMap={geneMap} />
+                  </td>
+                </tr>
+              ))}
+            </>
+
+            <tr>
+              <td colSpan={2}>
+                {pcrPrimersChanged.length > 0 && (
+                  <Row noGutters>
+                    <Col>
+                      <ListOfPcrPrimersChanged pcrPrimersChanged={pcrPrimersChanged} />
+                    </Col>
+                  </Row>
+                )}
+              </td>
+            </tr>
+          </tbody>
+        </Table>
       </Tooltip>
     </rect>
   )

--- a/packages/web/src/components/SequenceView/groupAdjacentAminoacidChanges.ts
+++ b/packages/web/src/components/SequenceView/groupAdjacentAminoacidChanges.ts
@@ -65,8 +65,8 @@ export class AminoacidChangesGroup {
     this.codonAaRange.end = change.codon + 1
     this.codonNucRange.end = change.contextNucRange.end
     this.changes.push(change)
-    this.nucSubstitutions.concat(change.nucSubstitutions)
-    this.nucDeletions.concat(change.nucDeletions)
+    this.nucSubstitutions = this.nucSubstitutions.concat(change.nucSubstitutions)
+    this.nucDeletions = this.nucDeletions.concat(change.nucDeletions)
     this.refContext = mergeContext(this.refContext, change.refContext)
     this.queryContext = mergeContext(this.queryContext, change.queryContext)
     this.contextNucRange.end = change.contextNucRange.end

--- a/packages/web/src/components/SequenceView/groupAdjacentAminoacidChanges.ts
+++ b/packages/web/src/components/SequenceView/groupAdjacentAminoacidChanges.ts
@@ -1,7 +1,13 @@
 /* eslint-disable no-loops/no-loops,no-plusplus */
 import copy from 'fast-copy'
 import { AMINOACID_GAP } from 'src/constants'
-import type { AminoacidDeletion, AminoacidSubstitution, Range } from 'src/algorithms/types'
+import type {
+  AminoacidDeletion,
+  AminoacidSubstitution,
+  Range,
+  NucleotideDeletion,
+  NucleotideSubstitution,
+} from 'src/algorithms/types'
 
 import { sumBy } from 'lodash'
 
@@ -24,6 +30,8 @@ export class AminoacidChangesGroup {
   public codonAaRange: Range
   public codonNucRange: Range
   public changes: AminoacidChange[]
+  public nucSubstitutions: NucleotideSubstitution[]
+  public nucDeletions: NucleotideDeletion[]
   public refContext: string
   public queryContext: string
   public contextNucRange: Range
@@ -40,6 +48,8 @@ export class AminoacidChangesGroup {
     this.codonAaRange = { begin: change.codon, end: change.codon + 1 }
     this.codonNucRange = copy(change.codonNucRange)
     this.changes = [copy(change)]
+    this.nucSubstitutions = copy(change.nucSubstitutions)
+    this.nucDeletions = copy(change.nucDeletions)
     this.queryContext = change.queryContext
     this.refContext = copy(change.refContext)
     this.contextNucRange = copy(change.contextNucRange)
@@ -55,6 +65,8 @@ export class AminoacidChangesGroup {
     this.codonAaRange.end = change.codon + 1
     this.codonNucRange.end = change.contextNucRange.end
     this.changes.push(change)
+    this.nucSubstitutions.concat(change.nucSubstitutions)
+    this.nucDeletions.concat(change.nucDeletions)
     this.refContext = mergeContext(this.refContext, change.refContext)
     this.queryContext = mergeContext(this.queryContext, change.queryContext)
     this.contextNucRange.end = change.contextNucRange.end

--- a/packages/web/src/components/SequenceView/groupAdjacentAminoacidChanges.ts
+++ b/packages/web/src/components/SequenceView/groupAdjacentAminoacidChanges.ts
@@ -9,7 +9,7 @@ import type {
   NucleotideSubstitution,
 } from 'src/algorithms/types'
 
-import { sumBy } from 'lodash'
+import { sumBy, uniqBy } from 'lodash'
 
 export interface AminoacidChange extends AminoacidSubstitution {
   type: 'substitution' | 'deletion'
@@ -65,11 +65,16 @@ export class AminoacidChangesGroup {
     this.codonAaRange.end = change.codon + 1
     this.codonNucRange.end = change.contextNucRange.end
     this.changes.push(change)
-    this.nucSubstitutions = this.nucSubstitutions.concat(change.nucSubstitutions)
-    this.nucDeletions = this.nucDeletions.concat(change.nucDeletions)
     this.refContext = mergeContext(this.refContext, change.refContext)
     this.queryContext = mergeContext(this.queryContext, change.queryContext)
     this.contextNucRange.end = change.contextNucRange.end
+
+    this.nucSubstitutions = this.nucSubstitutions.concat(change.nucSubstitutions)
+    this.nucSubstitutions = uniqBy(this.nucSubstitutions, (sub) => sub.pos)
+
+    this.nucDeletions = this.nucDeletions.concat(change.nucDeletions)
+    this.nucDeletions = uniqBy(this.nucDeletions, (del) => del.start)
+
     this.updateCounts()
   }
 }


### PR DESCRIPTION
Here we establish a many-to-many relation between aminoacid changes (substitutions, deletions) and nucleotide changes (substitutions, deletions).

We group changes by positions:
 - nucleotide substitution is related to aminoacid change iff nucleotide position is within the codon nucleotide range of that aminoacid
 - nucleotide deletion is related to aminoacid change iff nucleotide deletion range intersects the codon nucleotide range of that aminoacid

We only state the fact of spatial locality of these changes and we say nothing about the causal relations between nucleotide changes and aminoacid changes, as this can not always be easily deduced from sequences only.

This data is automatically propagated to JSON result output and to the web app.


Here is what it looks like in the app:

In nucleotide change tooltips:

![01](https://user-images.githubusercontent.com/9403403/121357722-4ea64780-c932-11eb-8385-033c2434043c.png)

![02](https://user-images.githubusercontent.com/9403403/121357732-51a13800-c932-11eb-9e25-929ea75eea68.png)


In aminoacid change tooltips:

![03](https://user-images.githubusercontent.com/9403403/121357782-5c5bcd00-c932-11eb-9e16-256d2c777840.png)

![04](https://user-images.githubusercontent.com/9403403/121357793-5ebe2700-c932-11eb-8753-b0db0f5b01f1.png)

![05](https://user-images.githubusercontent.com/9403403/121357806-6087ea80-c932-11eb-8ca7-3b271fb76c55.png)

