### PR TITLE
Version QC config JSON file

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,6 +7,7 @@ fmt/7.1.3
 ghc-filesystem/1.4.0
 gtest/1.10.0
 ms-gsl/3.1.0
+neargye-semver/0.3.0
 tbb/2021.2.0-rc@local/stable
 
 [generators]

--- a/conanfile.wasm.txt
+++ b/conanfile.wasm.txt
@@ -3,6 +3,7 @@ boost/1.75.0
 fast-cpp-csv-parser/20191004
 fmt/7.1.3
 ms-gsl/3.1.0
+neargye-semver/0.3.0
 
 [generators]
 cmake

--- a/data/sars-cov-2/qc.json
+++ b/data/sars-cov-2/qc.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.2.0",
   "privateMutations": {
     "enabled": true,
     "typical": 8,

--- a/packages/nextclade/CMakeLists.txt
+++ b/packages/nextclade/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(Boost 1.75.0 COMPONENTS headers REQUIRED)
 find_package(Microsoft.GSL 3.1.0 REQUIRED)
 find_package(fast-cpp-csv-parser 20191004 REQUIRED)
 find_package(fmt 7.1.0 REQUIRED)
+find_package(semver 0.3.0 REQUIRED)
 
 set(SOURCE_FILES
   include/nextclade/nextclade.h
@@ -66,6 +67,8 @@ set(SOURCE_FILES
   src/nextclade.cpp
   src/qc/getQcRuleStatus.cpp
   src/qc/getQcRuleStatus.h
+  src/qc/isQcConfigVersionRecent.cpp
+  src/qc/isQcConfigVersionRecent.h
   src/qc/ruleFrameShifts.cpp
   src/qc/ruleFrameShifts.h
   src/qc/ruleMissingData.cpp
@@ -162,6 +165,7 @@ target_link_libraries(${PROJECT_NAME}
   Microsoft.GSL::GSL
   fast-cpp-csv-parser::fast-cpp-csv-parser
   fmt::fmt-header-only
+  semver::semver
   )
 
 set(NEXTCLADE_BUILD_TESTS ON CACHE BOOL "Build unit tests")

--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -415,6 +415,8 @@ namespace Nextclade {
 
   QcConfig parseQcConfig(const std::string& qcConfigJsonStr);
 
+  bool isQcConfigVersionRecent(const QcConfig& qcConfig);
+
   std::vector<PcrPrimerCsvRow> parsePcrPrimersCsv(//
     const std::string& pcrPrimersCsvString,       //
     const std::string& filename                   //

--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -50,6 +50,7 @@ namespace Nextclade {
   };
 
   struct QcConfig {
+    std::string schemaVersion;
     QCRulesConfigMissingData missingData;
     QCRulesConfigMixedSites mixedSites;
     QCRulesConfigPrivateMutations privateMutations;

--- a/packages/nextclade/src/io/parseQcConfig.cpp
+++ b/packages/nextclade/src/io/parseQcConfig.cpp
@@ -4,8 +4,10 @@
 #include <nextclade/nextclade.h>
 
 #include <nlohmann/json.hpp>
+#include <semver.hpp>
 
 #include "parseAnalysisResults.h"
+#include "qc/isQcConfigVersionRecent.h"
 
 
 namespace Nextclade {
@@ -53,6 +55,11 @@ namespace Nextclade {
       json j = json::parse(qcConfigJsonStr);
 
       QcConfig qcConfig{};
+
+      // Version prior to 1.2.0 did not include "schemaVersion" field.
+      // Treat files without this field as them as "1.1.0".
+      readValue(j, "/schemaVersion", qcConfig.schemaVersion, std::string{"1.1.0"});
+
 
       readValue(j, "/missingData/enabled", qcConfig.missingData.enabled, false);
       if (qcConfig.missingData.enabled) {

--- a/packages/nextclade/src/io/serializeQcConfig.cpp
+++ b/packages/nextclade/src/io/serializeQcConfig.cpp
@@ -24,6 +24,8 @@ namespace Nextclade {
   std::string serializeQcConfig(Nextclade::QcConfig& qcConfig) {
     auto j = json::object();
 
+    writeValue(j, "/schemaVersion", std::string{Nextclade::getVersion()});
+
     writeValue(j, "/missingData/enabled", qcConfig.missingData.enabled);
     if (qcConfig.missingData.enabled) {
       writeValue(j, "/missingData/missingDataThreshold", qcConfig.missingData.missingDataThreshold);

--- a/packages/nextclade/src/qc/isQcConfigVersionRecent.cpp
+++ b/packages/nextclade/src/qc/isQcConfigVersionRecent.cpp
@@ -1,0 +1,12 @@
+#include "isQcConfigVersionRecent.h"
+
+#include <nextclade/nextclade.h>
+
+#include <semver.hpp>
+
+namespace Nextclade {
+  bool isQcConfigVersionRecent(const QcConfig& qcConfig) {
+    const auto schemaVersion = semver::version{qcConfig.schemaVersion};
+    return schemaVersion >= semver::version{Nextclade::getVersion()};
+  }
+}// namespace Nextclade

--- a/packages/nextclade/src/qc/isQcConfigVersionRecent.h
+++ b/packages/nextclade/src/qc/isQcConfigVersionRecent.h
@@ -1,9 +1,3 @@
 #pragma once
 
-
-namespace Nextclade {
-
-  struct QcConfig;
-
-  bool isQcConfigVersionRecent(const QcConfig& qcConfig);
-}// namespace Nextclade
+#include <nextclade/nextclade.h>

--- a/packages/nextclade/src/qc/isQcConfigVersionRecent.h
+++ b/packages/nextclade/src/qc/isQcConfigVersionRecent.h
@@ -1,0 +1,9 @@
+#pragma once
+
+
+namespace Nextclade {
+
+  struct QcConfig;
+
+  bool isQcConfigVersionRecent(const QcConfig& qcConfig);
+}// namespace Nextclade

--- a/packages/nextclade_cli/src/cli.cpp
+++ b/packages/nextclade_cli/src/cli.cpp
@@ -1028,6 +1028,13 @@ int main(int argc, char *argv[]) {
 
     const auto qcJsonString = readFile(cliParams.inputQcConfig);
     const auto qcRulesConfig = Nextclade::parseQcConfig(qcJsonString);
+    if (!Nextclade::isQcConfigVersionRecent(qcRulesConfig)) {
+      logger.warn(
+        "The QC configuration file \"{:s}\" version ({:s}) is older than the version of Nextclade ({:s}). You might be "
+        "missing out on new features. It is recommended to download the latest configuration file. Alternatively, to "
+        "silence this warning, add/change property \"schemaVersion\": \"{:s}\" in your file.",
+        cliParams.inputQcConfig, qcRulesConfig.schemaVersion, Nextclade::getVersion(), Nextclade::getVersion());
+    }
 
     const auto treeString = readFile(cliParams.inputTree);
 

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -139,6 +139,7 @@ export interface QCRulesConfigStopCodons {
 }
 
 export interface QcConfig {
+  schemaVersion: string
   missingData: QCRulesConfigMissingData
   mixedSites: QCRulesConfigMixedSites
   privateMutations: QCRulesConfigPrivateMutations


### PR DESCRIPTION
The `qc.json` is now versioned (with `"schemaVersion"` field), checks are made optional where possible, and warning is emitted is JSON is older than Nextclade. Here are the most important cases:

 - It will crash if at least one required field is missing ("knownStopCodons" in this case):
     ```json5
     {
       "stopCodons": { "enabled": true }
     }
     ```

    The error message is:

    > [ERROR] Nextclade: Error: When parsing QC configuration file: key "/stopCodons/knownStopCodons" is missing


 - These are valid. The check won't run.
    ```json5
    {
      // nothing
    }
    
    {
      "stopCodons": {}
    }
    
    {
      "stopCodons": { "enabled": false }
    }
    
    ```

 - The only way to enable a check is to have `"enabled": true` and all of the required params present and have valid values:
    ```json5
    {
      "stopCodons": { "enabled": true, "knownStopCodons": [] }
    }
    
    {
      "stopCodons": { "enabled": true, "knownStopCodons": [{"geneName": "ORF8", "codon": 26}] }
    }
    
    ```


 - These will trigger a warning in version 1.2.0 and above, prompting user to upgrade the file:
    ```json5
    {
      // no "schemaVersion"
    }
    
    {
      "schemaVersion": "1.1.0",
    }
    ```

 - The warning message is as follows:

    > [ WARN] Nextclade: The QC configuration file "data/sars-cov-2/qc.json" version (1.1.0) is older than the version of Nextclade (1.2.0). You might be missing out on new features. It is recommended to download the latest configuration file. Alternatively, to silence this warning, add/change property "schemaVersion": "1.2.0" in your file.


    We might add some more details on ow exactly to update the file when we figure out data distribution.

 - No warning with this:

    ```json5
    {
      "schemaVersion": "1.2.0",
    }
    
    {
      "schemaVersion": "1.3.5",
    }
    
    ```

    But perhaps should warn about the opposite, to upgrade Nextclade CLI?


 - There is no easy way to tell user what features are enabled. We would need to maintain a list of strings in-sync with the struct, plus bunch of manual checks, and not forget when updating any of that. I don't think it is worth the hassle, as we have more important stuff to do.
