### PR TITLE
fix(web): run init only once

### DIFF
--- a/packages/web/src/helpers/parseUrl.ts
+++ b/packages/web/src/helpers/parseUrl.ts
@@ -1,0 +1,70 @@
+import { ParsedUrlQuery } from 'querystring'
+
+/** Borrowed from Next.js */
+export function getLocationOrigin() {
+  const { protocol, hostname, port } = window.location
+  return `${protocol}//${hostname}${port ? `:${port}` : ''}`
+}
+
+/** Borrowed from Next.js */
+export function searchParamsToUrlQuery(searchParams: URLSearchParams): ParsedUrlQuery {
+  const query: ParsedUrlQuery = {}
+  searchParams.forEach((value, key) => {
+    if (typeof query[key] === 'undefined') {
+      query[key] = value
+    } else if (Array.isArray(query[key])) {
+      ;(query[key] as string[]).push(value)
+    } else {
+      query[key] = [query[key] as string, value]
+    }
+  })
+  return query
+}
+
+/** Borrowed from Next.js */
+export function parseRelativeUrl(url: string, base?: string) {
+  const globalBase = new URL(typeof window === 'undefined' ? 'http://n' : getLocationOrigin())
+  const resolvedBase = base ? new URL(base, globalBase) : globalBase
+  const { pathname, searchParams, search, hash, href, origin } = new URL(url, resolvedBase)
+  if (origin !== globalBase.origin) {
+    throw new Error(`invariant: invalid relative URL, router received ${url}`)
+  }
+  return {
+    pathname,
+    query: searchParamsToUrlQuery(searchParams),
+    search,
+    hash,
+    href: href.slice(globalBase.origin.length),
+  }
+}
+
+/** Borrowed from Next.js */
+export interface ParsedUrl {
+  hash: string
+  hostname?: string | null
+  href: string
+  pathname: string
+  port?: string | null
+  protocol?: string | null
+  query: ParsedUrlQuery
+  search: string
+}
+
+/** Borrowed from Next.js */
+export function parseUrl(url: string): ParsedUrl {
+  if (url.startsWith('/')) {
+    return parseRelativeUrl(url)
+  }
+
+  const parsedURL = new URL(url)
+  return {
+    hash: parsedURL.hash,
+    hostname: parsedURL.hostname,
+    href: parsedURL.href,
+    pathname: parsedURL.pathname,
+    port: parsedURL.port,
+    protocol: parsedURL.protocol,
+    query: searchParamsToUrlQuery(parsedURL.searchParams),
+    search: parsedURL.search,
+  }
+}

--- a/packages/web/src/io/fetchDatasets.ts
+++ b/packages/web/src/io/fetchDatasets.ts
@@ -1,4 +1,4 @@
-import { Router } from 'next/router'
+import { ParsedUrlQuery } from 'querystring'
 import { Dispatch } from 'redux'
 
 import { fetchDatasetsIndex, findDataset, getLatestCompatibleEnabledDatasets } from 'src/io/fetchDatasetsIndex'
@@ -6,7 +6,7 @@ import { getQueryParam } from 'src/io/fetchInputsAndRunMaybe'
 import { setCurrentDataset, setDatasets } from 'src/state/algorithm/algorithm.actions'
 import { errorAdd } from 'src/state/error/error.actions'
 
