### PR TITLE
Ignore stop codon ORF8:68*

### DIFF
--- a/data/sars-cov-2/qc.json
+++ b/data/sars-cov-2/qc.json
@@ -25,6 +25,9 @@
   },
   "stopCodons": {
     "enabled": true,
-    "ignoredStopCodons": [{"geneName": "ORF8", "codon": 26}]
+    "ignoredStopCodons": [
+      {"geneName": "ORF8", "codon": 26},
+      {"geneName": "ORF8", "codon": 67}
+    ]
   }
 }


### PR DESCRIPTION
Adds `ORF8:68*` to the ignore list of misplaced stop codons for the "Stop codon" QC rule.