### PR TITLE
Add output errors CSV file

### DIFF
--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -28,12 +28,14 @@ struct CliParams {
   std::optional<std::string> outputBasename;
   std::optional<std::string> outputFasta;
   std::optional<std::string> outputInsertions;
+  std::optional<std::string> outputErrors;
   bool writeReference{};
 };
 
 struct Paths {
   fs::path outputFasta;
   fs::path outputInsertions;
+  fs::path outputErrors;
   std::map<std::string, fs::path> outputGenes;
 };
 
@@ -246,6 +248,13 @@ std::tuple<CliParams, cxxopts::Options, NextalignOptions> parseCommandLine(int a
     )
 
     (
+      "E,output-errors",
+      "(optional, string) Path to output errors and warnings occurred during processing, in CSV format (overrides paths given with `--output-dir` and `--output-basename`). If the required directory tree does not exist, it will be created.",
+      cxxopts::value<std::string>(),
+      "OUTPUT_ERRORS"
+    )
+
+    (
       "min-length",
       "(optional, integer, non-negative) Minimum length of nucleotide sequence to consider for alignment. If a sequence is shorter than that, alignment will not be attempted and a warning will be emitted. When adjusting this parameter, note that alignment of short sequences can be unreliable.",
       cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().alignment.minimalLength)),
