### PR TITLE
feat(web): truncate peptide context and list of changes in tooltips

### DIFF
--- a/packages/web/src/components/SequenceView/PeptideContext.tsx
+++ b/packages/web/src/components/SequenceView/PeptideContext.tsx
@@ -201,6 +201,35 @@ export function PeptideContextCodon({ refCodon, queryCodon, change, codon, nucBe
   )
 }
 
+export function renderCodons([change, refCodon, queryCodon]: [AminoacidChange, string, string]) {
+  return (
+    <PeptideContextCodon
+      key={change.codon}
+      refCodon={refCodon}
+      queryCodon={queryCodon}
+      change={change}
+      codon={change.codon}
+      nucBegin={change.codonNucRange.begin}
+    />
+  )
+}
+
+export function PeptideContextEllipsis() {
+  return (
+    <td>
+      <TableNuc>
+        <TableBodyNuc>
+          {Array(6).fill(
+            <TrNuc>
+              <TdNuc colSpan={3}>{'...'}</TdNuc>
+            </TrNuc>,
+          )}
+        </TableBodyNuc>
+      </TableNuc>
+    </td>
+  )
+}
+
 export interface PeptideContextProps {
   group: AminoacidChangesGroup
 }
@@ -236,7 +265,14 @@ export function PeptideContext({ group }: PeptideContextProps) {
 
   const changesAndCodons = safeZip3(changes, refCodons.slice(1, -1), queryCodons.slice(1, -1))
 
-  const width = (changes.length + 2) * 80 + 80
+  let itemsBegin = changesAndCodons
+  let itemsEnd: typeof changesAndCodons = []
+  if (changesAndCodons.length > 6) {
+    itemsBegin = changesAndCodons.slice(0, 3)
+    itemsEnd = changesAndCodons.slice(-3)
+  }
+
+  const width = (itemsBegin.length + itemsEnd.length + 2) * 80 + 80
 
   return (
     <Table borderless className="mb-1 mx-2" $width={width}>
@@ -274,16 +310,9 @@ export function PeptideContext({ group }: PeptideContextProps) {
             nucBegin={contextNucRange.begin}
           />
 
-          {changesAndCodons.map(([change, refCodon, queryCodon]) => (
-            <PeptideContextCodon
-              key={change.codon}
-              refCodon={refCodon}
-              queryCodon={queryCodon}
-              change={change}
-              codon={change.codon}
-              nucBegin={change.codonNucRange.begin}
-            />
-          ))}
+          {itemsBegin.map(renderCodons)}
+          {itemsEnd.length > 0 && <PeptideContextEllipsis />}
+          {itemsEnd.length > 0 && itemsEnd.map(renderCodons)}
 
           <PeptideContextCodon
             refCodon={lastRefCodon}

--- a/packages/web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
@@ -64,6 +64,13 @@ function PeptideMarkerMutationGroupDisconnected({
   const x = codonAaRange.begin * pixelsPerAa
   const width = changes.length * Math.max(AA_MIN_WIDTH_PX, pixelsPerAa)
 
+  let changesHead = changes
+  let changesTail: typeof changes = []
+  if (changes.length > 6) {
+    changesHead = changes.slice(0, 3)
+    changesTail = changes.slice(-3)
+  }
+
   const totalNucChanges = nucSubstitutions.length + nucDeletions.length
 
   return (
@@ -92,7 +99,7 @@ function PeptideMarkerMutationGroupDisconnected({
                 </tr>
 
                 <>
-                  {changes.map((change) => (
+                  {changesHead.map((change) => (
                     <tr key={change.codon}>
                       <td>{change.type === 'substitution' ? t('Substitution') : t('Deletion')}</td>
                       <td>
@@ -100,6 +107,25 @@ function PeptideMarkerMutationGroupDisconnected({
                       </td>
                     </tr>
                   ))}
+                </>
+
+                {changesTail.length > 0 && (
+                  <tr>
+                    <td>{'...'}</td>
+                    <td>{'...'}</td>
+                  </tr>
+                )}
+
+                <>
+                  {changesTail.length > 0 &&
+                    changesTail.map((change) => (
+                      <tr key={change.codon}>
+                        <td>{change.type === 'substitution' ? t('Substitution') : t('Deletion')}</td>
+                        <td>
+                          <AminoacidMutationBadge mutation={change} geneMap={geneMap ?? []} />
+                        </td>
+                      </tr>
+                    ))}
                 </>
 
                 {totalNucChanges > 0 && (


### PR DESCRIPTION
Currently when a large group of consecutive mutations or deletions appear in a peptide, mouse hovering this group displays a tooltip which may not fit to the screen due to both the width of the peptide context table and height of the list of mutations and deletions.

This PR truncates the context table and the lists, both in the middle, keeping the edges, all making sure tooltips are not too large and that they fit to the screen nicely.

Large tooltips previously appeared due to a bug fixed in https://github.com/nextstrain/nextclade/pull/543, but we should still truncate for the cases where large groups of mutations or deletions appear in user-provided sequences due to various reasons.