### PR TITLE
feat: use default dataset gene and gene order preference

### DIFF
--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -348,6 +348,7 @@ export interface Dataset {
   datasetRefs: DatasetRef[]
   defaultRef: string
   defaultGene: string
+  geneOrderPreference: string[]
 }
 
 export interface DatasetsIndexJson {

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -347,6 +347,7 @@ export interface Dataset {
   description: string
   datasetRefs: DatasetRef[]
   defaultRef: string
+  defaultGene: string
 }
 
 export interface DatasetsIndexJson {

--- a/packages/web/src/components/SequenceView/ListOfAminoacidDeletions.tsx
+++ b/packages/web/src/components/SequenceView/ListOfAminoacidDeletions.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import copy from 'fast-copy'
 import { connect } from 'react-redux'
 
 import type { AminoacidDeletion, Gene } from 'src/algorithms/types'
@@ -8,16 +9,18 @@ import { formatAADeletion } from 'src/helpers/formatMutation'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { splitToRows } from 'src/components/Results/splitToRows'
 import { TableSlim } from 'src/components/Common/TableSlim'
-import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
+import { selectCurrentDataset, selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 
 export interface ListOfAminoacidDeletionsProps {
   aminoacidDeletions: AminoacidDeletion[]
   geneMap?: Gene[]
+  geneOrderPreference: string[]
 }
 
 const mapStateToProps = (state: State) => ({
   geneMap: selectGeneMap(state),
+  geneOrderPreference: selectCurrentDataset(state)?.geneOrderPreference ?? [],
 })
 
 const mapDispatchToProps = {}
@@ -27,7 +30,11 @@ export const ListOfAminoacidDeletions = connect(
   mapDispatchToProps,
 )(ListOfAminoacidDeletionsDisconnected)
 
-export function ListOfAminoacidDeletionsDisconnected({ aminoacidDeletions, geneMap }: ListOfAminoacidDeletionsProps) {
+export function ListOfAminoacidDeletionsDisconnected({
+  aminoacidDeletions,
+  geneMap,
+  geneOrderPreference,
+}: ListOfAminoacidDeletionsProps) {
   const { t } = useTranslationSafe()
 
   if (!geneMap) {
@@ -36,7 +43,9 @@ export function ListOfAminoacidDeletionsDisconnected({ aminoacidDeletions, geneM
 
   const totalDeletions = aminoacidDeletions.length
   const maxRows = 6
-  const deletionsSelected = aminoacidDeletions.slice(0, 20)
+  const deletionsSelected = copy(aminoacidDeletions)
+    .sort((left, right) => geneOrderPreference.indexOf(left.gene) - geneOrderPreference.indexOf(right.gene))
+    .slice(0, 90)
 
   const columns = splitToRows(deletionsSelected, { maxRows })
 

--- a/packages/web/src/components/SequenceView/ListOfAminoacidDeletions.tsx
+++ b/packages/web/src/components/SequenceView/ListOfAminoacidDeletions.tsx
@@ -11,6 +11,7 @@ import { splitToRows } from 'src/components/Results/splitToRows'
 import { TableSlim } from 'src/components/Common/TableSlim'
 import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
 import { selectCurrentDataset, selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
+import { sortByGenes } from './sortByGenes'
 
 export interface ListOfAminoacidDeletionsProps {
   aminoacidDeletions: AminoacidDeletion[]
@@ -43,9 +44,7 @@ export function ListOfAminoacidDeletionsDisconnected({
 
   const totalDeletions = aminoacidDeletions.length
   const maxRows = 6
-  const deletionsSelected = copy(aminoacidDeletions)
-    .sort((left, right) => geneOrderPreference.indexOf(left.gene) - geneOrderPreference.indexOf(right.gene))
-    .slice(0, 90)
+  const deletionsSelected = copy(aminoacidDeletions).sort(sortByGenes(geneOrderPreference)).slice(0, 90)
 
   const columns = splitToRows(deletionsSelected, { maxRows })
 

--- a/packages/web/src/components/SequenceView/ListOfAminoacidSubstitutions.tsx
+++ b/packages/web/src/components/SequenceView/ListOfAminoacidSubstitutions.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import copy from 'fast-copy'
 import { connect } from 'react-redux'
 
 import type { AminoacidSubstitution, Gene } from 'src/algorithms/types'
@@ -9,15 +10,17 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { splitToRows } from 'src/components/Results/splitToRows'
 import { TableSlim } from 'src/components/Common/TableSlim'
 import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
-import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
+import { selectCurrentDataset, selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 
 export interface ListOfAminoacidMutationsProps {
   aminoacidSubstitutions: AminoacidSubstitution[]
   geneMap?: Gene[]
+  geneOrderPreference: string[]
 }
 
 const mapStateToProps = (state: State) => ({
   geneMap: selectGeneMap(state),
+  geneOrderPreference: selectCurrentDataset(state)?.geneOrderPreference ?? [],
 })
 
 const mapDispatchToProps = {}
@@ -30,6 +33,7 @@ export const ListOfAminoacidSubstitutions = connect(
 export function ListOfAminoacidMutationsDisconnected({
   aminoacidSubstitutions,
   geneMap,
+  geneOrderPreference,
 }: ListOfAminoacidMutationsProps) {
   const { t } = useTranslationSafe()
 
@@ -39,7 +43,9 @@ export function ListOfAminoacidMutationsDisconnected({
 
   const totalMutations = aminoacidSubstitutions.length
   const maxRows = 6
-  const substitutionsSelected = aminoacidSubstitutions.slice(0, 20)
+  const substitutionsSelected = copy(aminoacidSubstitutions)
+    .sort((left, right) => geneOrderPreference.indexOf(left.gene) - geneOrderPreference.indexOf(right.gene))
+    .slice(0, 90)
 
   const columns = splitToRows(substitutionsSelected, { maxRows })
 

--- a/packages/web/src/components/SequenceView/ListOfAminoacidSubstitutions.tsx
+++ b/packages/web/src/components/SequenceView/ListOfAminoacidSubstitutions.tsx
@@ -11,6 +11,7 @@ import { splitToRows } from 'src/components/Results/splitToRows'
 import { TableSlim } from 'src/components/Common/TableSlim'
 import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
 import { selectCurrentDataset, selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
+import { sortByGenes } from './sortByGenes'
 
 export interface ListOfAminoacidMutationsProps {
   aminoacidSubstitutions: AminoacidSubstitution[]
@@ -43,9 +44,7 @@ export function ListOfAminoacidMutationsDisconnected({
 
   const totalMutations = aminoacidSubstitutions.length
   const maxRows = 6
-  const substitutionsSelected = copy(aminoacidSubstitutions)
-    .sort((left, right) => geneOrderPreference.indexOf(left.gene) - geneOrderPreference.indexOf(right.gene))
-    .slice(0, 90)
+  const substitutionsSelected = copy(aminoacidSubstitutions).sort(sortByGenes(geneOrderPreference)).slice(0, 90)
 
   const columns = splitToRows(substitutionsSelected, { maxRows })
 

--- a/packages/web/src/components/SequenceView/sortByGenes.ts
+++ b/packages/web/src/components/SequenceView/sortByGenes.ts
@@ -1,0 +1,12 @@
+export function negativeNumberToInfinity(x: number) {
+  return x < 0 ? Number.POSITIVE_INFINITY : x
+}
+
+export function sortByGenes<T extends { gene: string }>(geneOrderPreference: string[]) {
+  return function sortByGenesPredicate(left: T, right: T): number {
+    // We want items that are not in the preference list to be sorted to the end
+    const l = negativeNumberToInfinity(geneOrderPreference.indexOf(left.gene))
+    const r = negativeNumberToInfinity(geneOrderPreference.indexOf(right.gene))
+    return l - r
+  }
+}

--- a/packages/web/src/state/algorithm/algorithmRun.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmRun.sagas.ts
@@ -39,7 +39,7 @@ import {
   selectRefSeq,
   selectRefTreeStr,
 } from 'src/state/algorithm/algorithm.selectors'
-import { resetViewedGene } from 'src/state/ui/ui.actions'
+import { setViewedGene } from 'src/state/ui/ui.actions'
 import {
   createAnalysisThreadPool,
   createThreadParseSequencesStreaming,
@@ -412,13 +412,14 @@ export function* getQuerySequences(dataset: DatasetFlat, queryInput?: AlgorithmI
  */
 export function* runAlgorithm(queryInput?: AlgorithmInput) {
   yield* put(setAlgorithmGlobalStatus(AlgorithmGlobalStatus.loadingData))
-  yield* put(resetViewedGene())
   yield* put(push('/results'))
 
   const dataset = yield* select(selectCurrentDataset)
   if (!dataset) {
     throw new Error('No dataset is selected. Unable to proceed. This is an internal error and might indicate a bug.')
   }
+
+  yield* put(setViewedGene(dataset.defaultGene))
 
   const {
     ref: { refStr, refName },


### PR DESCRIPTION
Corresponding change in data: https://github.com/nextstrain/nextclade_data/pull/9

This helps to visualize gene-related data better, according to practical needs.

 - [x] switches sequence view to the `dataset.defaultGene` (e.g. shows "Gene S" in sequence view when SARS-CoV-2 dataset is selected)
 - [x] uses `dataset.geneOrderPreference` to sort aminoacid mutation and  deletion lists in tooltips (e.g. shows mutations in important genes genes "S", "ORF1a" before others).

![01](https://user-images.githubusercontent.com/9403403/131420407-80d00534-648a-4967-bc9d-f5ee147d8a8b.png)