@@ -393,6 +402,7 @@ std::tuple<CliParams, cxxopts::Options, NextalignOptions> parseCommandLine(int a
     cliParams.outputFasta = getParamOptional<std::string>(cxxOptsParsed, "output-fasta");
     cliParams.writeReference = getParamRequiredDefaulted<bool>(cxxOptsParsed, "include-reference");
     cliParams.outputInsertions = getParamOptional<std::string>(cxxOptsParsed, "output-insertions");
+    cliParams.outputErrors = getParamOptional<std::string>(cxxOptsParsed, "output-errors");
 
     if (bool(cliParams.genes) != bool(cliParams.genemap)) {
       throw ErrorCliOptionInvalidValue(
@@ -535,6 +545,10 @@ std::string formatCliParams(const CliParams &cliParams) {
     fmt::format_to(buf, "{:>20s}=\"{:<s}\"\n", "--output-insertions", *cliParams.outputInsertions);
   }
 
+  if (cliParams.outputErrors) {
+    fmt::format_to(buf, "{:>20s}=\"{:<s}\"\n", "--output-errors", *cliParams.outputErrors);
+  }
+
   return fmt::to_string(buf);
 }
 
@@ -567,6 +581,12 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
     outputInsertions = *cliParams.outputInsertions;
   }
 
+  auto outputErrors = outDir / baseName;
+  outputErrors += ".errors.csv";
+  if (cliParams.outputErrors) {
+    outputErrors = *cliParams.outputErrors;
+  }
+
   std::map<std::string, fs::path> outputGenes;
   for (const auto &gene : genes) {
     auto outputGene = outDir / baseName;
@@ -577,6 +597,7 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
   return {
     .outputFasta = outputFasta,
     .outputInsertions = outputInsertions,
+    .outputErrors = outputErrors,
     .outputGenes = outputGenes,
   };
 }
@@ -642,6 +663,7 @@ void run(
   /* in  */ const NextalignOptions &options,
   /* out */ std::ostream &outputFastaStream,
   /* out */ std::ostream &outputInsertionsStream,
+  /* out */ std::ostream &outputErrorsFile,
   /* out */ std::map<std::string, std::ofstream> &outputGeneStreams,
   /* in */ bool shouldWriteReference,
   /* out */ Logger &logger) {
@@ -686,8 +708,8 @@ void run(
   /** Output filter is a serial ordered filter function which accepts the results from transform filters,
    * one at a time, displays and writes them to output streams */
   const auto outputFilter = tbb::make_filter<AlgorithmOutput, void>(ioFiltersMode,//
-    [&refName, &outputFastaStream, &outputInsertionsStream, &outputGeneStreams, &refsHaveBeenWritten, &logger](
-      const AlgorithmOutput &output) {
+    [&refName, &outputFastaStream, &outputInsertionsStream, &outputErrorsFile, &outputGeneStreams, &refsHaveBeenWritten,
+      &logger](const AlgorithmOutput &output) {
       const auto index = output.index;
       const auto &seqName = output.seqName;
 
@@ -698,6 +720,7 @@ void run(
         } catch (const std::exception &e) {
           logger.warn("Warning: in sequence \"{:s}\": {:s}. Note that this sequence will be excluded from results.",
             seqName, e.what());
+          outputErrorsFile << fmt::format("\"{:s}\",\"{:s}\",\"{:s}\",\"{:s}\"\n", seqName, e.what(), "", "<<ALL>>");
           return;
         }
       }
@@ -712,13 +735,27 @@ void run(
       logger.info("| {:5d} | {:<40s} | {:>16d} | {:12d} |",//
         index, seqName, alignmentScore, insertions.size());
 
+      std::vector<std::string> warningsCombined;
+      std::vector<std::string> failedGeneNames;
       for (const auto &warning : warnings.global) {
         logger.warn("Warning: in sequence \"{:s}\": {:s}", seqName, warning);
+        warningsCombined.push_back(warning);
       }
 
       for (const auto &warning : warnings.inGenes) {
         logger.warn("Warning: in sequence \"{:s}\": {:s}", seqName, warning.message);
+        warningsCombined.push_back(warning.message);
+        failedGeneNames.push_back(warning.geneName);
       }
+
+      auto warningsJoined = boost::join(warningsCombined, ";");
+      boost::replace_all(warningsJoined, R"(")", R"("")");// escape double quotes
+
+      auto failedGeneNamesJoined = boost::join(failedGeneNames, ";");
+      boost::replace_all(failedGeneNamesJoined, R"(")", R"("")");// escape double quotes
+
+      outputErrorsFile << fmt::format("\"{:s}\",\"{:s}\",\"{:s}\",\"{:s}\"\n", seqName, "", warningsJoined,
+        failedGeneNamesJoined);
 
       // TODO: hoist ref sequence transforms - process and write results only once, outside of main loop
       if (!refsHaveBeenWritten && !error) {
@@ -817,6 +854,11 @@ int main(int argc, char *argv[]) {
       fs::create_directories(outputInsertionsParent);
     }
 
+    const auto outputErrorsParent = paths.outputErrors.parent_path();
+    if (!outputErrorsParent.empty()) {
+      fs::create_directories(outputErrorsParent);
+    }
+
     std::ofstream outputFastaFile(paths.outputFasta);
     if (!outputFastaFile.good()) {
       throw ErrorIoUnableToWrite(fmt::format("Error: unable to write \"{:s}\"", paths.outputFasta.string()));
@@ -827,6 +869,12 @@ int main(int argc, char *argv[]) {
       throw ErrorIoUnableToWrite(fmt::format("Error: unable to write \"{:s}\"", paths.outputInsertions.string()));
     }
     outputInsertionsFile << "seqName,insertions\n";
+
+    std::ofstream outputErrorsFile(paths.outputErrors);
+    if (!outputErrorsFile.good()) {
+      throw ErrorIoUnableToWrite(fmt::format("Error: unable to write \"{:s}\"", paths.outputErrors.string()));
+    }
+    outputErrorsFile << "seqName,errors,warnings,failedGenes\n";
 
     std::map<std::string, std::ofstream> outputGeneFiles;
     for (const auto &[geneName, outputGenePath] : paths.outputGenes) {
@@ -859,7 +907,7 @@ int main(int argc, char *argv[]) {
 
     try {
       run(parallelism, inOrder, fastaStream, refData, geneMap, options, outputFastaFile, outputInsertionsFile,
-        outputGeneFiles, shouldWriteReference, logger);
+        outputErrorsFile, outputGeneFiles, shouldWriteReference, logger);
     } catch (const std::exception &e) {
       logger.error("Error: {:>16s} |\n", e.what());
     }

--- a/packages/nextclade_cli/src/cli.cpp
+++ b/packages/nextclade_cli/src/cli.cpp
@@ -39,12 +39,14 @@ struct CliParams {
   std::optional<std::string> outputBasename;
   std::optional<std::string> outputFasta;
   std::optional<std::string> outputInsertions;
+  std::optional<std::string> outputErrors;
   bool writeReference{};
 };
 
 struct Paths {
   fs::path outputFasta;
   fs::path outputInsertions;
+  fs::path outputErrors;
   std::map<std::string, fs::path> outputGenes;
 };
 
@@ -307,6 +309,13 @@ std::tuple<CliParams, NextalignOptions> parseCommandLine(int argc,
     )
 
     (
+      "E,output-errors",
+      "(optional, string) Path to output errors and warnings occurred during processing, in CSV format (overrides paths given with `--output-dir` and `--output-basename`). If the required directory tree does not exist, it will be created.",
+      cxxopts::value<std::string>(),
+      "OUTPUT_ERRORS"
+    )
+
+    (
       "min-length",
       "(optional, integer, non-negative) Minimum length of nucleotide sequence to consider for alignment. If a sequence is shorter than that, alignment will not be attempted and a warning will be emitted. When adjusting this parameter, note that alignment of short sequences can be unreliable.",
       cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().alignment.minimalLength)),
@@ -450,6 +459,7 @@ std::tuple<CliParams, NextalignOptions> parseCommandLine(int argc,
     cliParams.outputFasta = getParamOptional<std::string>(cxxOptsParsed, "output-fasta");
     cliParams.writeReference = getParamRequiredDefaulted<bool>(cxxOptsParsed, "include-reference");
     cliParams.outputInsertions = getParamOptional<std::string>(cxxOptsParsed, "output-insertions");
+    cliParams.outputErrors = getParamOptional<std::string>(cxxOptsParsed, "output-errors");
 
     cliParams.inputFasta = getParamRequired<std::string>(cxxOptsParsed, "input-fasta");
     cliParams.inputRootSeq = getParamRequired<std::string>(cxxOptsParsed, "input-root-seq");
@@ -631,6 +641,12 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
     outputInsertions = *cliParams.outputInsertions;
   }
 
+  auto outputErrors = outDir / baseName;
+  outputErrors += ".errors.csv";
+  if (cliParams.outputErrors) {
+    outputErrors = *cliParams.outputErrors;
+  }
+
   std::map<std::string, fs::path> outputGenes;
   for (const auto &gene : genes) {
     auto outputGene = outDir / baseName;
@@ -641,6 +657,7 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
   return {
     .outputFasta = outputFasta,
     .outputInsertions = outputInsertions,
+    .outputErrors = outputErrors,
     .outputGenes = outputGenes,
   };
 }
@@ -715,6 +732,7 @@ void run(
   /* out */ std::unique_ptr<std::ostream> &outputTreeStream,
   /* out */ std::ostream &outputFastaStream,
   /* out */ std::ostream &outputInsertionsStream,
+  /* out */ std::ostream &outputErrorsFile,
   /* out */ std::map<std::string, std::ofstream> &outputGeneStreams,
   /* in */ bool shouldWriteReference,
   /* out */ Logger &logger) {
@@ -786,8 +804,9 @@ void run(
   /** Output filter is a serial ordered filter function which accepts the results from transform filters,
    * one at a time, displays and writes them to output streams */
   const auto outputFilter = tbb::make_filter<Nextclade::AlgorithmOutput, void>(ioFiltersMode,//
-    [&refName, &outputFastaStream, &outputInsertionsStream, &outputGeneStreams, &csv, &tsv, &refsHaveBeenWritten,
-      &logger, &resultsConcurrent, &outputJsonStream, &outputTreeStream](const Nextclade::AlgorithmOutput &output) {
+    [&refName, &outputFastaStream, &outputInsertionsStream, &outputErrorsFile, &outputGeneStreams, &csv, &tsv,
+      &refsHaveBeenWritten, &logger, &resultsConcurrent, &outputJsonStream,
+      &outputTreeStream](const Nextclade::AlgorithmOutput &output) {
       const auto index = output.index;
       const auto &seqName = output.seqName;
       const auto &refAligned = output.result.ref;
@@ -811,6 +830,7 @@ void run(
           const std::string &errorMessage = e.what();
           logger.warn("Warning: In sequence \"{:s}\": {:s}. Note that this sequence will be excluded from results.",
             seqName, errorMessage);
+          outputErrorsFile << fmt::format("\"{:s}\",\"{:s}\",\"{:s}\",\"{:s}\"\n", seqName, e.what(), "", "<<ALL>>");
           if (csv) {
             csv->addErrorRow(seqName, errorMessage);
           }
@@ -820,13 +840,27 @@ void run(
           return;
         }
       } else {
+        std::vector<std::string> warningsCombined;
+        std::vector<std::string> failedGeneNames;
         for (const auto &warning : warnings.global) {
           logger.warn("Warning: in sequence \"{:s}\": {:s}", seqName, warning);
+          warningsCombined.push_back(warning);
         }
 
         for (const auto &warning : warnings.inGenes) {
           logger.warn("Warning: in sequence \"{:s}\": {:s}", seqName, warning.message);
+          warningsCombined.push_back(warning.message);
+          failedGeneNames.push_back(warning.geneName);
         }
+
+        auto warningsJoined = boost::join(warningsCombined, ";");
+        boost::replace_all(warningsJoined, R"(")", R"("")");// escape double quotes
+
+        auto failedGeneNamesJoined = boost::join(failedGeneNames, ";");
+        boost::replace_all(failedGeneNamesJoined, R"(")", R"("")");// escape double quotes
+
+        outputErrorsFile << fmt::format("\"{:s}\",\"{:s}\",\"{:s}\",\"{:s}\"\n", seqName, "", warningsJoined,
+          failedGeneNamesJoined);
 
         // TODO: hoist ref sequence transforms - process and write results only once, outside of main loop
         if (!refsHaveBeenWritten) {
@@ -1020,6 +1054,13 @@ int main(int argc, char *argv[]) {
     openOutputFile(paths.outputInsertions, outputInsertionsStream);
     outputInsertionsStream << "seqName,insertions\n";
 
+    std::ofstream outputErrorsFile(paths.outputErrors);
+    if (!outputErrorsFile.good()) {
+      throw ErrorIoUnableToWrite(fmt::format("Error: unable to write \"{:s}\"", paths.outputErrors.string()));
+    }
+    outputErrorsFile << "seqName,errors,warnings,failedGenes\n";
+
+
     std::map<std::string, std::ofstream> outputGeneStreams;
     for (const auto &[geneName, outputGenePath] : paths.outputGenes) {
       auto result = outputGeneStreams.emplace(std::make_pair(geneName, std::ofstream{}));
@@ -1061,7 +1102,7 @@ int main(int argc, char *argv[]) {
     try {
       run(parallelism, inOrder, inputFastaStream, refData, qcRulesConfig, treeString, pcrPrimers, geneMap, options,
         outputJsonStream, outputCsvStream, outputTsvStream, outputTreeStream, outputFastaStream, outputInsertionsStream,
-        outputGeneStreams, shouldWriteReference, logger);
+        outputErrorsFile, outputGeneStreams, shouldWriteReference, logger);
     } catch (const std::exception &e) {
       logger.error("Error: {:>16s} |", e.what());
     }

--- a/packages/web/src/components/Results/ExportDialogButton.tsx
+++ b/packages/web/src/components/Results/ExportDialogButton.tsx
@@ -29,6 +29,7 @@ import {
   exportTreeJsonTrigger,
   exportTsvTrigger,
   exportInsertionsCsvTrigger,
+  exportErrorsCsvTrigger,
 } from 'src/state/algorithm/algorithm.actions'
 import {
   FileIconCsv,
@@ -101,6 +102,7 @@ export interface ExportDialogButtonProps {
   exportTreeJsonTrigger: (filename: string) => void
   exportTsvTrigger: (filename: string) => void
   exportInsertionsCsvTrigger: (filename: string) => void
+  exportErrorsCsvTrigger: (filename: string) => void
   exportParams: ExportParams
   canDownload: boolean
 }
@@ -119,6 +121,7 @@ const mapDispatchToProps = {
   exportTreeJsonTrigger: () => exportTreeJsonTrigger(),
   exportTsvTrigger: () => exportTsvTrigger(),
   exportInsertionsCsvTrigger: () => exportInsertionsCsvTrigger(),
+  exportErrorsCsvTrigger: () => exportErrorsCsvTrigger(),
 }
 
 export function ExportDialogButtonDisconnected({
@@ -130,6 +133,7 @@ export function ExportDialogButtonDisconnected({
   exportTreeJsonTrigger,
   exportTsvTrigger,
   exportInsertionsCsvTrigger,
+  exportErrorsCsvTrigger,
   exportParams,
   canDownload,
 }: ExportDialogButtonProps) {
@@ -245,6 +249,17 @@ export function ExportDialogButtonDisconnected({
                     HelpDetails={t('Contains insertions stripped from aligned sequences.')}
                     HelpDownload={t('Download insertions in CSV format')}
                     onDownload={exportInsertionsCsvTrigger}
+                  />
+
+                  <ExportFileElement
+                    Icon={<FileIconCsv />}
+                    filename={exportParams.filenameErrorsCsv}
+                    HelpMain={t('Errors, warnings, and failed genes in CSV format.')}
+                    HelpDetails={t(
+                      'Contains a list of errors, a list of warnings and a list of genes that failed processing, per sequence, in CSV format.',
+                    )}
+                    HelpDownload={t('Download warnings, and failed genes in CSV format')}
+                    onDownload={exportErrorsCsvTrigger}
                   />
 
                   <ExportFileElement

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -41,6 +41,7 @@ export const exportTreeJsonTrigger = action<void>('exportTreeJsonTrigger')
 export const exportFastaTrigger = action<void>('exportFastaTrigger')
 export const exportPeptides = action.async<void, void, Error>('exportPeptidesTrigger')
 export const exportInsertionsCsvTrigger = action<void>('exportInsertionsCsvTrigger')
+export const exportErrorsCsvTrigger = action<void>('exportErrorsCsvTrigger')
 export const exportAll = action.async<void, void, Error>('exportAllTrigger')
 export const setExportFilenames = action<ExportParams>('setExportFilenames')
 

--- a/packages/web/src/state/algorithm/algorithm.selectors.ts
+++ b/packages/web/src/state/algorithm/algorithm.selectors.ts
@@ -11,6 +11,8 @@ export const selectResults = (state: State) => state.algorithm.results
 
 export const selectResultsArray = (state: State) => state.algorithm.results.map((result) => result.result)
 
+export const selectResultsState = (state: State) => state.algorithm.results
+
 export const selectIsDirty = (state: State): boolean => state.algorithm.isDirty
 
 export const selectHasRequiredInputs = (state: State): boolean => selectQueryStr(state) !== undefined

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -63,6 +63,7 @@ export interface ExportParams {
   filenameFasta: string
   filenamePeptidesZip: string
   filenameInsertionsCsv: string
+  filenameErrorsCsv: string
   filenamePeptidesTemplate: string
 }
 
@@ -127,6 +128,7 @@ export const DEFAULT_EXPORT_PARAMS: ExportParams = {
   filenameFasta: 'nextclade.aligned.fasta',
   filenamePeptidesZip: 'nextclade.peptides.fasta.zip',
   filenameInsertionsCsv: 'nextclade.insertions.csv',
+  filenameErrorsCsv: 'nextclade.errors.csv',
   filenamePeptidesTemplate: 'nextclade.peptide.{{GENE}}.fasta',
 }
 

--- a/packages/web/src/state/algorithm/algorithmExport.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmExport.sagas.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-loops/no-loops,no-continue */
+/* eslint-disable no-loops/no-loops,no-continue,sonarjs/no-duplicate-string */
 import { call, select, takeEvery } from 'typed-redux-saga'
 
 import type { ZipFileDescription } from 'src/helpers/saveFile'
@@ -8,6 +8,7 @@ import { serializeResults, serializeResultsToJson } from 'src/io/serializeResult
 import {
   exportAll,
   exportCsvTrigger,
+  exportErrorsCsvTrigger,
   exportFastaTrigger,
   exportInsertionsCsvTrigger,
   exportJsonTrigger,
@@ -22,6 +23,7 @@ import {
   selectOutputTree,
   selectResults,
   selectResultsArray,
+  selectResultsState,
 } from 'src/state/algorithm/algorithm.selectors'
 import fsaSaga from 'src/state/util/fsaSaga'
 import { notUndefinedOrNull } from 'src/helpers/notUndefined'
@@ -142,6 +144,38 @@ export function* exportInsertionsCsv() {
   saveFile(csvStr, exportParams.filenameInsertionsCsv, 'text/csv;charset=utf-8')
 }
 
+export function joinEntries(entries: string[]) {
+  return entries.join(';').replace('"', '""')
+}
+
+export function* prepareErrorsCsvStr() {
+  const results = yield* select(selectResultsState)
+
+  let csv = 'seqName,errors,warnings,failedGenes'
+  for (const result of results) {
+    const { seqName, errors } = result
+
+    const geneWarnings = result?.warnings.inGenes.flatMap((w) => w.message)
+    const warnings = [...(result?.warnings.global ?? []), ...geneWarnings]
+
+    let failedGeneNames = result?.warnings.inGenes.flatMap((w) => w.geneName)
+    if (errors.length > 0) {
+      failedGeneNames = ['<<ALL>>']
+    }
+
+    const row = `"${seqName}","${joinEntries(errors)}","${joinEntries(warnings)}","${joinEntries(failedGeneNames)}"`
+    csv = `${csv}\r\n${row}`
+  }
+
+  return csv
+}
+
+export function* exportErrorsCsv() {
+  const exportParams = yield* select(selectExportParams)
+  const csvStr = yield* prepareErrorsCsvStr()
+  saveFile(csvStr, exportParams.filenameErrorsCsv, 'text/csv;charset=utf-8')
+}
+
 export function* exportAllWorker() {
   const exportParams = yield* select(selectExportParams)
 
@@ -151,6 +185,7 @@ export function* exportAllWorker() {
   const treeJsonStr = yield* prepareResultTreeJsonStr()
   const fastaStr = yield* prepareResultFastaStr()
   const insertionsCsvStr = yield* prepareInsertionsCsvStr()
+  const errorsCsvStr = yield* prepareErrorsCsvStr()
 
   const peptideFiles = yield* prepareResultPeptideFiles()
 
@@ -162,6 +197,7 @@ export function* exportAllWorker() {
     { filename: exportParams.filenameTreeJson, data: treeJsonStr },
     { filename: exportParams.filenameFasta, data: fastaStr },
     { filename: exportParams.filenameInsertionsCsv, data: insertionsCsvStr },
+    { filename: exportParams.filenameErrorsCsv, data: errorsCsvStr },
   ]
 
   yield* call(saveZip, { files: allFiles, filename: exportParams.filenameZip })
@@ -175,5 +211,6 @@ export default [
   takeEvery(exportFastaTrigger, exportFasta),
   takeEvery(exportPeptides.trigger, fsaSaga(exportPeptides, exportPeptidesWorker)),
   takeEvery(exportInsertionsCsvTrigger, exportInsertionsCsv),
+  takeEvery(exportErrorsCsvTrigger, exportErrorsCsv),
   takeEvery(exportAll.trigger, fsaSaga(exportAll, exportAllWorker)),
 ]

--- a/packages/web/src/state/algorithm/algorithmExport.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmExport.sagas.ts
@@ -155,7 +155,7 @@ export function* prepareErrorsCsvStr() {
   for (const result of results) {
     const { seqName, errors } = result
 
-    const geneWarnings = result.warnings.inGenes.flatMap((w) => w.message)
+    const geneWarnings = result.warnings.inGenes.flatMap((w) => w.message) ?? []
     const warnings = [...(result.warnings.global ?? []), ...geneWarnings]
 
     let failedGeneNames = result.warnings.inGenes.flatMap((w) => w.geneName)

--- a/packages/web/src/state/algorithm/algorithmExport.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmExport.sagas.ts
@@ -145,7 +145,7 @@ export function* exportInsertionsCsv() {
 }
 
 export function joinEntries(entries: string[]) {
-  return entries.join(';').replace('"', '""')
+  return entries.join(';').replace(/"/g, '""')
 }
 
 export function* prepareErrorsCsvStr() {

--- a/packages/web/src/state/algorithm/algorithmExport.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmExport.sagas.ts
@@ -155,10 +155,10 @@ export function* prepareErrorsCsvStr() {
   for (const result of results) {
     const { seqName, errors } = result
 
-    const geneWarnings = result?.warnings.inGenes.flatMap((w) => w.message)
-    const warnings = [...(result?.warnings.global ?? []), ...geneWarnings]
+    const geneWarnings = result.warnings.inGenes.flatMap((w) => w.message)
+    const warnings = [...(result.warnings.global ?? []), ...geneWarnings]
 
-    let failedGeneNames = result?.warnings.inGenes.flatMap((w) => w.geneName)
+    let failedGeneNames = result.warnings.inGenes.flatMap((w) => w.geneName)
     if (errors.length > 0) {
       failedGeneNames = ['<<ALL>>']
     }


### PR DESCRIPTION
Resolves #436 

The errors CSV file contains errors, warnings and names of failed genes for each sequence.

This PR adds this to the "base" CLI output (files written to the default path with the default name, similar to gene fasta) and also the `--output-errors` flag to change the default path, for both Nextclade CLI and Nextalign CLI.

It also adds the same file to the "Downloads" dialog in the web app, as a standalone file and included into the zip archive.

![01](https://user-images.githubusercontent.com/9403403/122841931-9fd41500-d2fc-11eb-9713-3a44e6f12a51.png)



