### PR TITLE
fix: results table and tree layout in safari

### DIFF
--- a/packages/web/src/components/Layout/LayoutResults.tsx
+++ b/packages/web/src/components/Layout/LayoutResults.tsx
@@ -21,6 +21,7 @@ const Header = styled.header`
 
 const MainContent = styled.main`
   flex-grow: 1;
+  flex-basis: 100%;
   overflow: auto;
   min-height: 2em;
 `

--- a/packages/web/src/components/Results/ResultsPage.tsx
+++ b/packages/web/src/components/Results/ResultsPage.tsx
@@ -49,7 +49,8 @@ const HeaderRightContainer = styled.div`
 `
 
 const MainContent = styled.main`
-  flex-grow: 1;
+  flex: 1;
+  flex-basis: 100%;
   overflow: auto;
   border: none;
 `

--- a/packages/web/src/components/Tree/TreePage.tsx
+++ b/packages/web/src/components/Tree/TreePage.tsx
@@ -13,6 +13,8 @@ import { Tree } from './Tree'
 import { Sidebar } from './Sidebar'
 
 export const Container = styled.div`
+  flex: 1;
+  flex-basis: 100%;
   width: 100%;
   height: 100%;
   min-width: 1000px;
@@ -38,12 +40,15 @@ const HeaderCenter = styled.header`
 `
 
 const MainContent = styled.main`
-  flex-grow: 1;
+  flex: 1;
+  flex-basis: 100%;
   overflow-y: hidden;
 `
 
 const AuspiceContainer = styled.div`
   display: flex;
+  flex: 1;
+  flex-basis: 100%;
   height: 100%;
 `
 


### PR DESCRIPTION
Here we apply `flex-basis: 100%` in a few places, because older versions of Safari (< 14) do not apply correct height in column-based flex layouts the compound syntax is used (e.g. `flex: 1 0 100%` results in zero height) or if omitted.

