### PR TITLE
fix: translate past first stop codon in nextclade web

### DIFF
--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -130,7 +130,8 @@ public:
       const auto query = toNucleotideSequence(queryStr);
 
       // FIXME: pass options from JS
-      const auto nextalignOptions = getDefaultOptions();
+      auto nextalignOptions = getDefaultOptions();
+      nextalignOptions.translatePastStop = true;
 
       const auto result = analyzeOneSequence(//
         queryName,                           //


### PR DESCRIPTION
After #504 when translation past stop codons became optional, Nextalign and Nextclade CLI gained their flags to toggle this option. However, Nextclade Web was incorrectly using the default value, and translation was terminated on the first stop. 

This fixes the option's value so that Nextclade Web translates full peptides as expected.

This also solves the problem of gigantic peptide context tooltips, caused by deletions that appear in peptides context due to padding with `-` after translation stops. This kind of situations is additionally mitigated in #544.