### PR TITLE
Fix vercel build

### DIFF
--- a/scripts/build_locally.sh
+++ b/scripts/build_locally.sh
@@ -38,8 +38,13 @@ export NEXTCLADE_EMSDK_VERSION_DEFAULT=2.0.6
 export NEXTCLADE_EMSDK_VERSION=${NEXTCLADE_EMSDK_VERSION:=${NEXTCLADE_EMSDK_VERSION_DEFAULT}}
 export NEXTCLADE_EMSDK_DIR_DEFAULT="${PROJECT_ROOT_DIR}/.cache/.emscripten/emsdk-${NEXTCLADE_EMSDK_VERSION}"
 export NEXTCLADE_EMSDK_DIR=${NEXTCLADE_EMSDK_DIR:=${NEXTCLADE_EMSDK_DIR_DEFAULT}}
-export NEXTCLADE_EMSDK_CACHE_DEFAULT="${PROJECT_ROOT_DIR}/.cache/.emscripten/emsdk_cache-${NEXTCLADE_EMSDK_VERSION}"
-export NEXTCLADE_EMSDK_CACHE="${NEXTCLADE_EMSDK_CACHE:=${NEXTCLADE_EMSDK_CACHE_DEFAULT}}"
+export NEXTCLADE_EMSDK_USE_CACHE="${NEXTCLADE_EMSDK_USE_CACHE:=1}"
+
+NEXTCLADE_EMSDK_CACHE=""
+if [ "${NEXTCLADE_EMSDK_USE_CACHE}" == "1" ]; then
+  export NEXTCLADE_EMSDK_CACHE_DEFAULT="${PROJECT_ROOT_DIR}/.cache/.emscripten/emsdk_cache-${NEXTCLADE_EMSDK_VERSION}"
+  export NEXTCLADE_EMSDK_CACHE="${NEXTCLADE_EMSDK_CACHE:=${NEXTCLADE_EMSDK_CACHE_DEFAULT}}"
+fi
 
 export CONAN_USER_HOME="${CONAN_USER_HOME:=${PROJECT_ROOT_DIR}/.cache}"
 export CCACHE_DIR="${CCACHE_DIR:=${PROJECT_ROOT_DIR}/.cache/.ccache}"
@@ -369,10 +374,13 @@ GTPP="${GTPP:=${GTTP_DEFAULT}}"
 # Generate a semicolon-delimited list of arguments for cppcheck
 # (to run during cmake build). The arguments are taken from the file
 # `.cppcheck` in the source root
