### PR TITLE
use nextstrain-sphinx-theme in nextclade docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,7 @@ html_css_files = [
 html_favicon = '_static/favicon.ico'
 
 html_theme_options = {
-    'display_version': False,
-    'logo_only': True,
+    'logo_only': False,
     'collapse_navigation': False,
     'titles_only': True,
 }


### PR DESCRIPTION
It was already in the environment for docs here but not being specified in the conf.py file. @ivan-aksamentov let me know if you'd like to petition for any of the options you specified which aren't in https://github.com/nextstrain/sphinx-theme to be included in it.