### PR TITLE
fix: remove mentions of Wuhan-Hu-1 in tooltips

### DIFF
--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnGaps.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnGaps.mdx
@@ -2,6 +2,6 @@
 
 Displays number of `-` characters (gaps) in the sequence.
 
-Hovering mouse over a cell in this column will display a tooltip where contiguous gaps relative to the reference Wuhan-Hu-1 are listed for the corresponding sequence.
+Hovering mouse over a cell in this column will display a tooltip where contiguous gaps relative to the reference sequence are listed for the corresponding sequence.
 
 Positions are 1-based.

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnInsertions.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnInsertions.mdx
@@ -2,8 +2,8 @@
 
 Displays total length of insertions in the sequence.
 
-Hovering mouse over a cell in this column will display a tooltip with insertions relative to the reference Wuhan-Hu-1.
+Hovering mouse over a cell in this column will display a tooltip with insertions relative to the reference sequence.
 
-The complete table is available for download in the "Downloads" dialog.
+The complete table if insertions is available for download in the "Downloads" dialog.
 
 Positions are 1-based.

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnMut.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnMut.mdx
@@ -3,6 +3,6 @@
 Displays number of mutations in the sequence.
 
 Hovering mouse over a cell in this column will display a tooltip with a list of mutations in the corresponding sequence, as well as a list of aminoacid changes that these mutations cause.
-Mutations are called relative to the reference sequence Wuhan-Hu-1.
+Mutations are called relative to the reference sequence.
 
 Positions are 1-based.


### PR DESCRIPTION
Now that we have more pathogens, references to SARS-CoV-2 specifics no longer make sense.