-CMAKE_CXX_CPPCHECK="cppcheck;--template=gcc"
-while IFS='' read -r flag; do
-  CMAKE_CXX_CPPCHECK="${CMAKE_CXX_CPPCHECK};${flag}"
-done<"${THIS_DIR}/../.cppcheck"
+CMAKE_CXX_CPPCHECK=""
+if command -v "cppcheck"; then
+  CMAKE_CXX_CPPCHECK="cppcheck;--template=gcc"
+  while IFS='' read -r flag; do
+    CMAKE_CXX_CPPCHECK="${CMAKE_CXX_CPPCHECK};${flag}"
+  done<"${THIS_DIR}/../.cppcheck"
+fi
 
 # Print coloured message
 function print() {
@@ -407,10 +415,11 @@ echo "CMAKE_BUILD_TYPE         = ${CMAKE_BUILD_TYPE:=}"
 echo "CONAN_BUILD_TYPE         = ${CONAN_BUILD_TYPE:=}"
 echo "NEXTALIGN_STATIC_BUILD   = ${NEXTALIGN_STATIC_BUILD:=}"
 echo ""
-echo "NEXTCLADE_BUILD_WASM     = ${NEXTCLADE_BUILD_WASM}"
-echo "NEXTCLADE_EMSDK_VERSION  = ${NEXTCLADE_EMSDK_VERSION}"
-echo "NEXTCLADE_EMSDK_DIR      = ${NEXTCLADE_EMSDK_DIR}"
-echo ""
+echo "NEXTCLADE_BUILD_WASM        = ${NEXTCLADE_BUILD_WASM}"
+echo "NEXTCLADE_EMSDK_VERSION     = ${NEXTCLADE_EMSDK_VERSION}"
+echo "NEXTCLADE_EMSDK_DIR         = ${NEXTCLADE_EMSDK_DIR}"
+echo "NEXTCLADE_EMSDK_USE_CACHE   = ${NEXTCLADE_EMSDK_USE_CACHE}"
+echo "NEXTCLADE_EMSDK_CACHE       = ${NEXTCLADE_EMSDK_CACHE}"
 echo ""
 echo "USE_COLOR                = ${USE_COLOR:=}"
 echo "USE_CLANG                = ${USE_CLANG:=}"
@@ -560,8 +569,12 @@ pushd "${BUILD_DIR}" > /dev/null
 
 popd > /dev/null
 
-print 25 "Run cppcheck";
-. "${THIS_DIR}/cppcheck.sh"
+if command -v "cppcheck"; then
+  print 25 "Run cppcheck";
+  . "${THIS_DIR}/cppcheck.sh"
+else
+  print 25 "Skipping cppcheck: not found";
+fi
 
 
 if [ "${CROSS}" == "1" ]; then

--- a/scripts/build_on_vercel.sh
+++ b/scripts/build_on_vercel.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+BASH_DEBUG="${BASH_DEBUG:=}"
+([ "${BASH_DEBUG}" == "true" ] || [ "${BASH_DEBUG}" == "1" ]) && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+shopt -s dotglob
+trap "exit" INT
+
+set -x
+
+# Directory where this script resides
+THIS_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
+
+# Where the source code is
+PROJECT_ROOT_DIR="$(realpath ${THIS_DIR}/..)"
+
+source "${PROJECT_ROOT_DIR}/.env.example"
+if [ -f "${PROJECT_ROOT_DIR}/.env" ]; then
+  source "${PROJECT_ROOT_DIR}/.env"
+fi
+
+export PATH=/usr/sbin${PATH:+":$PATH"}
+
+# Vercel caches `node_modules/`, so let's put our caches there
+export CACHE_DIR="${PROJECT_ROOT_DIR}/node_modules"
+
+# Deps that are not cached
+export DEPS_DIR="${PROJECT_ROOT_DIR}/deps"
+
+mkdir -p "${CACHE_DIR}"
+mkdir -p "${DEPS_DIR}"
+
+# Vercel seems to be currently using VMs provisioned with Amazon Linux 2, which is a derivative of RHEL 7,
+# If something breaks, perhaps they've changed things.
+cat /etc/os-release
+cat /etc/image-id
+cat /etc/system-release
+echo "RHEL version: $(rpm -E %{rhel} || echo 'unknown')"
+
+# Disable yum fastestmirror plugin. It only makes things slower.
+printf "[main]\nenabled=0\n" > "/etc/yum/pluginconf.d/fastestmirror.conf"
+
+# Remove some dead symlinks which cause log pollution
+rm /lib64/libvips-cpp.so.42
+rm /lib64/libvips.so.42
+
+# Remove default Python. It does not have SQLite module enabled required for `conan`.
+rm -rf /usr/local/bin/python3.6
+rm -rf /usr/local/lib/python3.6
+
+# Add "UIS" repos, with more up-to-date packages (https://ius.io/)
+# Python 3.6 from IUS has SQLite enabled.
+yum install -y -q \
+"https://repo.ius.io/ius-release-el7.rpm" \
+"https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+
+yum update -y -q
+
+yum install -y -q --enablerepo=ius \
+  ccache \
+  sqlite \
+  sqlite-devel \
+  python36u python36u-libs python36u-devel python36u-pip \
+  xz
+
+# Set Python 3.6 from UIS as  default
+alternatives --install /usr/bin/python python /usr/bin/python3.6 60 || true
+alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 60 || true
+alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.6 60 || true
+alternatives --install /usr/bin/python3.6 python3.6 /usr/bin/python3.6 60 || true
+ln -s /usr/bin/python3.6 /usr/local/bin/python3.6 || true
+ln -s /usr/lib/python3.6 /usr/local/lib/python3.6 || true
+export PYTHONPATH=/usr/lib/python3.6${PYTHONPATH:+":$PYTHONPATH"}
+
+
+# Make sure Python has SQLite module enabled
+which "python3"
+python3 -c "import sqlite3; print(sqlite3.sqlite_version)" || true
+
+python3 -m pip install --upgrade --quiet conan
+
+# Install CMake
+curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-linux-x86_64.tar.gz | tar xfz - --strip-components=1 -C "${DEPS_DIR}/"
+export PATH="${DEPS_DIR}/bin:${PATH}"
+
+# `ccache` produces relatively small cache, let's keep it
+export CCACHE_DIR="${CACHE_DIR}/ccache"
+
+# `emsdk` cache is too big to fit to Vercel's 500MB allowed, so don't cache.
+export NEXTCLADE_EMSDK_USE_CACHE="0"
+
+make prod-wasm-nowatch
+
+pushd packages/web >/dev/null
+  cp .env.vercel .env
+popd >/dev/null
+
+make prod-web-nowatch


### PR DESCRIPTION
Vercel build was broken since we moved to C++ and WASM. Other CIs use Docker for wasm build, but Vecel does not allow to run Docker containers (a branch with my attempts: [abandoned/chore/vercel-docker](https://github.com/nextstrain/nextclade/tree/abandoned/chore/vercel-docker))

This PR runs WASM and web build on Vercel's VM, which seems to be using Amazon Linux 2 distro. This setup assumes it runs on Amazon Linux 2 and if Vercel changes this one day, then everything will break.

Several hacks were implemented, in particular for Python SQLIte support, which is required for Conan.

