### PR TITLE
feat: adjust QC scores for frame shits and stop codons

### DIFF
--- a/packages/nextclade/src/qc/ruleFrameShifts.cpp
+++ b/packages/nextclade/src/qc/ruleFrameShifts.cpp
@@ -19,7 +19,7 @@ namespace Nextclade {
 
     int totalFrameShifts = safe_cast<int>(alignment.frameShifts.size());
 
-    const double score = totalFrameShifts > 0 ? 100.0 : 0.0;
+    const double score = totalFrameShifts * 75;
     const auto& status = getQcRuleStatus(score);
 
     return QcResultFrameShifts{

--- a/packages/nextclade/src/qc/ruleStopCodons.cpp
+++ b/packages/nextclade/src/qc/ruleStopCodons.cpp
@@ -46,7 +46,7 @@ namespace Nextclade {
       }
     }
 
-    const double score = totalStopCodons > 0 ? 100.0 : 0.0;
+    const double score = totalStopCodons * 75;
     const auto& status = getQcRuleStatus(score);
 
     return QcResultStopCodons{


### PR DESCRIPTION
Previously, for frame shifts and stop codons QC rules, the score assigned was:
 - 0 is no detected
 - 100 if at least 1 detected

This PR changes score to be `n * 75`, where `n` is number of detections

