### PR TITLE
Add insertions CSV file to download dialog

### DIFF
--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -214,6 +214,18 @@ std::string serializeToCsv(const std::string& analysisResultsStr, const std::str
   return outputCsvStream.str();
 }
 
+std::string serializeInsertionsToCsv(const std::string& analysisResultsStr) {
+  const auto analysisResults = Nextclade::parseAnalysisResults(analysisResultsStr);
+  std::stringstream outputInsertionsStream;
+  outputInsertionsStream << "seqName,insertions\n";
+  for (const auto& result : analysisResults.results) {
+    const auto& seqName = result.seqName;
+    const auto& insertions = result.insertions;
+    outputInsertionsStream << fmt::format("\"{:s}\",\"{:s}\"\n", seqName, Nextclade::formatInsertions(insertions));
+  }
+  return outputInsertionsStream.str();
+}
+
 // NOLINTNEXTLINE(cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)
 EMSCRIPTEN_BINDINGS(nextclade_wasm) {
   emscripten::function("getExceptionMessage", &getExceptionMessage);
@@ -253,4 +265,5 @@ EMSCRIPTEN_BINDINGS(nextclade_wasm) {
   emscripten::function("treeFinalize", &treeFinalize);
 
   emscripten::function("serializeToCsv", &serializeToCsv);
+  emscripten::function("serializeInsertionsToCsv", &serializeInsertionsToCsv);
 }

--- a/packages/web/src/components/Results/ExportDialogButton.tsx
+++ b/packages/web/src/components/Results/ExportDialogButton.tsx
@@ -28,6 +28,7 @@ import {
   exportPeptides,
   exportTreeJsonTrigger,
   exportTsvTrigger,
+  exportInsertionsCsvTrigger,
 } from 'src/state/algorithm/algorithm.actions'
 import {
   FileIconCsv,
@@ -99,6 +100,7 @@ export interface ExportDialogButtonProps {
   exportPeptidesTrigger: (filename: string) => void
   exportTreeJsonTrigger: (filename: string) => void
   exportTsvTrigger: (filename: string) => void
+  exportInsertionsCsvTrigger: (filename: string) => void
   exportParams: ExportParams
   canDownload: boolean
 }
@@ -116,6 +118,7 @@ const mapDispatchToProps = {
   exportPeptidesTrigger: () => exportPeptides.trigger(),
   exportTreeJsonTrigger: () => exportTreeJsonTrigger(),
   exportTsvTrigger: () => exportTsvTrigger(),
+  exportInsertionsCsvTrigger: () => exportInsertionsCsvTrigger(),
 }
 
 export function ExportDialogButtonDisconnected({
@@ -126,6 +129,7 @@ export function ExportDialogButtonDisconnected({
   exportPeptidesTrigger,
   exportTreeJsonTrigger,
   exportTsvTrigger,
+  exportInsertionsCsvTrigger,
   exportParams,
   canDownload,
 }: ExportDialogButtonProps) {
@@ -232,6 +236,15 @@ export function ExportDialogButtonDisconnected({
                       'Download aligned peptides in FASTA format, one file per gene, all in a zip archive.',
                     )}
                     onDownload={exportPeptidesTrigger}
+                  />
+
+                  <ExportFileElement
+                    Icon={<FileIconCsv />}
+                    filename={exportParams.filenameInsertionsCsv}
+                    HelpMain={t('Insertions in CSV format.')}
+                    HelpDetails={t('Contains insertions stripped from aligned sequences.')}
+                    HelpDownload={t('Download insertions in CSV format')}
+                    onDownload={exportInsertionsCsvTrigger}
                   />
 
                   <ExportFileElement

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -40,6 +40,7 @@ export const exportJsonTrigger = action<void>('exportJsonTrigger')
 export const exportTreeJsonTrigger = action<void>('exportTreeJsonTrigger')
 export const exportFastaTrigger = action<void>('exportFastaTrigger')
 export const exportPeptides = action.async<void, void, Error>('exportPeptidesTrigger')
+export const exportInsertionsCsvTrigger = action<void>('exportInsertionsCsvTrigger')
 export const exportAll = action.async<void, void, Error>('exportAllTrigger')
 export const setExportFilenames = action<ExportParams>('setExportFilenames')
 

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -62,6 +62,7 @@ export interface ExportParams {
   filenameTreeJson: string
   filenameFasta: string
   filenamePeptidesZip: string
+  filenameInsertionsCsv: string
   filenamePeptidesTemplate: string
 }
 
@@ -125,6 +126,7 @@ export const DEFAULT_EXPORT_PARAMS: ExportParams = {
   filenameTreeJson: 'nextclade.auspice.json',
   filenameFasta: 'nextclade.aligned.fasta',
   filenamePeptidesZip: 'nextclade.peptides.fasta.zip',
+  filenameInsertionsCsv: 'nextclade.insertions.csv',
   filenamePeptidesTemplate: 'nextclade.peptide.{{GENE}}.fasta',
 }
 

--- a/packages/web/src/state/algorithm/algorithmExport.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmExport.sagas.ts
@@ -129,29 +129,6 @@ export function* exportPeptidesWorker() {
   yield* call(saveZip, { files, filename: exportParams.filenamePeptidesZip })
 }
 
-export function* exportAllWorker() {
-  const exportParams = yield* select(selectExportParams)
-
-  const csvStr = yield* prepareResultsCsvStr()
-  const tsvStr = yield* prepareResultsTsvStr()
-  const jsonStr = yield* prepareResultsJsonStr()
-  const treeJsonStr = yield* prepareResultTreeJsonStr()
-  const fastaStr = yield* prepareResultFastaStr()
-
-  const peptideFiles = yield* prepareResultPeptideFiles()
-
-  const allFiles: ZipFileDescription[] = [
-    ...peptideFiles,
-    { filename: exportParams.filenameCsv, data: csvStr },
-    { filename: exportParams.filenameTsv, data: tsvStr },
-    { filename: exportParams.filenameJson, data: jsonStr },
-    { filename: exportParams.filenameTreeJson, data: treeJsonStr },
-    { filename: exportParams.filenameFasta, data: fastaStr },
-  ]
-
-  yield* call(saveZip, { files: allFiles, filename: exportParams.filenameZip })
-}
-
 export function* prepareInsertionsCsvStr() {
   const results = yield* select(selectResultsArray)
   const resultsGood = results.filter(notUndefinedOrNull)
@@ -163,6 +140,31 @@ export function* exportInsertionsCsv() {
   const exportParams = yield* select(selectExportParams)
   const csvStr = yield* prepareInsertionsCsvStr()
   saveFile(csvStr, exportParams.filenameInsertionsCsv, 'text/csv;charset=utf-8')
+}
+
+export function* exportAllWorker() {
+  const exportParams = yield* select(selectExportParams)
+
+  const csvStr = yield* prepareResultsCsvStr()
+  const tsvStr = yield* prepareResultsTsvStr()
+  const jsonStr = yield* prepareResultsJsonStr()
+  const treeJsonStr = yield* prepareResultTreeJsonStr()
+  const fastaStr = yield* prepareResultFastaStr()
+  const insertionsCsvStr = yield* prepareInsertionsCsvStr()
+
+  const peptideFiles = yield* prepareResultPeptideFiles()
+
+  const allFiles: ZipFileDescription[] = [
+    ...peptideFiles,
+    { filename: exportParams.filenameCsv, data: csvStr },
+    { filename: exportParams.filenameTsv, data: tsvStr },
+    { filename: exportParams.filenameJson, data: jsonStr },
+    { filename: exportParams.filenameTreeJson, data: treeJsonStr },
+    { filename: exportParams.filenameFasta, data: fastaStr },
+    { filename: exportParams.filenameInsertionsCsv, data: insertionsCsvStr },
+  ]
+
+  yield* call(saveZip, { files: allFiles, filename: exportParams.filenameZip })
 }
 
 export default [

--- a/packages/web/src/workers/run.ts
+++ b/packages/web/src/workers/run.ts
@@ -13,6 +13,7 @@ import type { ParseSequencesStreamingThread } from 'src/workers/worker.parseSequ
 import type { TreeFinalizeThread } from 'src/workers/worker.treeFinalize'
 import type { TreePrepareThread } from 'src/workers/worker.treePrepare'
 import type { SerializeToCsvThread } from 'src/workers/worker.serializeToCsv'
+import type { SerializeInsertionsToCsvThread } from './worker.serializeInsertionsToCsv'
 
 /**
  * Creates and initializes the analysis webworker pool.
@@ -142,4 +143,11 @@ export async function serializeToCsv(analysisResultsStr: string, delimiter: stri
     new Worker('src/workers/worker.serializeToCsv.ts', { name: 'worker.serializeToCsv' }),
   )
   return thread.serializeToCsv(analysisResultsStr, delimiter)
+}
+
+export async function serializeInsertionsToCsv(analysisResultsStr: string) {
+  const thread = await spawn<SerializeInsertionsToCsvThread>(
+    new Worker('src/workers/worker.serializeInsertionsToCsv.ts', { name: 'worker.serializeInsertionsToCsv' }),
+  )
+  return thread.serializeInsertionsToCsv(analysisResultsStr)
 }

--- a/packages/web/src/workers/worker.serializeInsertionsToCsv.ts
+++ b/packages/web/src/workers/worker.serializeInsertionsToCsv.ts
@@ -1,0 +1,22 @@
+import 'regenerator-runtime'
+
+import { expose } from 'threads/worker'
+
+import { loadWasmModule, runWasmModule, WasmModule } from 'src/workers/wasmModule'
+
+export interface SerializeInsertionsToCsvWasmModule extends WasmModule {
+  serializeInsertionsToCsv(analysisResultsStr: string): string
+}
+
+export async function serializeInsertionsToCsv(analysisResultsStr: string) {
+  const module = await loadWasmModule<SerializeInsertionsToCsvWasmModule>('nextclade_wasm')
+  return runWasmModule<SerializeInsertionsToCsvWasmModule, string>(module, (module) => {
+    return module.serializeInsertionsToCsv(analysisResultsStr)
+  })
+}
+
+const serializeInsertionsToCsvWorker = { serializeInsertionsToCsv }
+export type SerializeInsertionsToCsvWorker = typeof serializeInsertionsToCsvWorker
+export type SerializeInsertionsToCsvThread = SerializeInsertionsToCsvWorker
+
+expose(serializeInsertionsToCsvWorker)


### PR DESCRIPTION
This adds CSV file with stripped insertions to Nextclade web app "Download" dialog.

This is the same file as produced by Nextclade CLI and Nextalign CLI with `--output-insertions` flag.

This fils is also added into the "Download all" zip archive.

![0001](https://user-images.githubusercontent.com/9403403/122832140-37c90300-d2eb-11eb-8d89-f8d036a33b83.png)
