### PR TITLE
feat(cli): remove output-subdir flag

### DIFF
--- a/packages/nextclade_cli/cli.json
+++ b/packages/nextclade_cli/cli.json
@@ -321,17 +321,10 @@
             },
             {
               "flags": ["-o", "--output-dir"],
-              "desc": "Path to parent directory to write dataset directory to. If the directory tree does not exist, it will be created.",
+              "desc": "Path to directory to write dataset files to. If the target directory tree does not exist, it will be created.",
               "cppName": "outputDir",
               "cppType": "std::string",
               "isOptional": false
-            },
-            {
-              "flags": ["-O", "--output-subdir"],
-              "desc": "Name of the output dataset subdirectory, nested under the path provided by `--output-dir`. If the directory tree does not exist, it will be created. If omitted, the default is: '{name}_{tag}', evaluated dynamically depending on the dataset name and version tag.",
-              "cppName": "outputSubdir",
-              "cppType": "std::string",
-              "isOptional": true
             }
           ]
         },

--- a/packages/nextclade_cli/src/commands/executeCommandDatasetGet.cpp
+++ b/packages/nextclade_cli/src/commands/executeCommandDatasetGet.cpp
@@ -63,15 +63,8 @@ namespace Nextclade {
         " This is a bug. Please report it to developers.");
     }
 
-    const auto& dataset = datasets[0];
     const auto& version = datasets[0].datasetRefs[0].versions[0];
 
-    auto outputSubdir = cliParams->outputSubdir;
-    if (outputSubdir.empty()) {
-      outputSubdir = fmt::format("{}_{}", dataset.name, version.tag);
-    }
-
-    const auto outputPath = (fs::path(cliParams->outputDir) / outputSubdir).string();
-    fetchDatasetVersion(version, outputPath);
+    fetchDatasetVersion(version, cliParams->outputDir);
   }
 }// namespace Nextclade


### PR DESCRIPTION
The presence of 2 flags for output directory makes command line interface awkward to use.

Now that we emit `tag,json` file along with dataset files, it should help users to identify downloaded datasets regardless of directory name.

This removes the `--output-subdir` flag, keeping only `--output-dir`
