### PR TITLE
Fix range formatting for display in web app

### DIFF
--- a/packages/web/src/helpers/formatRange.ts
+++ b/packages/web/src/helpers/formatRange.ts
@@ -1,8 +1,11 @@
 export function formatRange(begin: number, end: number) {
+  // NOTE: we (and JavaScript) use 0-based, half-open ranges,
+  // but bioinformaticians prefer 1-based, closed ranges.
+  // So we convert from "0-based, half-open ranges" to "1-based, closed ranges" here
   const beginOne = begin + 1
-  const endOne = end + 1
+  const endOne = end
 
-  if (endOne - beginOne < 2) {
+  if (endOne === beginOne) {
     return beginOne.toString()
   }
   return `${beginOne}-${endOne}`


### PR DESCRIPTION
This fixes the off-by-one error in `formatRange()` (typescript version).

It touches quite a few places in the web app:

![01](https://user-images.githubusercontent.com/9403403/123141981-433a3c80-d459-11eb-94bd-c591ffad1425.png)


[The C++ version](https://github.com/nextstrain/nextclade/blob/fdb6a7acd5bd5fffbac68d327f0eb963a8d0bc3d/packages/nextclade/src/io/formatMutation.cpp#L10-L19) is correct.