### PR TITLE
fix: ensure there are no false QC schema version warnings

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -538,4 +538,8 @@ namespace Nextclade {
   std::string formatStopCodon(const StopCodonLocation& stopCodon);
 
   const char* getVersion();
+
+  const char* getAnalysisResultsJsonSchemaVersion();
+
+  const char* getQcConfigJsonSchemaVersion();
 }// namespace Nextclade

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -326,9 +326,8 @@ namespace Nextclade {
   }
 
   std::string serializeResults(const std::vector<AnalysisResult>& results) {
-    const std::string SCHEMA_VERSION = "1.0.0";
     auto j = json::object();
-    j.emplace("schemaVersion", SCHEMA_VERSION);
+    j.emplace("schemaVersion", Nextclade::getAnalysisResultsJsonSchemaVersion());
     j.emplace("nextcladeVersion", Nextclade::getVersion());
     j.emplace("timestamp", getTimestampNow());
     j.emplace("results", serializeResultsArray(results));

--- a/packages/nextclade/src/nextclade.cpp
+++ b/packages/nextclade/src/nextclade.cpp
@@ -179,4 +179,13 @@ namespace Nextclade {
   const char* getVersion() {
     return PROJECT_VERSION;
   }
+
+  const char* getAnalysisResultsJsonSchemaVersion() {
+    return "1.0.0";
+  }
+
+  const char* getQcConfigJsonSchemaVersion() {
+    return "1.2.0";
+  }
+
 }// namespace Nextclade

--- a/packages/nextclade/src/qc/isQcConfigVersionRecent.cpp
+++ b/packages/nextclade/src/qc/isQcConfigVersionRecent.cpp
@@ -7,6 +7,6 @@
 namespace Nextclade {
   bool isQcConfigVersionRecent(const QcConfig& qcConfig) {
     const auto schemaVersion = semver::version{qcConfig.schemaVersion};
-    return schemaVersion >= semver::version{Nextclade::getVersion()};
+    return schemaVersion >= semver::version{Nextclade::getQcConfigJsonSchemaVersion()};
   }
 }// namespace Nextclade

--- a/packages/nextclade_cli/src/cli.cpp
+++ b/packages/nextclade_cli/src/cli.cpp
@@ -1030,10 +1030,10 @@ int main(int argc, char *argv[]) {
     const auto qcRulesConfig = Nextclade::parseQcConfig(qcJsonString);
     if (!Nextclade::isQcConfigVersionRecent(qcRulesConfig)) {
       logger.warn(
-        "The QC configuration file \"{:s}\" version ({:s}) is older than the version of Nextclade ({:s}). You might be "
-        "missing out on new features. It is recommended to download the latest configuration file. Alternatively, to "
-        "silence this warning, add/change property \"schemaVersion\": \"{:s}\" in your file.",
-        cliParams.inputQcConfig, qcRulesConfig.schemaVersion, Nextclade::getVersion(), Nextclade::getVersion());
+        "The version of QC configuration file \"{:s}\" (`\"schemaVersion\": \"{:s}\"`) is older than the QC "
+        "configuration version expected by Nextclade ({:s}). "
+        "You might be missing out on new features. It is recommended to download the latest QC configuration file.",
+        cliParams.inputQcConfig, qcRulesConfig.schemaVersion, Nextclade::getQcConfigJsonSchemaVersion());
     }
 
     const auto treeString = readFile(cliParams.inputTree);


### PR DESCRIPTION
Currently Nextclade expects QC config `schemaVersion` to match Nextclade version itself. This means QC `schemaVersion` needs to be updated on every release.

This is no longer convenient now that we will be transitioning to the separate datasets repo. So instead we freeze the QC `schemaVersion` on a particular semver string hardcoded in Nextclade code.

Analysis results JSON `schemaVersion` was also refactored to bring the two versions closer together, even though Analysis results JSON `schemaVersion` is only used to write results and not checked or read anywhere for now.

