### PR TITLE
Display warnings when a gene is missing in sequence view

### DIFF
--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -21,6 +21,15 @@ enum class Status : int {
   Error = 1,
 };
 
+struct GeneWarning {
+  std::string geneName;
+  std::string message;
+};
+
+struct Warnings {
+  std::vector<std::string> global;
+  std::vector<GeneWarning> inGenes;
+};
 
 class Error : public std::runtime_error {
 public:
@@ -197,7 +206,7 @@ struct NextalignResult {
   std::vector<Peptide> refPeptides;
   std::vector<Peptide> queryPeptides;
   std::vector<Insertion> insertions;
-  std::vector<std::string> warnings;
+  Warnings warnings;
 };
 
 struct AlgorithmOutput {

--- a/packages/nextalign/include/nextalign/private/nextalign_private.h
+++ b/packages/nextalign/include/nextalign/private/nextalign_private.h
@@ -30,7 +30,7 @@ struct NextalignResultInternal {
   std::vector<PeptideInternal> refPeptides;
   std::vector<PeptideInternal> queryPeptides;
   std::vector<InsertionInternal<Nucleotide>> insertions;
-  std::vector<std::string> warnings;
+  Warnings warnings;
 };
 
 Nucleotide toNucleotide(char nuc);

--- a/packages/nextalign/src/nextalign.cpp
+++ b/packages/nextalign/src/nextalign.cpp
@@ -45,13 +45,14 @@ NextalignResultInternal nextalignInternal(const NucleotideSequence& query, const
 
   std::vector<PeptideInternal> queryPeptides;
   std::vector<PeptideInternal> refPeptides;
-  std::vector<std::string> warnings;
+  Warnings warnings;
   if (!geneMap.empty()) {
     auto peptidesInternal =
       translateGenes(alignmentStatus.result->query, alignmentStatus.result->ref, geneMap, gapOpenCloseAA, options);
     concat_move(peptidesInternal.queryPeptides, queryPeptides);
     concat_move(peptidesInternal.refPeptides, refPeptides);
-    concat_move(peptidesInternal.warnings, warnings);
+    concat_move(peptidesInternal.warnings.global, warnings.global);
+    concat_move(peptidesInternal.warnings.inGenes, warnings.inGenes);
   }
 
   const auto stripped = stripInsertions(alignmentStatus.result->ref, alignmentStatus.result->query);

--- a/packages/nextalign/src/translate/translateGenes.h
+++ b/packages/nextalign/src/translate/translateGenes.h
@@ -9,7 +9,7 @@
 struct PeptidesInternal {
   std::vector<PeptideInternal> queryPeptides;
   std::vector<PeptideInternal> refPeptides;
-  std::vector<std::string> warnings;
+  Warnings warnings;
 };
 
 PeptidesInternal translateGenes(         //

--- a/packages/nextclade/CMakeLists.txt
+++ b/packages/nextclade/CMakeLists.txt
@@ -87,6 +87,8 @@ set(SOURCE_FILES
   src/tree/treePostprocess.h
   src/tree/treePreprocess.cpp
   src/tree/treePreprocess.h
+  src/utils/concat.h
+  src/utils/concat_move.h
   src/utils/config.h
   src/utils/contains.h
   src/utils/contract.h

--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -341,12 +341,13 @@ namespace Nextclade {
     std::vector<Nextclade::AnalysisResult> results;
   };
 
+
   struct NextcladeResult {
     std::string ref;
     std::string query;
     std::vector<Peptide> refPeptides;
     std::vector<Peptide> queryPeptides;
-    std::vector<std::string> warnings;
+    Warnings warnings;
     AnalysisResult analysisResult;
   };
 
@@ -453,6 +454,8 @@ namespace Nextclade {
   AnalysisResults parseAnalysisResults(const std::string& analysisResultsStr);
 
   std::string serializePcrPrimerRowsToString(const std::vector<PcrPrimerCsvRow>& pcrPrimers);
+
+  std::string serializeWarningsToString(const Warnings& warnings);
 
   std::string serializeGeneMap(const GeneMap& geneMap);
 

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -23,6 +23,11 @@ namespace Nextclade {
       return j;
     }
 
+    json serializeString(const std::string& s) {
+      return json{s};
+    }
+
+
     json serializeRange(const Range& range) {
       auto j = json::object();
       j.emplace("begin", range.begin);
@@ -317,6 +322,20 @@ namespace Nextclade {
 
   std::string serializePcrPrimerRowsToString(const std::vector<PcrPrimerCsvRow>& pcrPrimers) {
     json j = serializeArray(pcrPrimers, serializePcrPrimerCsvRow);
+    return jsonStringify(j);
+  }
+
+  json serializeGeneWarning(const GeneWarning& geneWarning) {
+    auto j = json::object();
+    j.emplace("geneName", geneWarning.geneName);
+    j.emplace("message", geneWarning.message);
+    return j;
+  }
+
+  std::string serializeWarningsToString(const Warnings& warnings) {
+    auto j = json::object();
+    j.emplace("global", serializeArray(warnings.global, serializeString));
+    j.emplace("inGenes", serializeArray(warnings.inGenes, serializeGeneWarning));
     return jsonStringify(j);
   }
 

--- a/packages/nextclade/src/utils/concat.h
+++ b/packages/nextclade/src/utils/concat.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <vector>
+
+/**
+ * Marge contents of two vectors. A new vector is created and all items are copied.
+ */
+template<typename T>
+inline std::vector<T> merge(const std::vector<T>& one, const std::vector<T>& two) {
+  std::vector<T> result;
+  std::copy(one.begin(), one.end(), std::back_inserter(result));
+  std::copy(two.begin(), two.end(), std::back_inserter(result));
+  return result;
+}

--- a/packages/nextclade/src/utils/concat_move.h
+++ b/packages/nextclade/src/utils/concat_move.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <vector>
+
+/**
+ * Appends contents of the `from` vector to the end of the `to` vector without copying.
+ * The contents of the `from` vector is invalidated and is no longer safe to use.
+ */
+template<typename T>
+inline void concat_move(std::vector<T>& from, std::vector<T>& to) {
+  to.insert(to.end(), std::make_move_iterator(from.begin()), std::make_move_iterator(from.end()));
+}

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -255,3 +255,13 @@ export interface SequenceParserResult {
   seqName: string
   seq: string
 }
+
+export interface GeneWarning {
+  geneName: string
+  message: string
+}
+
+export interface Warnings {
+  global: string[]
+  inGenes: GeneWarning[]
+}

--- a/packages/web/src/components/Results/ColumnName.tsx
+++ b/packages/web/src/components/Results/ColumnName.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import styled from 'styled-components'
 
-import type { AnalysisResult } from 'src/algorithms/types'
+import type { AnalysisResult, Warnings } from 'src/algorithms/types'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 
@@ -18,7 +18,7 @@ export const SequenceName = styled.div`
 export interface ColumnNameProps {
   seqName: string
   sequence?: AnalysisResult
-  warnings: string[]
+  warnings: Warnings
   errors: string[]
 }
 
@@ -28,10 +28,12 @@ export function ColumnName({ seqName, sequence, warnings, errors }: ColumnNamePr
   const [showTooltip, setShowTooltip] = useState(false)
   const id = getSafeId('sequence-label', { seqName })
 
+  const allWarnings = warnings.global.concat(warnings.inGenes.map((warn) => warn.message))
+
   const { StatusIcon } = getStatusIconAndText({
     t,
     isDone: !!sequence,
-    hasWarnings: warnings.length > 0,
+    hasWarnings: allWarnings.length > 0,
     hasErrors: errors.length > 0,
   })
 
@@ -46,7 +48,7 @@ export function ColumnName({ seqName, sequence, warnings, errors }: ColumnNamePr
       {seqName}
       {
         <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
-          <ColumnNameTooltip seqName={seqName} result={sequence} warnings={warnings} errors={errors} />
+          <ColumnNameTooltip seqName={seqName} result={sequence} warnings={allWarnings} errors={errors} />
         </Tooltip>
       }
     </SequenceName>

--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -244,7 +244,7 @@ function TableRowComponent({ index, style, data }: RowProps) {
         {viewedGene === GENE_OPTION_NUC_SEQUENCE ? (
           <SequenceView key={seqName} sequence={sequence} />
         ) : (
-          <PeptideView key={seqName} sequence={sequence} viewedGene={viewedGene} />
+          <PeptideView key={seqName} sequence={sequence} viewedGene={viewedGene} warnings={warnings} />
         )}
       </TableCell>
     </TableRow>

--- a/packages/web/src/components/SequenceView/PeptideView.tsx
+++ b/packages/web/src/components/SequenceView/PeptideView.tsx
@@ -1,20 +1,78 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { connect } from 'react-redux'
 import { ReactResizeDetectorDimensions, withResizeDetector } from 'react-resize-detector'
+import { Alert as ReactstrapAlert } from 'reactstrap'
+import styled from 'styled-components'
 
-import type { AnalysisResult, Gene } from 'src/algorithms/types'
+import type { AnalysisResult, Gene, GeneWarning, Warnings } from 'src/algorithms/types'
 import type { State } from 'src/state/reducer'
 import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { getSafeId } from 'src/helpers/getSafeId'
+
+import { WarningIcon } from 'src/components/Results/getStatusIconAndText'
+import { Tooltip } from 'src/components/Results/Tooltip'
 
 import { PeptideMarkerMutationGroup } from './PeptideMarkerMutationGroup'
 import { SequenceViewWrapper, SequenceViewSVG } from './SequenceView'
 import { groupAdjacentAminoacidChanges } from './groupAdjacentAminoacidChanges'
 import { PeptideMarkerUnknown } from './PeptideMarkerUnknown'
 
+const MissingRow = styled.div`
+  background-color: ${(props) => props.theme.gray650};
+  color: ${(props) => props.theme.gray100};
+  margin: auto;
+  cursor: pointer;
+  box-shadow: 2px 2px 5px #0005 inset;
+`
+
+const Alert = styled(ReactstrapAlert)`
+  box-shadow: ${(props) => props.theme.shadows.slight};
+  max-width: 400px;
+`
+
+export interface PeptideViewMissingProps {
+  geneName: string
+  reasons: GeneWarning[]
+}
+
+export function PeptideViewMissing({ geneName, reasons }: PeptideViewMissingProps) {
+  const { t } = useTranslationSafe()
+  const [showTooltip, setShowTooltip] = useState(false)
+  const id = getSafeId('sequence-label', { geneName })
+
+  return (
+    <MissingRow
+      id={id}
+      className="w-100 h-100 d-flex"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <span className="m-auto">{t('Gene "{{ geneName }}" is missing', { geneName })}</span>
+      <Tooltip
+        wide
+        fullWidth
+        target={id}
+        isOpen={showTooltip}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        <p>{t('This gene is missing due to the following errors during analysis: ')}</p>
+        {reasons.map((warn) => (
+          <Alert key={warn.geneName} color="warning" fade={false} className="px-2 py-1 my-1">
+            <WarningIcon />
+            {warn.message}
+          </Alert>
+        ))}
+      </Tooltip>
+    </MissingRow>
+  )
+}
+
 export interface PeptideViewProps extends ReactResizeDetectorDimensions {
   sequence: AnalysisResult
+  warnings: Warnings
   geneMap?: Gene[]
   viewedGene: string
 }
@@ -26,7 +84,7 @@ const mapDispatchToProps = {}
 
 export const PeptideViewUnsized = connect(mapStateToProps, mapDispatchToProps)(PeptideViewUnsizedDisconnected)
 
-export function PeptideViewUnsizedDisconnected({ width, sequence, geneMap, viewedGene }: PeptideViewProps) {
+export function PeptideViewUnsizedDisconnected({ width, sequence, warnings, geneMap, viewedGene }: PeptideViewProps) {
   const { t } = useTranslationSafe()
 
   if (!width || !geneMap) {
@@ -42,6 +100,15 @@ export function PeptideViewUnsizedDisconnected({ width, sequence, geneMap, viewe
     return (
       <SequenceViewWrapper>
         {t('Gene {{geneName}} is missing in gene map', { geneName: viewedGene })}
+      </SequenceViewWrapper>
+    )
+  }
+
+  const warningsForThisGene = warnings.inGenes.filter((warn) => warn.geneName === viewedGene)
+  if (warningsForThisGene.length > 0) {
+    return (
+      <SequenceViewWrapper>
+        <PeptideViewMissing geneName={gene.geneName} reasons={warningsForThisGene} />
       </SequenceViewWrapper>
     )
   }

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -55,7 +55,7 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
       result: undefined,
       query: undefined,
       queryPeptides: undefined,
-      warnings: [],
+      warnings: { global: [], inGenes: [] },
       errors: [],
     }
     draft.resultsFiltered = runFilters(current(draft))

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -1,4 +1,4 @@
-import type { Virus, AnalysisResult, Gene, Peptide } from 'src/algorithms/types'
+import type { Virus, AnalysisResult, Gene, Peptide, Warnings } from 'src/algorithms/types'
 import type { Sorting } from 'src/helpers/sortResults'
 import type { QCFilters } from 'src/filtering/filterByQCIssues'
 import { getVirus } from 'src/algorithms/defaults/viruses'
@@ -28,7 +28,7 @@ export interface SequenceAnalysisState {
   result?: AnalysisResult
   query?: string
   queryPeptides?: Peptide[]
-  warnings: string[]
+  warnings: Warnings
   errors: string[]
 }
 

--- a/packages/web/src/workers/worker.analyze.ts
+++ b/packages/web/src/workers/worker.analyze.ts
@@ -3,9 +3,9 @@ import 'regenerator-runtime'
 import type { Thread } from 'threads'
 import { expose } from 'threads/worker'
 
-import type { AnalysisResult, Peptide, SequenceParserResult } from 'src/algorithms/types'
-import type { Vector, WasmModule } from './wasmModule'
-import { loadWasmModule, runWasmModule, vectorToArray } from './wasmModule'
+import type { AnalysisResult, Peptide, SequenceParserResult, Warnings } from 'src/algorithms/types'
+import type { WasmModule } from './wasmModule'
+import { loadWasmModule, runWasmModule } from './wasmModule'
 
 export interface NextcladeWasmParams {
   refStr: string
@@ -24,7 +24,7 @@ export interface NextcladeWasmResult {
   query: string
   queryPeptides: string
   analysisResult: string
-  warnings: Vector<string>
+  warnings: string
   hasError: boolean
   error: string
 }
@@ -35,7 +35,7 @@ export interface NextcladeResult {
   query: string
   queryPeptides: Peptide[]
   analysisResult: AnalysisResult
-  warnings: string[]
+  warnings: Warnings
   hasError: boolean
   error: string
 }
@@ -108,7 +108,7 @@ export async function analyze(seq: SequenceParserResult) {
   return runWasmModule<NextcladeAnalysisModule, NextcladeResult>(gModule, () => {
     const result = nextcladeWasm.analyze(seq.seqName, seq.seq)
 
-    const warnings = vectorToArray(result.warnings)
+    const warnings = JSON.parse(result.warnings) as Warnings
 
     if (result.hasError) {
       return {


### PR DESCRIPTION
Previously a blank row was being displayed in sequence view for a gene, when that gene was missing, for example due to failed translation. 

It was hard to distinguish genes with no mutations and failed genes.

This adds:
 - row coloring - dark grey
 - a message that the gene is missing
 - a tooltip with reasons of why that gene might be missing 

Resolves: https://github.com/nextstrain/nextclade/issues/441

![01](https://user-images.githubusercontent.com/9403403/121888419-41b19b80-cd18-11eb-8001-811ea26db32f.png)
