### PR TITLE
feat: add insertions column into results table

### DIFF
--- a/packages/web/src/components/Common/TableSlim.tsx
+++ b/packages/web/src/components/Common/TableSlim.tsx
@@ -10,4 +10,19 @@ export const TableSlim = styled(ReactstrapTable)`
     margin: 0;
     padding: 0;
   }
+
+  & th {
+    margin: 0;
+    padding: 0 0.5rem;
+  }
+`
+
+export const TableSlimWithBorders = styled(TableSlim)`
+  & td {
+    border: 1px solid #ccc;
+  }
+
+  & th {
+    border: 1px solid #ccc;
+  }
 `

--- a/packages/web/src/components/Results/ColumnInsertions.tsx
+++ b/packages/web/src/components/Results/ColumnInsertions.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+
+import type { AnalysisResult } from 'src/algorithms/types'
+import { getSafeId } from 'src/helpers/getSafeId'
+import { Tooltip } from 'src/components/Results/Tooltip'
+import { ListOfInsertions } from 'src/components/Results/ListOfInsertions'
+
+export interface ColumnInsertionsProps {
+  sequence: AnalysisResult
+}
+
+export function ColumnInsertions({ sequence }: ColumnInsertionsProps) {
+  const [showTooltip, setShowTooltip] = useState(false)
+
+  const { seqName, insertions, totalInsertions } = sequence
+  const id = getSafeId('col-insertions', { seqName, insertions })
+
+  return (
+    <div id={id} className="w-100" onMouseEnter={() => setShowTooltip(true)} onMouseLeave={() => setShowTooltip(false)}>
+      {totalInsertions}
+      <Tooltip id={id} isOpen={showTooltip} target={id} wide fullWidth>
+        <ListOfInsertions insertions={insertions} totalInsertions={totalInsertions} />
+      </Tooltip>
+    </div>
+  )
+}

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnInsertions.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnInsertions.mdx
@@ -1,0 +1,7 @@
+##### Column: insertions
+
+Displays total length of insertions in the sequence.
+
+Hovering mouse over a cell in this column will display a tooltip where insertions relative to the reference Wuhan-Hu-1 are listed for the corresponding sequence.
+
+Positions are 1-based.

--- a/packages/web/src/components/Results/ListOfInsertions.tsx
+++ b/packages/web/src/components/Results/ListOfInsertions.tsx
@@ -1,35 +1,66 @@
 import React from 'react'
 
 import { useTranslation } from 'react-i18next'
-import type { DeepReadonly } from 'ts-essentials'
 
 import type { NucleotideInsertion } from 'src/algorithms/types'
-import { formatInsertion } from 'src/helpers/formatInsertion'
-import { truncateList } from 'src/components/Results/truncateList'
-import { Li, Ul } from 'src/components/Common/List'
+import { TableSlim, TableSlimWithBorders } from 'src/components/Common/TableSlim'
 
-const LIST_OF_INSERTIONS_MAX_ITEMS = 10 as const
+const INSERTION_MAX_LENGTH = 30 as const
 
