### PR TITLE
feat(web): limit width of the summary tooltip

### DIFF
--- a/packages/web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages/web/src/components/Results/ColumnNameTooltip.tsx
@@ -8,11 +8,15 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { formatRange } from 'src/helpers/formatRange'
 import { ListOfPcrPrimerChanges } from 'src/components/SequenceView/ListOfPcrPrimerChanges'
 import { ErrorIcon, getStatusIconAndText, WarningIcon } from 'src/components/Results/getStatusIconAndText'
-import { TableSlim } from 'src/components/Common/TableSlim'
+import { TableSlim as TablSlimBase } from 'src/components/Common/TableSlim'
 
 const Alert = styled(ReactstrapAlert)`
   box-shadow: ${(props) => props.theme.shadows.slight};
-  max-width: 400px;
+  width: 400px;
+`
+
+const TableSlim = styled(TablSlimBase)`
+  width: 400px;
 `
 
 export interface ColumnNameTooltipProps {


### PR DESCRIPTION
The tooltip for "Sequence name"  column of the results table is sometimes too wide, making the table columns inside look disconnected and harder to read. This happens when sequence names are very long.

This PR limits the width of the tooltip, such that the table looks pretty regardless of sequence name length. The sequence name is now forced to wrap to multiple lines if too long.