### PR TITLE
feat: add dataset-related URL parameters

### DIFF
--- a/docs/user/nextclade-web.md
+++ b/docs/user/nextclade-web.md
@@ -123,17 +123,37 @@ Once Nextclade has finished its analysis, you can download the results in a vari
 ### URL parameters
 
 Input files can be specified in the URL parameters. The name of the parameters match the corresponding `--input*`
-command-line flags of [Nextclade CLI](nextclade-cli). This way third party applications can hotlink to Nextclade and trigger the analysis.
+flags of [Nextclade CLI](nextclade-cli) and flags of the `dataset get` command for datasets.
 
-Nextclade is the client-side only, single page web application, hosted on a static server. We do not set any usage limits for the analyses triggered this way. All the computation triggered this way will happen on the end-user machine.
+You can learn more about input files and datasets in sections: [Input files](input-files), and [Nextclade datasets](datasets).
+
+If `input-fasta` URL parameter is provided, Nextclade Web automatically starts the analysis after all input and dataset files are downloaded.
+
+All parameters are optional.
+
+| URL parameter      | Meaning |
+|--------------------|---------|
+| input-fasta        | URL to a fasta file containing query sequences. If provided, the analysis will start automatically. 
+| input-root-seq     | URL to a fasta file containing reference (root) sequence.
+| input-tree         | URL to a Auspice JSON v2 file containing reference tree.
+| input-pcr-primers  | URL to a CSV file containing PCR primers.
+| input-qc-config    | URL to a JSON file containing QC onfiguration.
+| input-gene-map     | URL to a GFF3 file containing gene map.
+| dataset-name       | Safe name of the dataset to use. Examples: `sars-cov-2`, `flu_h3n2_ha`
+| dataset-reference  | Accession of the reference sequence of the dataset to use: Examples: `MN908947`, `CY034116`.
+| dataset-tag        | Version tag of the dataset to use.
 
 For example, the file with input sequences hosted at `https://example.com/sequences.fasta` can be specified with:
 
 ```
-https://clades.nextstrain.org?input-fasta=https://example.com/sequences.fasta
+https://clades.nextstrain.org
+    ?input-fasta=https://example.com/sequences.fasta
 ```
 
-In this case, Nextclade will skip the home page and will automatically start the analysis.
+(the newlines and the indentation are added here for readability, they should not be present in the URL)
+
+In this case, Nextclade will download the default dataset (currently: SARS-CoV2 based on MN908947 reference), thill download the privided file, will skip the home page and will automatically start the analysis.
+
 
 Multiple files can be specified, for example the sequences and the reference tree:
 
@@ -143,11 +163,28 @@ https://clades.nextstrain.org
     &input-tree=https://example.com/tree.json
 ```
 
-(the newlines and the indentation are added here for readability, they should not be present in the URL)
+Another dataset can be specified with `dataset-name`:
 
-The linked resources should be available for fetching by a web browser on the client machine. Make sure [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is enabled on your file server as well as that all required authentication (if any) is included into the file URL itself.
+```
+https://clades.nextstrain.org
+    ?dataset-name=flu_h3n2_ha
+    &input-fasta=https://example.com/flu_sequences.fasta
+```
 
-The URLs might get quite complex, so don't forget to [encode the special characters](https://en.wikipedia.org/wiki/Percent-encoding), to keep the URLs valid.
+Another dataset based on a particular reference sequence can be specified with a combination of `dataset-name` and `dataset-reference`:
+
+```
+https://clades.nextstrain.org
+    ?dataset-name=flu_h3n2_ha
+    &dataset-reference=CY034116
+    &input-fasta=https://example.com/flu_sequences.fasta
+```
+
+> 💡 Nextclade is a client-side-only, single-page web application, hosted on a static server. We do not set any usage limits for the analyses triggered. Note that all the computation will happen on the end-user machine.
+
+> ⚠️The linked resources should be available for fetching by a web browser on the client machine. Make sure [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is enabled on your file server as well as that all required authentication (if any) is included into the file URL itself.
+
+> ⚠️The URLs might get quite complex, so don't forget to [encode the special characters](https://en.wikipedia.org/wiki/Percent-encoding), to keep the URLs valid.
 
 ## What's next?
 

--- a/packages/web/src/components/Main/DatasetSelector.tsx
+++ b/packages/web/src/components/Main/DatasetSelector.tsx
@@ -1,36 +1,19 @@
-/* eslint-disable no-loops/no-loops */
-import React, { useEffect, useMemo, useState } from 'react'
+import React from 'react'
 
-import { maxBy, mapValues } from 'lodash'
 import { connect } from 'react-redux'
-import urljoin from 'url-join'
-import semver from 'semver'
+import {
+  selectDefaultDatasetName,
+  selectDatasets,
+  selectDefaultDatasetNameFriendly,
+  selectCurrentDataset,
+} from 'src/state/algorithm/algorithm.selectors'
 import styled from 'styled-components'
 
-import { useAxiosQuery } from 'src/helpers/useAxiosQuery'
-import type {
-  Dataset,
-  DatasetFiles,
-  DatasetFlat,
-  DatasetRef,
-  DatasetsIndexJson,
-  DatasetVersion,
-} from 'src/algorithms/types'
+import type { DatasetFlat } from 'src/algorithms/types'
 import type { State } from 'src/state/reducer'
-import { setDataset } from 'src/state/algorithm/algorithm.actions'
-import { Dropdown as DropdownBase } from 'src/components/Common/Dropdown'
-import type { DropdownOption } from 'src/components/Common/DropdownOption'
-import { stringToOption } from 'src/components/Common/DropdownOption'
+import { setCurrentDataset } from 'src/state/algorithm/algorithm.actions'
 import { SpinnerWrapped } from 'src/components/Common/Spinner'
-
-const DATA_FULL_DOMAIN = process.env.DATA_FULL_DOMAIN ?? '/'
-const DATA_INDEX_FILE = 'index.json'
-const DATA_INDEX_FILE_FULL_URL = urljoin(DATA_FULL_DOMAIN, DATA_INDEX_FILE)
-const thisVersion = process.env.PACKAGE_VERSION ?? ''
-
-export function isCompatible({ min, max }: { min?: string; max?: string }) {
-  return semver.gte(thisVersion, min ?? thisVersion) && semver.lte(thisVersion, max ?? thisVersion)
-}
+import { DatasetSelectorDropdown } from './DatasetSelectorDropdown'
 
 const DropdownContainer = styled.div`
   position: relative;
