### PR TITLE
fix: avoid crash when the `scale` property is missing in a tree coloring

### DIFF
--- a/packages/nextclade/src/tree/Tree.cpp
+++ b/packages/nextclade/src/tree/Tree.cpp
@@ -111,8 +111,6 @@ namespace Nextclade {
       for (auto& coloring : colorings) {
         const auto& key = coloring.at("key");
         if (key == "region" || key == "country" || key == "division") {
-          const auto& title = coloring.at("title");
-          const auto& type = coloring.at("type");
           const auto& oldScale = get(coloring, "scale", json::array());
 
           auto scale = json::array({
@@ -124,12 +122,7 @@ namespace Nextclade {
             scale.push_back(sc);
           }
 
-          coloring = json::object({
-            {"key", key},
-            {"scale", scale},
-            {"title", title},
-            {"type", type},
-          });
+          coloring.at("scale") = scale;
         }
       }
 


### PR DESCRIPTION
Here we remove assumption that the `meta.colorings[].scale` property is present on colorings of `type` `categorical`. We are also checking if the `scale` is an array, before attempting to push new values into it.

This change should make Nextclade more robust to some of the input tree files.

Only the colorings with keys`region`, `country` and `division` are affected.

