### PR TITLE
feat: simplify tree node info dialog

### DIFF
--- a/packages/nextclade/src/tree/treeAttachNodes.cpp
+++ b/packages/nextclade/src/tree/treeAttachNodes.cpp
@@ -262,8 +262,10 @@ namespace Nextclade {
 
     newNode.setNodeAttr("Has PCR primer changes", result.totalPcrPrimerChanges > 0 ? "Yes" : "No");
 
-    newNode.setNodeAttr("PCR primer changes",
-      formatAndJoinMaybeEmpty(result.pcrPrimerChanges, formatPcrPrimerChange, ", "));
+    if (result.totalPcrPrimerChanges > 0) {
+      newNode.setNodeAttr("PCR primer changes",
+        formatAndJoinMaybeEmpty(result.pcrPrimerChanges, formatPcrPrimerChange, ", "));
+    }
 
     newNode.setNodeAttr("QC Status", formatQcStatus(result.qc.overallStatus));
 

--- a/packages/nextclade/src/tree/treeAttachNodes.cpp
+++ b/packages/nextclade/src/tree/treeAttachNodes.cpp
@@ -267,8 +267,6 @@ namespace Nextclade {
 
     newNode.setNodeAttr("QC Status", formatQcStatus(result.qc.overallStatus));
 
-    newNode.setNodeAttr("QC Flags", formatQcFlags(result.qc));
-
     auto tempMutations = node.mutations();
     for (const auto& mutStr : nucMutations) {
       // TODO: This parsing seems redundant. Can we avoid converting these to strings in upstream code?


### PR DESCRIPTION
This simplifies the dialog to avoid duplicated and poorly formatted information.

 - [x] Remove "QC Flags" from tree node info
 - [x] Don't show "PCR primer changes: None" when "Has PCR primer changes: No". It still shows "PCR primer changes" when they are present.

Note that this affects the output tree JSON.