@@ -43,12 +26,6 @@ const DropdownContainer = styled.div`
     margin-left: auto;
     margin-right: auto;
   }
-`
-
-const Dropdown = styled(DropdownBase)`
-  position: absolute;
-  top: 0;
-  left: 0;
 `
 
 const DropdownLoadingOverlay = styled.div`
@@ -66,133 +43,22 @@ const Spinner = styled(SpinnerWrapped)`
   height: 100%;
 `
 
-const ErrorText = styled.div`
-  flex: 1;
-  height: 98%;
-  margin: auto;
-  color: ${(props) => props.theme.danger};
-  border-radius: 3px;
-`
-
-export function fileUrlsToAbsolute(files: DatasetFiles): DatasetFiles {
-  return mapValues(files, (file: string) => urljoin(DATA_FULL_DOMAIN, file))
-}
-
-// eslint-disable-next-line sonarjs/cognitive-complexity
-export function getEnabledDatasets(datasets?: Dataset[]): Dataset[] {
-  const enabledDatasets: Dataset[] = []
-  for (const dataset of datasets ?? []) {
-    if (!dataset.enabled) {
-      continue // eslint-disable-line no-continue
-    }
-
-    const enabledDataset: Dataset = { ...dataset }
-    enabledDataset.datasetRefs = []
-
-    for (const datasetRef of dataset.datasetRefs) {
-      if (!datasetRef.enabled) {
-        continue // eslint-disable-line no-continue
-      }
-
-      const enabledDatasetRef: DatasetRef = { ...datasetRef }
-      enabledDatasetRef.versions = []
-
-      for (const version of datasetRef.versions) {
-        if (version.enabled) {
-          enabledDatasetRef.versions.push(version)
-        }
-      }
-
-      if (enabledDatasetRef.versions.length > 0) {
-        enabledDataset.datasetRefs.push(enabledDatasetRef)
-      }
-    }
-
-    if (enabledDataset.datasetRefs.length > 0) {
-      enabledDatasets.push(enabledDataset)
-    }
-  }
-
-  return enabledDatasets
-}
-
-export function getCompatibleDatasets(datasets?: Dataset[]): Dataset[] {
-  const compatibleDatasets: Dataset[] = []
-
-  for (const dataset of datasets ?? []) {
-    const compatibleDatasetRefs: DatasetRef[] = []
-
-    for (const datasetRef of dataset.datasetRefs) {
-      let compatibleVersions: DatasetVersion[] = []
-      for (const version of datasetRef.versions) {
-        if (isCompatible(version.compatibility.nextcladeWeb)) {
-          compatibleVersions.push(version)
-        }
-      }
-
-      compatibleVersions = compatibleVersions.map((ver) => ({ ...ver, files: fileUrlsToAbsolute(ver.files) }))
-
-      if (compatibleVersions.length > 0) {
-        compatibleDatasetRefs.push({
-          ...datasetRef,
-          versions: compatibleVersions,
-        })
-      }
-    }
-
-    if (compatibleDatasetRefs.length > 0) {
-      compatibleDatasets.push({
-        ...dataset,
-        datasetRefs: compatibleDatasetRefs,
-      })
-    }
-  }
-
-  return compatibleDatasets
-}
-
-export function getLatestDatasetsFlat(datasets?: Dataset[]): DatasetFlat[] {
-  const latestDatasetsFlat: DatasetFlat[] = []
-  for (const dataset of datasets ?? []) {
-    for (const datasetRef of dataset.datasetRefs) {
-      const latestVersion = maxBy(datasetRef.versions, (version) => version.tag)
-      if (latestVersion) {
-        latestDatasetsFlat.push({
-          ...dataset,
-          ...datasetRef,
-          ...latestVersion,
-          nameFriendly: `${dataset.nameFriendly} (${datasetRef.reference.strainName})`,
-        })
-      }
-    }
-  }
-
-  return latestDatasetsFlat
-}
-
-export function getLatestCompatibleEnabledDatasets(datasetsIndexJson?: DatasetsIndexJson) {
-  const datasets = getLatestDatasetsFlat(getCompatibleDatasets(getEnabledDatasets(datasetsIndexJson?.datasets)))
-
-  const defaultDatasetName = datasetsIndexJson?.settings.defaultDatasetName ?? ''
-  const defaultDataset = datasets.find((dataset) => dataset.name === defaultDatasetName)
-  let defaultDatasetNameFriendly = ''
-  if (defaultDataset) {
-    defaultDatasetNameFriendly = defaultDataset.nameFriendly
-  } else if (datasets.length > 0) {
-    defaultDatasetNameFriendly = datasets[0].nameFriendly
-  }
-
-  return { datasets, defaultDatasetName, defaultDatasetNameFriendly }
-}
-
 export interface DatasetSelectorProps {
-  setDataset(dataset?: DatasetFlat): void
+  datasets: DatasetFlat[]
+  defaultDatasetName?: string
+  datasetCurrent?: DatasetFlat
+  setDatasetCurrent(dataset?: DatasetFlat): void
 }
 
-const mapStateToProps = (state: State) => ({})
+const mapStateToProps = (state: State) => ({
+  datasets: selectDatasets(state),
+  defaultDatasetName: selectDefaultDatasetName(state),
+  defaultDatasetNameFriendly: selectDefaultDatasetNameFriendly(state),
+  datasetCurrent: selectCurrentDataset(state),
+})
 
 const mapDispatchToProps = {
-  setDataset,
+  setDatasetCurrent: setCurrentDataset,
 }
 
 export const DatasetSelector = connect(mapStateToProps, mapDispatchToProps)(DatasetSelectorDisconnected)
@@ -204,43 +70,22 @@ export function removeBoolean<T>(value: boolean | undefined | T): T | undefined 
   return value
 }
 
-export function DatasetSelectorDisconnected({ setDataset }: DatasetSelectorProps) {
-  const { data: datasetsIndexJson, error, isLoading, isFetching, isError } =
-    useAxiosQuery<DatasetsIndexJson>(DATA_INDEX_FILE_FULL_URL) // prettier-ignore
-
-  const isBusy = isLoading || isFetching
-
-  const { datasets, defaultDatasetNameFriendly } =
-    useMemo(() => getLatestCompatibleEnabledDatasets(datasetsIndexJson), [datasetsIndexJson]) // prettier-ignore
-
-  const datasetNames = useMemo(() => datasets.map((dataset) => dataset.nameFriendly), [datasets])
-  const virusNameOptionDefault = useMemo(() => stringToOption(defaultDatasetNameFriendly), [defaultDatasetNameFriendly])
-  const virusNameOptions = useMemo(() => datasetNames.map((datasetName) => stringToOption(datasetName)), [datasetNames])
-  const [current, setCurrent] = useState<DropdownOption<string>>(virusNameOptionDefault)
-
-  useEffect(() => {
-    setCurrent(virusNameOptionDefault)
-  }, [virusNameOptionDefault])
-
-  useEffect(() => {
-    const dataset = datasets.find((dataset) => dataset.nameFriendly === current.label)
-    setDataset(dataset)
-  }, [current, datasets, setDataset])
+export function DatasetSelectorDisconnected({
+  datasets,
+  defaultDatasetName,
+  datasetCurrent,
+  setDatasetCurrent,
+}: DatasetSelectorProps) {
+  const isBusy = datasets.length === 0 || !datasetCurrent
 
   return (
     <DropdownContainer>
-      <Dropdown
-        identifier="dataset.name"
-        options={removeBoolean(!isBusy && virusNameOptions) ?? []}
-        defaultOption={removeBoolean(!isBusy && virusNameOptionDefault)}
-        value={removeBoolean(!isBusy && current)}
-        onOptionChange={setCurrent}
-        isDisabled={isBusy}
-      />
-      {isError && error && (
-        <DropdownLoadingOverlay>
-          <ErrorText>{`${error.name}: ${error.message}`}</ErrorText>
-        </DropdownLoadingOverlay>
+      {datasetCurrent && (
+        <DatasetSelectorDropdown
+          datasets={datasets}
+          datasetCurrent={datasetCurrent}
+          setDatasetCurrent={setDatasetCurrent}
+        />
       )}
 
       {isBusy && <DropdownLoadingOverlay>{<Spinner type="ThreeDots" size={20} color="#aaa" />}</DropdownLoadingOverlay>}

--- a/packages/web/src/components/Main/DatasetSelectorDropdown.tsx
+++ b/packages/web/src/components/Main/DatasetSelectorDropdown.tsx
@@ -1,0 +1,31 @@
+import React, { useCallback, useMemo } from 'react'
+
+import styled from 'styled-components'
+
+import type { DatasetFlat } from 'src/algorithms/types'
+import { Dropdown as DropdownBase } from 'src/components/Common/Dropdown'
+import { stringToOption } from 'src/components/Common/DropdownOption'
+
+const Dropdown = styled(DropdownBase)`
+  position: absolute;
+  top: 0;
+  left: 0;
+`
+
+export interface DatasetSelectorDropdown {
+  datasets: DatasetFlat[]
+  datasetCurrent: DatasetFlat
+  setDatasetCurrent(dataset?: DatasetFlat): void
+}
+
+export function DatasetSelectorDropdown({ datasets, datasetCurrent, setDatasetCurrent }: DatasetSelectorDropdown) {
+  const current = useMemo(() => stringToOption(datasetCurrent.nameFriendly), [datasetCurrent.nameFriendly])
+  const options = useMemo(() => datasets.map((dataset) => stringToOption(dataset.nameFriendly)), [datasets])
+
+  const onOptionChange = useCallback(() => {
+    const dataset = datasets.find((dataset) => dataset.nameFriendly === current.label)
+    setDatasetCurrent(dataset)
+  }, [current.label, datasets, setDatasetCurrent])
+
+  return <Dropdown identifier="dataset.name" options={options} value={current} onOptionChange={onOptionChange} />
+}

--- a/packages/web/src/helpers/useAxiosQuery.ts
+++ b/packages/web/src/helpers/useAxiosQuery.ts
@@ -1,31 +1,7 @@
-import axios, { AxiosError, AxiosRequestConfig } from 'axios'
 import { useQuery } from 'react-query'
 import type { UseQueryOptions, UseQueryResult } from 'react-query'
 
-import { HttpRequestError } from 'src/io/AlgorithmInput'
-
-export async function axiosFetch<TData = unknown>(url: string, options?: AxiosRequestConfig): Promise<TData> {
-  let res
-  try {
-    res = await axios.get(url, options)
-  } catch (error_) {
-    const error = error_ as AxiosError
-    throw new HttpRequestError(error)
-  }
-
-  if (!res?.data) {
-    throw new Error(`Unable to fetch: request to URL "${url}" resulted in no data`)
-  }
-
-  return res.data as TData
-}
-
-/**
- * This version skips any transforms (such as JSON parsing) and returns plain string
- */
-export async function axiosFetchRaw(url: string, options?: AxiosRequestConfig): Promise<string> {
-  return axiosFetch(url, { ...options, transformResponse: [] })
-}
+import { axiosFetch } from 'src/io/axiosFetch'
 
 export interface UseAxiosQueryOptions<TData> extends UseQueryOptions<TData, Error> {
   delay?: number

--- a/packages/web/src/initialize.ts
+++ b/packages/web/src/initialize.ts
@@ -3,7 +3,6 @@ import type { Router } from 'next/router'
 import { configureStore } from 'src/state/store'
 import { setLocale } from 'src/state/settings/settings.actions'
 import { showWhatsNewMaybe } from 'src/helpers/showWhatsNewMaybe'
-import { fetchInputsAndRunMaybe } from 'src/io/fetchInputsAndRunMaybe'
 
 export interface InitializeParams {
   router: Router
@@ -25,8 +24,6 @@ export async function initialize({ router }: InitializeParams) {
   store.dispatch(setLocale(localeKeyV2))
 
   showWhatsNewMaybe(lastVersionSeen, showWhatsnewOnUpdate, store.dispatch)
-
-  await fetchInputsAndRunMaybe(store.dispatch, router)
 
   return { persistor, store }
 }

--- a/packages/web/src/io/axiosFetch.ts
+++ b/packages/web/src/io/axiosFetch.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios'
+
+import { HttpRequestError } from 'src/io/AlgorithmInput'
+
+export async function axiosFetch<TData = unknown>(url: string, options?: AxiosRequestConfig): Promise<TData> {
+  let res
+  try {
+    res = await axios.get(url, options)
+  } catch (error_) {
+    const error = error_ as AxiosError
+    throw new HttpRequestError(error)
+  }
+
+  if (!res?.data) {
+    throw new Error(`Unable to fetch: request to URL "${url}" resulted in no data`)
+  }
+
+  return res.data as TData
+}
+
+export async function axiosFetchMaybe(url?: string): Promise<string | undefined> {
+  if (!url) {
+    return undefined
+  }
+  return axiosFetch(url)
+}
+
+/**
+ * This version skips any transforms (such as JSON parsing) and returns plain string
+ */
+export async function axiosFetchRaw(url: string, options?: AxiosRequestConfig): Promise<string> {
+  return axiosFetch(url, { ...options, transformResponse: [] })
+}
+
+export async function axiosFetchRawMaybe(url?: string): Promise<string | undefined> {
+  if (!url) {
+    return undefined
+  }
+  return axiosFetchRaw(url)
+}

--- a/packages/web/src/io/fetchDatasets.ts
+++ b/packages/web/src/io/fetchDatasets.ts
@@ -1,0 +1,42 @@
+import { Router } from 'next/router'
+import { Dispatch } from 'redux'
+
+import { fetchDatasetsIndex, findDataset, getLatestCompatibleEnabledDatasets } from 'src/io/fetchDatasetsIndex'
+import { getQueryParam } from 'src/io/fetchInputsAndRunMaybe'
+import { setCurrentDataset, setDatasets } from 'src/state/algorithm/algorithm.actions'
+import { errorAdd } from 'src/state/error/error.actions'
+
+export async function initializeDatasets(dispatch: Dispatch, router: Router) {
+  let datasets
+  let defaultDatasetName
+  let defaultDatasetNameFriendly
+  let hasError
+
+  try {
+    const datasetsIndexJson = await fetchDatasetsIndex()
+    ;({ datasets, defaultDatasetName, defaultDatasetNameFriendly } = getLatestCompatibleEnabledDatasets(
+      datasetsIndexJson,
+    ))
+  } catch (error) {
+    console.error(error)
+    if (error instanceof Error) {
+      dispatch(errorAdd({ error }))
+    } else {
+      dispatch(errorAdd({ error: new Error('Unknown error') }))
+    }
+    hasError = true
+  }
+
+  if (hasError || !datasets || !defaultDatasetName || !defaultDatasetNameFriendly) {
+    return
+  }
+
+  const datasetName = getQueryParam(router, 'dataset-name') ?? defaultDatasetName
+  const datasetRef = getQueryParam(router, 'dataset-reference')
+  const datasetTag = getQueryParam(router, 'dataset-tag')
+
+  const dataset = findDataset(datasets, datasetName, datasetRef, datasetTag)
+
+  dispatch(setDatasets({ defaultDatasetName, defaultDatasetNameFriendly, datasets }))
+  dispatch(setCurrentDataset(dataset))
+}

--- a/packages/web/src/io/fetchDatasetsIndex.ts
+++ b/packages/web/src/io/fetchDatasetsIndex.ts
@@ -1,0 +1,161 @@
+/* eslint-disable no-loops/no-loops */
+import { mapValues, maxBy } from 'lodash'
+import semver from 'semver'
+import urljoin from 'url-join'
+
+import { Dataset, DatasetFiles, DatasetFlat, DatasetRef, DatasetsIndexJson, DatasetVersion } from 'src/algorithms/types'
+import { axiosFetch } from 'src/io/axiosFetch'
+
+const DATA_FULL_DOMAIN = process.env.DATA_FULL_DOMAIN ?? '/'
+const DATA_INDEX_FILE = 'index.json'
+export const DATA_INDEX_FILE_FULL_URL = urljoin(DATA_FULL_DOMAIN, DATA_INDEX_FILE)
+const thisVersion = process.env.PACKAGE_VERSION ?? ''
+
+export function isCompatible({ min, max }: { min?: string; max?: string }) {
+  return semver.gte(thisVersion, min ?? thisVersion) && semver.lte(thisVersion, max ?? thisVersion)
+}
+
+export function fileUrlsToAbsolute(files: DatasetFiles): DatasetFiles {
+  return mapValues(files, (file: string) => urljoin(DATA_FULL_DOMAIN, file))
+}
+
+// eslint-disable-next-line sonarjs/cognitive-complexity
+export function getEnabledDatasets(datasets?: Dataset[]): Dataset[] {
+  const enabledDatasets: Dataset[] = []
+  for (const dataset of datasets ?? []) {
+    if (!dataset.enabled) {
+      continue // eslint-disable-line no-continue
+    }
+
+    const enabledDataset: Dataset = { ...dataset }
+    enabledDataset.datasetRefs = []
+
+    for (const datasetRef of dataset.datasetRefs) {
+      if (!datasetRef.enabled) {
+        continue // eslint-disable-line no-continue
+      }
+
+      const enabledDatasetRef: DatasetRef = { ...datasetRef }
+      enabledDatasetRef.versions = []
+
+      for (const version of datasetRef.versions) {
+        if (version.enabled) {
+          enabledDatasetRef.versions.push(version)
+        }
+      }
+
+      if (enabledDatasetRef.versions.length > 0) {
+        enabledDataset.datasetRefs.push(enabledDatasetRef)
+      }
+    }
+
+    if (enabledDataset.datasetRefs.length > 0) {
+      enabledDatasets.push(enabledDataset)
+    }
+  }
+
+  return enabledDatasets
+}
+
+export function getCompatibleDatasets(datasets?: Dataset[]): Dataset[] {
+  const compatibleDatasets: Dataset[] = []
+
+  for (const dataset of datasets ?? []) {
+    const compatibleDatasetRefs: DatasetRef[] = []
+
+    for (const datasetRef of dataset.datasetRefs) {
+      let compatibleVersions: DatasetVersion[] = []
+      for (const version of datasetRef.versions) {
+        if (isCompatible(version.compatibility.nextcladeWeb)) {
+          compatibleVersions.push(version)
+        }
+      }
+
+      compatibleVersions = compatibleVersions.map((ver) => ({ ...ver, files: fileUrlsToAbsolute(ver.files) }))
+
+      if (compatibleVersions.length > 0) {
+        compatibleDatasetRefs.push({
+          ...datasetRef,
+          versions: compatibleVersions,
+        })
+      }
+    }
+
+    if (compatibleDatasetRefs.length > 0) {
+      compatibleDatasets.push({
+        ...dataset,
+        datasetRefs: compatibleDatasetRefs,
+      })
+    }
+  }
+
+  return compatibleDatasets
+}
+
+export function getLatestDatasetsFlat(datasets?: Dataset[]): DatasetFlat[] {
+  const latestDatasetsFlat: DatasetFlat[] = []
+  for (const dataset of datasets ?? []) {
+    for (const datasetRef of dataset.datasetRefs) {
+      const latestVersion = maxBy(datasetRef.versions, (version) => version.tag)
+      if (latestVersion) {
+        latestDatasetsFlat.push({
+          ...dataset,
+          ...datasetRef,
+          ...latestVersion,
+          nameFriendly: `${dataset.nameFriendly} (${datasetRef.reference.strainName})`,
+        })
+      }
+    }
+  }
+
+  return latestDatasetsFlat
+}
+
+export function getLatestCompatibleEnabledDatasets(datasetsIndexJson?: DatasetsIndexJson) {
+  const datasets = getLatestDatasetsFlat(getCompatibleDatasets(getEnabledDatasets(datasetsIndexJson?.datasets)))
+
+  const defaultDatasetName = datasetsIndexJson?.settings.defaultDatasetName ?? ''
+  const defaultDataset = datasets.find((dataset) => dataset.name === defaultDatasetName)
+  let defaultDatasetNameFriendly = ''
+  if (defaultDataset) {
+    defaultDatasetNameFriendly = defaultDataset.nameFriendly
+  } else if (datasets.length > 0) {
+    defaultDatasetNameFriendly = datasets[0].nameFriendly
+  }
+
+  return { datasets, defaultDatasetName, defaultDatasetNameFriendly }
+}
+
+export class DatasetNotFoundError extends Error {
+  constructor(name: string, refAccession?: string, tag?: string) {
+    let message = `Dataset not found: name=${name}`
+    if (refAccession) {
+      message += `, reference=${refAccession}`
+    }
+    if (tag) {
+      message += `, tag=${tag}`
+    }
+    super(message)
+  }
+}
+
+export function findDataset(datasets: DatasetFlat[], name: string, refAccession?: string, tag?: string) {
+  const found = datasets.find((dataset) => {
+    const ref = refAccession ?? dataset.defaultRef
+    let isMatch = dataset.name === name && dataset.reference.accession === ref
+    if (tag) {
+      isMatch = isMatch && dataset.tag === tag
+    }
+    return isMatch
+  })
+
+  if (!found) {
+    throw new DatasetNotFoundError(name, refAccession, tag)
+  }
+
+  return found
+}
+
+export async function fetchDatasetsIndex() {
+  return axiosFetch<DatasetsIndexJson>(DATA_INDEX_FILE_FULL_URL)
+}

--- a/packages/web/src/io/fetchInputsAndRunMaybe.ts
+++ b/packages/web/src/io/fetchInputsAndRunMaybe.ts
@@ -1,39 +1,57 @@
-import Axios, { AxiosError } from 'axios'
 import type { Router } from 'next/router'
 import type { Dispatch } from 'redux'
 
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
-import { AlgorithmInputString, HttpRequestError } from 'src/io/AlgorithmInput'
+import { AlgorithmInputString } from 'src/io/AlgorithmInput'
+import { axiosFetchRawMaybe } from 'src/io/axiosFetch'
 import { errorAdd } from 'src/state/error/error.actions'
-import { algorithmRunAsync, setIsDirty, setRootSeq, setTree } from 'src/state/algorithm/algorithm.actions'
+import {
+  algorithmRunAsync,
+  setGeneMap,
+  setIsDirty,
+  setPcrPrimers,
+  setQcSettings,
+  setRootSeq,
+  setTree,
+} from 'src/state/algorithm/algorithm.actions'
 
-export async function fetchMaybe(url?: string): Promise<string | undefined> {
-  if (url) {
-    const { data } = await Axios.get<string | undefined>(url, { transformResponse: [] })
-    return data
-  }
-  return undefined
+export function getQueryParam(router: Router, param: string): string | undefined {
+  return takeFirstMaybe(router.query?.[param]) ?? undefined
 }
 
 export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router) {
-  const inputFastaUrl = takeFirstMaybe(router.query?.['input-fasta'])
-  const inputRootSeqUrl = takeFirstMaybe(router.query?.['input-root-seq'])
-  const inputTreeUrl = takeFirstMaybe(router.query?.['input-tree'])
+  const inputFastaUrl = getQueryParam(router, 'input-fasta')
+  const inputRootSeqUrl = getQueryParam(router, 'input-root-seq')
+  const inputTreeUrl = getQueryParam(router, 'input-tree')
+  const inputPcrPrimersUrl = getQueryParam(router, 'input-pcr-primers')
+  const inputQcConfigUrl = getQueryParam(router, 'input-qc-config')
+  const inputGeneMapUrl = getQueryParam(router, 'input-gene-map')
 
   let inputFasta: string | undefined
-  let inputRootSeqDangerous: string | undefined
-  let inputTreeDangerous: string | undefined
+  let inputRootSeq: string | undefined
+  let inputTree: string | undefined
+  let inputPcrPrimers: string | undefined
+  let inputQcConfig: string | undefined
+  let inputGeneMap: string | undefined
 
   let hasError = false
 
   try {
-    inputFasta = await fetchMaybe(inputFastaUrl)
-    inputRootSeqDangerous = await fetchMaybe(inputRootSeqUrl)
-    inputTreeDangerous = await fetchMaybe(inputTreeUrl)
-  } catch (error_) {
-    const error = new HttpRequestError(error_ as AxiosError)
+    ;[inputFasta, inputRootSeq, inputTree, inputPcrPrimers, inputQcConfig, inputGeneMap] = await Promise.all([
+      axiosFetchRawMaybe(inputFastaUrl),
+      axiosFetchRawMaybe(inputRootSeqUrl),
+      axiosFetchRawMaybe(inputTreeUrl),
+      axiosFetchRawMaybe(inputPcrPrimersUrl),
+      axiosFetchRawMaybe(inputQcConfigUrl),
+      axiosFetchRawMaybe(inputGeneMapUrl),
+    ])
+  } catch (error) {
     console.error(error)
-    dispatch(errorAdd({ error }))
+    if (error instanceof Error) {
+      dispatch(errorAdd({ error }))
+    } else {
+      dispatch(errorAdd({ error: new Error('Unknown error') }))
+    }
     hasError = true
   }
 
@@ -42,12 +60,24 @@ export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router)
   }
 
   // TODO: we could use AlgorithmInputUrl instead. User experience should be improved: e.g. show progress indicator
-  if (inputRootSeqDangerous) {
-    dispatch(setRootSeq.trigger(new AlgorithmInputString(inputRootSeqDangerous, inputRootSeqUrl)))
+  if (inputRootSeq) {
+    dispatch(setRootSeq.trigger(new AlgorithmInputString(inputRootSeq, inputRootSeqUrl)))
   }
 
-  if (inputTreeDangerous) {
-    dispatch(setTree.trigger(new AlgorithmInputString(inputTreeDangerous, inputTreeUrl)))
+  if (inputTree) {
+    dispatch(setTree.trigger(new AlgorithmInputString(inputTree, inputTreeUrl)))
+  }
+
+  if (inputPcrPrimers) {
+    dispatch(setPcrPrimers.trigger(new AlgorithmInputString(inputPcrPrimers, inputPcrPrimersUrl)))
+  }
+
+  if (inputQcConfig) {
+    dispatch(setQcSettings.trigger(new AlgorithmInputString(inputQcConfig, inputQcConfigUrl)))
+  }
+
+  if (inputGeneMap) {
+    dispatch(setGeneMap.trigger(new AlgorithmInputString(inputGeneMap, inputGeneMapUrl)))
   }
 
   if (inputFasta) {

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -11,7 +11,13 @@ export const setNumThreads = action<number>('setNumThreads')
 
 export const setIsDirty = action<boolean>('setIsDirty')
 
-export const setDataset = action<DatasetFlat | undefined>('setDataset')
+export const setDatasets = action<{
+  defaultDatasetName: string
+  defaultDatasetNameFriendly: string
+  datasets: DatasetFlat[]
+}>('setDatasets')
+
+export const setCurrentDataset = action<DatasetFlat | undefined>('setCurrentDataset')
 
 export const setFasta = action.async<AlgorithmInput, { queryStr: string; queryName: string }, Error>('setFasta')
 export const setTree = action.async<AlgorithmInput, { treeStr: string }, Error>('setTree')

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -36,13 +36,20 @@ import {
   addNextcladeResult,
   setGeneMapObject,
   setGenomeSize,
-  setDataset,
+  setCurrentDataset,
+  setDatasets,
 } from './algorithm.actions'
 import { algorithmDefaultState, AlgorithmGlobalStatus, AlgorithmSequenceStatus } from './algorithm.state'
 
 export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
-  .icase(setDataset, (draft, dataset) => {
-    draft.params.dataset = dataset
+  .icase(setDatasets, (draft, { defaultDatasetName, defaultDatasetNameFriendly, datasets }) => {
+    draft.params.defaultDatasetName = defaultDatasetName
+    draft.params.defaultDatasetNameFriendly = defaultDatasetNameFriendly
+    draft.params.datasets = datasets
+  })
+
+  .icase(setCurrentDataset, (draft, dataset) => {
+    draft.params.datasetCurrent = dataset
   })
 
   .icase(setGenomeSize, (draft, { genomeSize }) => {

--- a/packages/web/src/state/algorithm/algorithm.selectors.ts
+++ b/packages/web/src/state/algorithm/algorithm.selectors.ts
@@ -7,7 +7,13 @@ import { selectNumThreads } from 'src/state/settings/settings.selectors'
 
 export const selectParams = (state: State) => state.algorithm.params
 
-export const selectCurrentDataset = (state: State) => selectParams(state).dataset
+export const selectDefaultDatasetName = (state: State) => selectParams(state).defaultDatasetName
+
+export const selectDefaultDatasetNameFriendly = (state: State) => selectParams(state).defaultDatasetNameFriendly
+
+export const selectDatasets = (state: State) => selectParams(state).datasets
+
+export const selectCurrentDataset = (state: State) => selectParams(state).datasetCurrent
 
 export const selectResults = (state: State) => state.algorithm.results
 

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -67,7 +67,10 @@ export interface ExportParams {
 }
 
 export interface AlgorithmParams {
-  dataset?: DatasetFlat
+  datasets: DatasetFlat[]
+  defaultDatasetName?: string
+  defaultDatasetNameFriendly?: string
+  datasetCurrent?: DatasetFlat
   raw: {
     seqData?: AlgorithmInput
     auspiceData?: AlgorithmInput
@@ -134,7 +137,9 @@ export const DEFAULT_EXPORT_PARAMS: ExportParams = {
 export const algorithmDefaultState: AlgorithmState = {
   status: AlgorithmGlobalStatus.idle,
   params: {
-    dataset: undefined,
+    datasets: [],
+    defaultDatasetName: undefined,
+    datasetCurrent: undefined,
     raw: {},
     strings: {},
     final: {},

--- a/packages/web/src/state/algorithm/algorithmRun.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmRun.sagas.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-loops/no-loops,no-continue,no-void */
 import type { EventChannel } from 'redux-saga'
 import { buffers, eventChannel } from 'redux-saga'
-import { axiosFetchRaw } from 'src/helpers/useAxiosQuery'
 import type { PoolEvent } from 'threads/dist/master/pool'
 import { Pool } from 'threads'
 import { all, apply, call, fork, join, put, select, take, takeEvery } from 'typed-redux-saga'
@@ -10,6 +9,7 @@ import { push } from 'connected-next-router/actions'
 import type { AuspiceJsonV2 } from 'auspice'
 import { changeColorBy } from 'auspice/src/actions/colors'
 
+import { axiosFetchRaw } from 'src/io/axiosFetch'
 import { createAuspiceState } from 'src/state/auspice/createAuspiceState'
 import { auspiceStartClean, treeFilterByNodeType } from 'src/state/auspice/auspice.actions'
 import fsaSaga from 'src/state/util/fsaSaga'


### PR DESCRIPTION
This adds the following URL parameters related to datasets:

 - dataset-name
 - dataset-reference
 - dataset-tag

Additionally, the missing input file params were also added, so the full set is now:

 - input-fasta
 - input-root-seq
 - input-tree
 - input-pcr-primers
 - input-qc-config
 - input-gene-map

Due to complex iterations between datasets, various file input methods and ways of launching the analysis, a few things had to be moved:
 - datasets state was moved from the dataset selector component into redux store
 - datasets fetching logic was moved from the dataset selector component to the initialization stage (a side effect in the App component)
 - dataset selector component is now stateless

For the future: it is important that datasets are fetched and one of them is selected (either default, from URL params or from dataset selector) before analysis begins.

