### PR TITLE
fix: remove SARS-CoV-2 clade schema from the clade column tooltip

### DIFF
--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnClade.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnClade.mdx
@@ -1,15 +1,5 @@
-import { ReactComponent as CladeSchema } from 'src/assets/img/nextstrain_clades.svg'
-
 ##### Column: clade
 
 The result of the clade assignment of a sequence, as defined by Nextstrain.
-Currently known clades are depicted in the schema below.
 
-<figure className="figure w-100 text-center">
-  <picture className="w-100 figure-img" alt="illustration of the model">
-    <CladeSchema width={350} />
-  </picture>
-  <figcaption>
-    <small>Fig.1. Illustration of phylogenetic relationship of clades, as defined by Nextstrain</small>
-  </figcaption>
-</figure>
+The clade is taken from the closest node on the phylogenetic tree after phylogenetic placement. See documentation for more details.


### PR DESCRIPTION
It does not make sense to have it there when analyzing other pathogens.