-export async function initializeDatasets(dispatch: Dispatch, router: Router) {
+export async function initializeDatasets(dispatch: Dispatch, urlQuery: ParsedUrlQuery) {
   let datasets
   let defaultDatasetName
   let defaultDatasetNameFriendly
@@ -28,15 +28,17 @@ export async function initializeDatasets(dispatch: Dispatch, router: Router) {
   }
 
   if (hasError || !datasets || !defaultDatasetName || !defaultDatasetNameFriendly) {
-    return
+    return false
   }
 
-  const datasetName = getQueryParam(router, 'dataset-name') ?? defaultDatasetName
-  const datasetRef = getQueryParam(router, 'dataset-reference')
-  const datasetTag = getQueryParam(router, 'dataset-tag')
+  const datasetName = getQueryParam(urlQuery, 'dataset-name') ?? defaultDatasetName
+  const datasetRef = getQueryParam(urlQuery, 'dataset-reference')
+  const datasetTag = getQueryParam(urlQuery, 'dataset-tag')
 
   const dataset = findDataset(datasets, datasetName, datasetRef, datasetTag)
 
   dispatch(setDatasets({ defaultDatasetName, defaultDatasetNameFriendly, datasets }))
   dispatch(setCurrentDataset(dataset))
+
+  return true
 }

--- a/packages/web/src/io/fetchInputsAndRunMaybe.ts
+++ b/packages/web/src/io/fetchInputsAndRunMaybe.ts
@@ -1,5 +1,5 @@
-import type { Router } from 'next/router'
 import type { Dispatch } from 'redux'
+import type { ParsedUrlQuery } from 'querystring'
 
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
 import { AlgorithmInputString } from 'src/io/AlgorithmInput'
@@ -15,17 +15,17 @@ import {
   setTree,
 } from 'src/state/algorithm/algorithm.actions'
 
-export function getQueryParam(router: Router, param: string): string | undefined {
-  return takeFirstMaybe(router.query?.[param]) ?? undefined
+export function getQueryParam(urlQuery: ParsedUrlQuery, param: string): string | undefined {
+  return takeFirstMaybe(urlQuery?.[param]) ?? undefined
 }
 
-export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router) {
-  const inputFastaUrl = getQueryParam(router, 'input-fasta')
-  const inputRootSeqUrl = getQueryParam(router, 'input-root-seq')
-  const inputTreeUrl = getQueryParam(router, 'input-tree')
-  const inputPcrPrimersUrl = getQueryParam(router, 'input-pcr-primers')
-  const inputQcConfigUrl = getQueryParam(router, 'input-qc-config')
-  const inputGeneMapUrl = getQueryParam(router, 'input-gene-map')
+export async function fetchInputsAndRunMaybe(dispatch: Dispatch, urlQuery: ParsedUrlQuery) {
+  const inputFastaUrl = getQueryParam(urlQuery, 'input-fasta')
+  const inputRootSeqUrl = getQueryParam(urlQuery, 'input-root-seq')
+  const inputTreeUrl = getQueryParam(urlQuery, 'input-tree')
+  const inputPcrPrimersUrl = getQueryParam(urlQuery, 'input-pcr-primers')
+  const inputQcConfigUrl = getQueryParam(urlQuery, 'input-qc-config')
+  const inputGeneMapUrl = getQueryParam(urlQuery, 'input-gene-map')
 
   let inputFasta: string | undefined
   let inputRootSeq: string | undefined
@@ -56,7 +56,7 @@ export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router)
   }
 
   if (hasError) {
-    return
+    return false
   }
 
   // TODO: we could use AlgorithmInputUrl instead. User experience should be improved: e.g. show progress indicator
@@ -83,6 +83,7 @@ export async function fetchInputsAndRunMaybe(dispatch: Dispatch, router: Router)
   if (inputFasta) {
     dispatch(setIsDirty(true))
     dispatch(algorithmRunAsync.trigger(new AlgorithmInputString(inputFasta, inputFastaUrl)))
-    await router.replace('/results')
   }
+
+  return true
 }


### PR DESCRIPTION
It could often happen that due to props changes of the Next.js's App component, the steps that should only run once could run multiple times. This caused strange bugs, like app state randomly changing on page navigation or state first loaded correctly, but then reset to an unexpected value.

This PR ensures that the application initialization steps run only once.
These currently are:
 - prefetching pages
 - initializing Redux store
 - initializing persistence (local storage)
 - fetching, parsing and saving dataset index in the Redux store
 - parsing URL params
 - fetching input files from URL params

Previously some or all of these steps could have ran multiple times. But now they are guaranteed to run to successful completion only once (but can be repeated if failed).

Additionally, Next.js would sometimes send an empty URL query in `router.query`, sometimes multiple times. Random changes in URL params would then cause the app state to change in unexpected ways, like switching the selected dataset 

We mitigate it here by parsing the URL manually (using the same code as used in Next.js Router) and using the result instead of `router.query`. This manually parsed query is available from the first render and is stable, so no state changes happen.