-export interface ListOfInsertionsProps {
-  readonly insertions: DeepReadonly<NucleotideInsertion[]>
+export function truncateString(s: string, maxLen: number) {
+  const truncatedText = '... (truncated)'
+  const targetLength = maxLen - truncatedText.length
+  if (s.length > targetLength) {
+    return s.slice(0, targetLength).concat(truncatedText)
+  }
+  return s
 }
 
-export function ListOfInsertions({ insertions }: ListOfInsertionsProps) {
+export interface ListOfInsertionsProps {
+  insertions: NucleotideInsertion[]
+  totalInsertions: number
+}
+
+export function ListOfInsertions({ insertions, totalInsertions }: ListOfInsertionsProps) {
   const { t } = useTranslation()
 
-  const totalInsertions = insertions.length
-
-  let insertionItems = insertions.map(({ pos, ins }) => {
-    const insertion = formatInsertion({ pos, ins })
-    return <Li key={insertion}>{insertion}</Li>
-  })
-
-  insertionItems = truncateList(insertionItems, LIST_OF_INSERTIONS_MAX_ITEMS, t('...more'))
-
   return (
-    <div>
-      <div>{t('Insertions ({{totalInsertions}})', { totalInsertions })}</div>
-      <Ul>{insertionItems}</Ul>
-    </div>
+    <>
+      <TableSlim borderless className="mb-1">
+        <tbody>
+          <tr>
+            <td>{t('Number of insertions')}</td>
+            <td>{insertions.length}</td>
+          </tr>
+
+          <tr>
+            <td>{t('Total length of insertions')}</td>
+            <td>{totalInsertions}</td>
+          </tr>
+        </tbody>
+      </TableSlim>
+
+      {insertions.length > 0 && (
+        <TableSlimWithBorders className="mb-1">
+          <thead>
+            <tr>
+              <th>{t('1st nuc.')}</th>
+              <th>{t('Length.')}</th>
+              <th>{t('Nuc. fragment')}</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {insertions.map(({ pos, ins }) => (
+              <tr key={pos}>
+                <td className="text-center">{pos}</td>
+                <td className="text-center">{ins.length}</td>
+                <td className="text-left">{truncateString(ins, INSERTION_MAX_LENGTH)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </TableSlimWithBorders>
+      )}
+    </>
   )
 }

--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -28,12 +28,14 @@ import { ColumnMutations } from './ColumnMutations'
 import { ColumnNonACGTNs } from './ColumnNonACGTNs'
 import { ColumnMissing } from './ColumnMissing'
 import { ColumnGaps } from './ColumnGaps'
+import { ColumnInsertions } from './ColumnInsertions'
 import { ResultsControlsSort } from './ResultsControlsSort'
 import { ButtonHelp } from './ButtonHelp'
 
 import HelpTipsColumnClade from './HelpTips/HelpTipsColumnClade.mdx'
 import HelpTipsColumnGaps from './HelpTips/HelpTipsColumnGaps.mdx'
 import HelpTipsColumnId from './HelpTips/HelpTipsColumnId.mdx'
+import HelpTipsColumnInsertions from './HelpTips/HelpTipsColumnInsertions.mdx'
 import HelpTipsColumnMissing from './HelpTips/HelpTipsColumnMissing.mdx'
 import HelpTipsColumnMut from './HelpTips/HelpTipsColumnMut.mdx'
 import HelpTipsColumnNonAcgtn from './HelpTips/HelpTipsColumnNonAcgtn.mdx'
@@ -55,6 +57,7 @@ export const RESULTS_TABLE_FLEX_BASIS = {
   nonACGTN: 70,
   ns: 60,
   gaps: 60,
+  insertions: 60,
 } as const
 
 export const RESULTS_TABLE_FLEX_BASIS_PX = Object.fromEntries(
@@ -240,6 +243,10 @@ function TableRowComponent({ index, style, data }: RowProps) {
         <ColumnGaps sequence={sequence} />
       </TableCell>
 
+      <TableCell basis={RESULTS_TABLE_FLEX_BASIS_PX.insertions} grow={0} shrink={0}>
+        <ColumnInsertions sequence={sequence} />
+      </TableCell>
+
       <TableCell grow={20} shrink={20}>
         {viewedGene === GENE_OPTION_NUC_SEQUENCE ? (
           <SequenceView key={seqName} sequence={sequence} />
@@ -298,6 +305,17 @@ const mapDispatchToProps = {
   sortByTotalGapsAsc: () => resultsSortTrigger({ category: SortCategory.totalGaps, direction: SortDirection.asc }),
   sortByTotalGapsDesc: () => resultsSortTrigger({ category: SortCategory.totalGaps, direction: SortDirection.desc }),
 
+  sortByTotalInsertionsAsc: () =>
+    resultsSortTrigger({
+      category: SortCategory.totalInsertions,
+      direction: SortDirection.asc,
+    }),
+  sortByTotalInsertionsDesc: () =>
+    resultsSortTrigger({
+      category: SortCategory.totalInsertions,
+      direction: SortDirection.desc,
+    }),
+
   setViewedGene,
 }
 
@@ -340,6 +358,10 @@ export interface ResultProps {
 
   sortByTotalGapsDesc(): void
 
+  sortByTotalInsertionsAsc(): void
+
+  sortByTotalInsertionsDesc(): void
+
   setViewedGene(viewedGene: string): void
 }
 
@@ -362,6 +384,8 @@ export function ResultsTableDisconnected({
   sortByTotalNsDesc,
   sortByTotalGapsAsc,
   sortByTotalGapsDesc,
+  sortByTotalInsertionsAsc,
+  sortByTotalInsertionsDesc,
   viewedGene,
   setViewedGene,
 }: ResultProps) {
@@ -451,6 +475,16 @@ export function ResultsTableDisconnected({
             </TableHeaderCellContent>
             <ButtonHelpStyled identifier="btn-help-col-gaps">
               <HelpTipsColumnGaps />
+            </ButtonHelpStyled>
+          </TableHeaderCell>
+
+          <TableHeaderCell basis={RESULTS_TABLE_FLEX_BASIS_PX.insertions} grow={0} shrink={0}>
+            <TableHeaderCellContent>
+              <TableCellText>{t('Ins.')}</TableCellText>
+              <ResultsControlsSort sortAsc={sortByTotalInsertionsAsc} sortDesc={sortByTotalInsertionsDesc} />
+            </TableHeaderCellContent>
+            <ButtonHelpStyled identifier="btn-help-col-insertions">
+              <HelpTipsColumnInsertions />
             </ButtonHelpStyled>
           </TableHeaderCell>
 

--- a/packages/web/src/helpers/sortResults.ts
+++ b/packages/web/src/helpers/sortResults.ts
@@ -11,6 +11,7 @@ export enum SortCategory {
   totalNonACGTNs = 'totalNonACGTNs',
   totalMissing = 'totalMissing',
   totalGaps = 'totalGaps',
+  totalInsertions = 'totalInsertions',
 }
 
 export enum SortDirection {
@@ -82,6 +83,10 @@ export function sortByGaps(results: SequenceAnalysisState[], direction: SortDire
   return orderBy(results, (res) => res.result?.totalDeletions ?? defaultNumber(direction), direction)
 }
 
+export function sortByInsertions(results: SequenceAnalysisState[], direction: SortDirection) {
+  return orderBy(results, (res) => res.result?.totalInsertions ?? defaultNumber(direction), direction)
+}
+
 export function sortResults(results: SequenceAnalysisState[], sorting: Sorting) {
   const { category, direction } = sorting
 
@@ -109,6 +114,9 @@ export function sortResults(results: SequenceAnalysisState[], sorting: Sorting) 
 
     case SortCategory.totalGaps:
       return sortByGaps(results, direction)
+
+    case SortCategory.totalInsertions:
+      return sortByInsertions(results, direction)
   }
 
   return results


### PR DESCRIPTION
This adds "Ins." column, for "Insertions". It simply exposes in the UI the data that we already had.

Row tooltip:

![01](https://user-images.githubusercontent.com/9403403/122962472-bd998c80-d385-11eb-9023-2ba1317f08bc.png)


Help tooltip for the column:

![02](https://user-images.githubusercontent.com/9403403/122962492-c2f6d700-d385-11eb-9a37-9481dfc4e439.png)

