### PR TITLE
fix: incorrect snp cluster ranges

### DIFF
--- a/packages/nextclade/src/qc/ruleSnpClusters.cpp
+++ b/packages/nextclade/src/qc/ruleSnpClusters.cpp
@@ -6,14 +6,19 @@
 #include <optional>
 #include <vector>
 
+#include "../utils/contract.h"
 #include "../utils/safe_cast.h"
 #include "getQcRuleStatus.h"
 
+
 namespace Nextclade {
-  std::vector<std::vector<int>> findSnpClusters(                //
-    const std::vector<NucleotideSubstitution>& privateMutations,//
-    const QCRulesConfigSnpClusters& config                      //
+  std::vector<std::vector<int>> findSnpClusters(                   //
+    const std::vector<NucleotideSubstitution>& privateMutationsRaw,//
+    const QCRulesConfigSnpClusters& config                         //
   ) {
+    auto privateMutations = privateMutationsRaw;
+    std::sort(privateMutations.begin(), privateMutations.end());
+
     const auto clusterCutOff = safe_cast<size_t>(config.clusterCutOff);
     std::deque<int> currentCluster;
     std::vector<std::vector<int>> allClusters;
@@ -60,7 +65,7 @@ namespace Nextclade {
   }
 
   std::optional<QCResultSnpClusters> ruleSnpClusters(           //
-    const AnalysisResult&,                                     //
+    const AnalysisResult&,                                      //
     const std::vector<NucleotideSubstitution>& privateMutations,//
     const QCRulesConfigSnpClusters& config                      //
   ) {

--- a/packages/nextclade/src/qc/ruleSnpClusters.cpp
+++ b/packages/nextclade/src/qc/ruleSnpClusters.cpp
@@ -39,6 +39,10 @@ namespace Nextclade {
       previousPos = pos;
     }
 
+    for (auto& cluster : allClusters) {
+      std::sort(cluster.begin(), cluster.end());
+    }
+
     return allClusters;
   }
 


### PR DESCRIPTION
Looks like the code assumed that the positions of mutations in clusters were sorted ascending and took cluster range boundaries as first and last positions.

https://github.com/nextstrain/nextclade/blob/392a741176cefe5defeff54675240c876c95f105/packages/nextclade/src/qc/ruleSnpClusters.cpp#L54-L55

But mutation positions were not sorted. This lead to incorrect ranges, sometimes with wrong, sometimes with inverted boundaries.

This PR adds sorting to mitigate that.

