### PR TITLE
BREAKING CHANGE Wrap results json in an object, add properties

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -333,6 +333,14 @@ namespace Nextclade {
     QcResult qc;
   };
 
+
+  struct AnalysisResults {
+    std::string schemaVersion;
+    std::string nextcladeVersion;
+    std::uint64_t timestamp;
+    std::vector<Nextclade::AnalysisResult> results;
+  };
+
   struct NextcladeResult {
     std::string ref;
     std::string query;
@@ -442,7 +450,7 @@ namespace Nextclade {
 
   std::vector<PcrPrimerCsvRow> parsePcrPrimerCsvRowsStr(const std::string& pcrPrimerCsvRowsStr);
 
-  std::vector<AnalysisResult> parseAnalysisResults(const std::string& analysisResultsStr);
+  AnalysisResults parseAnalysisResults(const std::string& analysisResultsStr);
 
   std::string serializePcrPrimerRowsToString(const std::vector<PcrPrimerCsvRow>& pcrPrimers);
 

--- a/packages/nextclade/src/io/parseAnalysisResults.cpp
+++ b/packages/nextclade/src/io/parseAnalysisResults.cpp
@@ -23,7 +23,7 @@ namespace Nextclade {
   public:
     explicit ErrorAnalysisResultsRootTypeInvalid(const std::string& type)
         : ErrorNonFatal(fmt::format(
-            "When parsing analysis results JSON: Expected to find an array as the root entry, but found \"{:s}\"",
+            "When parsing analysis results JSON: Expected to find an object as the root entry, but found \"{:s}\"",
             type)) {}
   };
 
@@ -312,12 +312,18 @@ namespace Nextclade {
     };
   }
 
-  std::vector<Nextclade::AnalysisResult> parseAnalysisResults(const std::string& analysisResultsStr) {
+  AnalysisResults parseAnalysisResults(const std::string& analysisResultsStr) {
     const auto j = json::parse(analysisResultsStr);
-    if (!j.is_array()) {
+    if (!j.is_object()) {
       throw ErrorAnalysisResultsRootTypeInvalid(j.type_name());
     }
-    return parseArray<AnalysisResult>(j, parseAnalysisResult);
+
+    return AnalysisResults{
+      .schemaVersion = at(j, "schemaVersion"),
+      .nextcladeVersion = at(j, "nextcladeVersion"),
+      .timestamp = at(j, "timestamp"),
+      .results = parseArray<AnalysisResult>(j, "results", parseAnalysisResult),
+    };
   }
 
   PcrPrimerCsvRow parsePcrPrimerCsvRow(const json& j) {

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -3,6 +3,7 @@
 #include <nextclade/nextclade.h>
 #include <nextclade/private/nextclade_private.h>
 
+#include <chrono>
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -282,11 +283,26 @@ namespace Nextclade {
     return jsonStringify(j);
   }
 
-  std::string serializeResults(const std::vector<AnalysisResult>& results) {
+  json serializeResultsArray(const std::vector<AnalysisResult>& results) {
     auto j = json::array();
     for (const auto& result : results) {
       j.emplace_back(serializeResult(result));
     }
+    return j;
+  }
+
+  auto getTimestampNow() {
+    const auto p1 = std::chrono::system_clock::now();
+    return std::chrono::duration_cast<std::chrono::seconds>(p1.time_since_epoch()).count();
+  }
+
+  std::string serializeResults(const std::vector<AnalysisResult>& results) {
+    const std::string SCHEMA_VERSION = "1.0.0";
+    auto j = json::object();
+    j.emplace("schemaVersion", SCHEMA_VERSION);
+    j.emplace("nextcladeVersion", Nextclade::getVersion());
+    j.emplace("timestamp", getTimestampNow());
+    j.emplace("results", serializeResultsArray(results));
     return jsonStringify(j);
   }
 

--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -199,6 +199,16 @@ std::string treeFinalize(const std::string& treeStr, const std::string& refStr, 
   return tree.serialize(0);
 }
 
+std::string serializeToCsv(const std::string& analysisResultsStr, const std::string& delimiter) {
+  const auto analysisResults = Nextclade::parseAnalysisResults(analysisResultsStr);
+  std::stringstream outputCsvStream;
+  Nextclade::CsvWriter csv{outputCsvStream, Nextclade::CsvWriterOptions{.delimiter = delimiter[0]}};
+  for (const auto& result : analysisResults.results) {
+    csv.addRow(result);
+  }
+  return outputCsvStream.str();
+}
+
 // NOLINTNEXTLINE(cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)
 EMSCRIPTEN_BINDINGS(nextclade_wasm) {
   emscripten::register_vector<std::string>("std::vector<std::string>");
@@ -238,4 +248,6 @@ EMSCRIPTEN_BINDINGS(nextclade_wasm) {
   emscripten::function("parseRefSequence", &parseRefSequence);
   emscripten::function("parseSequencesStreaming", &parseSequencesStreaming);
   emscripten::function("treeFinalize", &treeFinalize);
+
+  emscripten::function("serializeToCsv", &serializeToCsv);
 }

--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -194,7 +194,7 @@ std::string treeFinalize(const std::string& treeStr, const std::string& refStr, 
   const auto ref = toNucleotideSequence(refStr);
   const auto analysisResults = Nextclade::parseAnalysisResults(analysisResultsStr);
   auto tree = Nextclade::Tree{treeStr};
-  treeAttachNodes(tree, ref, analysisResults);
+  treeAttachNodes(tree, ref, analysisResults.results);
   treePostprocess(tree);
   return tree.serialize(0);
 }

--- a/packages/web/src/io/serializeResults.ts
+++ b/packages/web/src/io/serializeResults.ts
@@ -1,127 +1,42 @@
 import type { StrictOmit } from 'ts-essentials'
-import { omit, unset } from 'lodash'
-import jsonexport from 'jsonexport'
 
 import type { AnalysisResult } from 'src/algorithms/types'
 import type { SequenceAnalysisState } from 'src/state/algorithm/algorithm.state'
-import { formatAADeletion, formatAAMutation, formatMutation } from 'src/helpers/formatMutation'
-import { formatRange } from 'src/helpers/formatRange'
-import { formatInsertion } from 'src/helpers/formatInsertion'
-import { formatNonAcgtn } from 'src/helpers/formatNonAcgtn'
-import { formatPrimer } from 'src/helpers/formatPrimer'
-import { formatSnpCluster } from 'src/helpers/formatSnpCluster'
-
-const CSV_EOL = '\r\n'
-
-const headers = [
-  'seqName',
-  'clade',
-  'qc.overallScore',
-  'qc.overallStatus',
-  'totalGaps',
-  'totalInsertions',
-  'totalMissing',
-  'totalMutations',
-  'totalNonACGTNs',
-  'totalPcrPrimerChanges',
-  'substitutions',
-  'deletions',
-  'insertions',
-  'missing',
-  'nonACGTNs',
-  'pcrPrimerChanges',
-  'aaSubstitutions',
-  'totalAminoacidSubstitutions',
-  'aaDeletions',
-  'totalAminoacidDeletions',
-  'alignmentEnd',
-  'alignmentScore',
-  'alignmentStart',
-  'qc.missingData.missingDataThreshold',
-  'qc.missingData.score',
-  'qc.missingData.status',
-  'qc.missingData.totalMissing',
-  'qc.mixedSites.mixedSitesThreshold',
-  'qc.mixedSites.score',
-  'qc.mixedSites.status',
-  'qc.mixedSites.totalMixedSites',
-  'qc.privateMutations.cutoff',
-  'qc.privateMutations.excess',
-  'qc.privateMutations.score',
-  'qc.privateMutations.status',
-  'qc.privateMutations.total',
-  'qc.snpClusters.clusteredSNPs',
-  'qc.snpClusters.score',
-  'qc.snpClusters.status',
-  'qc.snpClusters.totalSNPs',
-  'errors',
-]
+import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 
 export type AnalysisResultWithErrors = AnalysisResult & { errors: string[] }
-export type Exportable = StrictOmit<AnalysisResult, 'alignedQuery' | 'nucleotideComposition'>
 
-export function prepareResultJson(result: AnalysisResultWithErrors): Exportable {
-  return omit(result, ['alignedQuery', 'nucleotideComposition'])
+export interface Exportable extends StrictOmit<AnalysisResult, 'alignedQuery' | 'nucleotideComposition'> {
+  errors: string
+}
+
+export function serializeResults(analysisResults: AnalysisResult[]) {
+  // eslint-disable-next-line prefer-destructuring
+  const PACKAGE_VERSION = process.env.PACKAGE_VERSION
+
+  const finalResult = {
+    schemaVersion: '1.0.0',
+    nextcladeVersion: PACKAGE_VERSION,
+    timestamp: Math.floor(Date.now() / 1000),
+    results: analysisResults,
+  }
+
+  return JSON.stringify(finalResult, null, 2)
 }
 
 export function prepareResultsJson(results: SequenceAnalysisState[]) {
-  return results.map(({ seqName, status, errors, result }) => {
-    if (!result) {
-      return { seqName, errors }
-    }
-
-    const datum = prepareResultJson({ ...result, errors: [] })
-    unset(datum, 'qc.seqName')
-    return datum
-  })
+  return results
+    .map(({ result }) => {
+      if (!result) {
+        return undefined
+      }
+      return result
+    })
+    .filter(notUndefinedOrNull)
 }
 
 export function serializeResultsToJson(results: SequenceAnalysisState[]) {
   const data = prepareResultsJson(results)
-  const str = JSON.stringify(data, null, 2)
+  const str = serializeResults(data)
   return `${str}\n`
-}
-
-export function prepareResultCsv(datum: Exportable) {
-  return {
-    ...datum,
-    qc: {
-      ...datum.qc,
-      snpClusters: {
-        ...(datum.qc?.snpClusters ?? {}),
-        clusteredSNPs: datum.qc?.snpClusters?.clusteredSNPs.map(formatSnpCluster).join(','),
-      },
-    },
-    substitutions: datum.substitutions.map((mut) => formatMutation(mut)).join(','),
-    aaSubstitutions: datum.aaSubstitutions.map((mut) => formatAAMutation(mut)).join(','),
-    aaDeletions: datum.aaDeletions.map((del) => formatAADeletion(del)).join(','),
-    deletions: datum.deletions.map(({ start, length }) => formatRange(start, start + length)).join(','),
-    insertions: datum.insertions.map((ins) => formatInsertion(ins)).join(','),
-    missing: datum.missing.map(({ begin, end }) => formatRange(begin, end)).join(','),
-    nonACGTNs: datum.nonACGTNs.map((nacgtn) => formatNonAcgtn(nacgtn)).join(','),
-    pcrPrimerChanges: datum.pcrPrimerChanges.map(formatPrimer).join(','),
-  }
-}
-
-export function prepareResultCsvCladesOnly(datum: Exportable) {
-  const { seqName, clade } = datum
-  return { seqName, clade }
-}
-
-export async function toCsvString(data: Array<unknown> | Record<string, unknown>, delimiter: string) {
-  const csv = await jsonexport(data, { headers, rowDelimiter: delimiter, endOfLine: CSV_EOL })
-  return `${csv}${CSV_EOL}`
-}
-
-export async function serializeResultsToCsv(results: SequenceAnalysisState[], delimiter: string) {
-  const data = results.map(({ seqName, status, errors, result }) => {
-    if (!result) {
-      return { seqName, errors: errors.map((e) => `"${e}"`).join(',') }
-    }
-
-    const datum = prepareResultJson({ ...result, errors: [] })
-    return prepareResultCsv(datum)
-  })
-
-  return toCsvString(data, delimiter)
 }

--- a/packages/web/src/state/algorithm/algorithmExport.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmExport.sagas.ts
@@ -4,7 +4,7 @@ import { call, select, takeEvery } from 'typed-redux-saga'
 import type { ZipFileDescription } from 'src/helpers/saveFile'
 
 import { saveFile, saveZip } from 'src/helpers/saveFile'
-import { serializeResultsToCsv, serializeResultsToJson } from 'src/io/serializeResults'
+import { serializeResults, serializeResultsToJson } from 'src/io/serializeResults'
 import {
   exportAll,
   exportCsvTrigger,
@@ -20,13 +20,17 @@ import {
   selectOutputSequences,
   selectOutputTree,
   selectResults,
+  selectResultsArray,
 } from 'src/state/algorithm/algorithm.selectors'
 import fsaSaga from 'src/state/util/fsaSaga'
 import { notUndefinedOrNull } from 'src/helpers/notUndefined'
+import { serializeToCsv } from 'src/workers/run'
 
 export function* prepareResultsCsvStr() {
-  const results = yield* select(selectResults)
-  return yield* call(serializeResultsToCsv, results, ';')
+  const results = yield* select(selectResultsArray)
+  const resultsGood = results.filter(notUndefinedOrNull)
+  const resultsGoodStr = serializeResults(resultsGood)
+  return yield* call(serializeToCsv, resultsGoodStr, ';')
 }
 
 export function* exportCsv() {
@@ -36,8 +40,10 @@ export function* exportCsv() {
 }
 
 export function* prepareResultsTsvStr() {
-  const results = yield* select(selectResults)
-  return yield* call(serializeResultsToCsv, results, '\t')
+  const results = yield* select(selectResultsArray)
+  const resultsGood = results.filter(notUndefinedOrNull)
+  const resultsGoodStr = serializeResults(resultsGood)
+  return yield* call(serializeToCsv, resultsGoodStr, '\t')
 }
 
 export function* exportTsv() {

--- a/packages/web/src/state/algorithm/algorithmRun.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmRun.sagas.ts
@@ -59,6 +59,7 @@ import { selectNumThreads } from 'src/state/settings/settings.selectors'
 import { prepareGeneMap } from 'src/io/prepareGeneMap'
 import { errorAdd } from 'src/state/error/error.actions'
 import { sanitizeError } from 'src/helpers/sanitizeError'
+import { serializeResults } from 'src/io/serializeResults'
 
 export interface SequenceParserChannelElement {
   seq?: SequenceParserResult
@@ -430,7 +431,7 @@ export function* runAlgorithm(queryInput?: AlgorithmInput) {
     .map((nextcladeResult) => nextcladeResult.analysisResult)
 
   if (analysisResults.length > 0) {
-    const analysisResultsStr = JSON.stringify(analysisResults)
+    const analysisResultsStr = serializeResults(analysisResults)
 
     yield* put(setAlgorithmGlobalStatus(AlgorithmGlobalStatus.buildingTree))
     const treeFinalStr = yield* call(treeFinalize, treePreparedStr, refStr, analysisResultsStr)

--- a/packages/web/src/workers/run.ts
+++ b/packages/web/src/workers/run.ts
@@ -12,6 +12,7 @@ import type { ParseRefSequenceThread } from 'src/workers/worker.parseRefSeq'
 import type { ParseSequencesStreamingThread } from 'src/workers/worker.parseSequencesStreaming'
 import type { TreeFinalizeThread } from 'src/workers/worker.treeFinalize'
 import type { TreePrepareThread } from 'src/workers/worker.treePrepare'
+import type { SerializeToCsvThread } from 'src/workers/worker.serializeToCsv'
 
 /**
  * Creates and initializes the analysis webworker pool.
@@ -134,4 +135,11 @@ export async function treeFinalize(treePreparedStr: string, refStr: string, anal
     new Worker('src/workers/worker.treeFinalize.ts', { name: 'worker.treeFinalize' }),
   )
   return thread.treeFinalize(treePreparedStr, refStr, analysisResultsStr)
+}
+
+export async function serializeToCsv(analysisResultsStr: string, delimiter: string) {
+  const thread = await spawn<SerializeToCsvThread>(
+    new Worker('src/workers/worker.serializeToCsv.ts', { name: 'worker.serializeToCsv' }),
+  )
+  return thread.serializeToCsv(analysisResultsStr, delimiter)
 }

--- a/packages/web/src/workers/worker.serializeToCsv.ts
+++ b/packages/web/src/workers/worker.serializeToCsv.ts
@@ -1,0 +1,22 @@
+import 'regenerator-runtime'
+
+import { expose } from 'threads/worker'
+
+import { loadWasmModule, runWasmModule, WasmModule } from 'src/workers/wasmModule'
+
+export interface SerializeToCsvWasmModule extends WasmModule {
+  serializeToCsv(analysisResultsStr: string, delimiter: string): string
+}
+
+export async function serializeToCsv(analysisResultsStr: string, delimiter: string) {
+  const module = await loadWasmModule<SerializeToCsvWasmModule>('nextclade_wasm')
+  return runWasmModule<SerializeToCsvWasmModule, string>(module, (module) => {
+    return module.serializeToCsv(analysisResultsStr, delimiter)
+  })
+}
+
+const serializeToCsvWorker = { serializeToCsv }
+export type SerializeToCsvWorker = typeof serializeToCsvWorker
+export type SerializeToCsvThread = SerializeToCsvWorker
+
+expose(serializeToCsvWorker)


### PR DESCRIPTION
Resolves #395

This transforms root of the JSON output file (`nextclade.json`) from array to object.

The old array of results is now at `results` property.
Timestamp of the run, schema and Nextclade version are added as properties of the root object. This should help extending the format of this file in the future

Related #212 
 