### PR TITLE
feat(web): better frame shifts and stop codons columns

### DIFF
--- a/packages/web/src/components/Results/ColumnFrameShifts.tsx
+++ b/packages/web/src/components/Results/ColumnFrameShifts.tsx
@@ -19,7 +19,7 @@ export function ColumnFrameShifts({ sequence }: ColumnCladeProps) {
   const { totalFrameShifts, totalFrameShiftsIgnored } = sequence.qc.frameShifts
   const grandTotal = totalFrameShiftsIgnored + totalFrameShifts
   const shouldShowTooltip = grandTotal > 0
-  const value = grandTotal === 0 ? 0 : `${totalFrameShifts} + ${totalFrameShiftsIgnored}`
+  const value = grandTotal === 0 ? 0 : `${totalFrameShifts} (${totalFrameShiftsIgnored})`
 
   return (
     <div id={id} className="w-100" onMouseEnter={() => setShowTooltip(true)} onMouseLeave={() => setShowTooltip(false)}>

--- a/packages/web/src/components/Results/ColumnFrameShifts.tsx
+++ b/packages/web/src/components/Results/ColumnFrameShifts.tsx
@@ -19,7 +19,7 @@ export function ColumnFrameShifts({ sequence }: ColumnCladeProps) {
   const { totalFrameShifts, totalFrameShiftsIgnored } = sequence.qc.frameShifts
   const grandTotal = totalFrameShiftsIgnored + totalFrameShifts
   const shouldShowTooltip = grandTotal > 0
-  const value = grandTotal === 0 ? 0 : `${totalFrameShifts} (${totalFrameShiftsIgnored})`
+  const value = grandTotal === 0 ? 0 : `${totalFrameShifts} (${grandTotal})`
 
   return (
     <div id={id} className="w-100" onMouseEnter={() => setShowTooltip(true)} onMouseLeave={() => setShowTooltip(false)}>

--- a/packages/web/src/components/Results/ColumnStopCodons.tsx
+++ b/packages/web/src/components/Results/ColumnStopCodons.tsx
@@ -19,7 +19,7 @@ export function ColumnStopCodons({ sequence }: ColumnCladeProps) {
   const { totalStopCodons, totalStopCodonsIgnored } = sequence.qc.stopCodons
   const grandTotal = totalStopCodons + totalStopCodonsIgnored
   const shouldShowTooltip = grandTotal > 0
-  const value = grandTotal === 0 ? 0 : `${totalStopCodons} + ${totalStopCodonsIgnored}`
+  const value = grandTotal === 0 ? 0 : `${totalStopCodons} (${totalStopCodonsIgnored})`
 
   return (
     <div id={id} className="w-100" onMouseEnter={() => setShowTooltip(true)} onMouseLeave={() => setShowTooltip(false)}>

--- a/packages/web/src/components/Results/ColumnStopCodons.tsx
+++ b/packages/web/src/components/Results/ColumnStopCodons.tsx
@@ -19,7 +19,7 @@ export function ColumnStopCodons({ sequence }: ColumnCladeProps) {
   const { totalStopCodons, totalStopCodonsIgnored } = sequence.qc.stopCodons
   const grandTotal = totalStopCodons + totalStopCodonsIgnored
   const shouldShowTooltip = grandTotal > 0
-  const value = grandTotal === 0 ? 0 : `${totalStopCodons} (${totalStopCodonsIgnored})`
+  const value = grandTotal === 0 ? 0 : `${totalStopCodons} (${grandTotal})`
 
   return (
     <div id={id} className="w-100" onMouseEnter={() => setShowTooltip(true)} onMouseLeave={() => setShowTooltip(false)}>

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnFrameShifts.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnFrameShifts.mdx
@@ -1,11 +1,7 @@
 ##### Column: frame shifts
 
-Displays total length of unexpected reading frame shifts in the sequence. Shifted ranges are expressed in codon coordinates of the affected gene.
+Displays total number of unexpected reading frame shifts in the sequence. Shifted ranges are expressed in codon coordinates of the affected gene.
 
-Hovering mouse over a cell in this column will display a tooltip with detailed information about the detected frame shift ranges for each gene.
-
-Note that the dataset authors may define a list of known good (expected) frame shifts in the quality control (QC) configuration. These frame shifts are not included in the displayed number and are listed separately in the tooltip.
-
-The meaning of the notation with parenteses: first number is a number of unexpected changes and the second is grand total (unexpected + known).
+Displayed in parentheses are the total number of frame shifts, including known ones. Dataset authors may define a list of known good (expected) frame shifts in the quality control (QC) configuration to prevent them from causing a bad QC score. These frame shifts are only counted in the number in parentheses.
 
 Positions are 1-based.

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnFrameShifts.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnFrameShifts.mdx
@@ -6,4 +6,6 @@ Hovering mouse over a cell in this column will display a tooltip with detailed i
 
 Note that the dataset authors may define a list of known good (expected) frame shifts in the quality control (QC) configuration. These frame shifts are not included in the displayed number and are listed separately in the tooltip.
 
+The meaning of the notation with parenteses: first number is a number of unexpected changes and the second is grand total (unexpected + known).
+
 Positions are 1-based.

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnStopCodons.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnStopCodons.mdx
@@ -6,6 +6,8 @@ Hovering mouse over a cell in this column will display a tooltip with detailed i
 
 Note that the dataset authors may define a list of known good (expected) premature stop codons in the quality control (QC) configuration. These stop codons are not included in the displayed number and are listed separately in the tooltip.
 
+The meaning of the notation with parenteses: first number is a number of unexpected changes and the second is grand total (unexpected + known).
+
 The usual stop condons at the end of genes (as defined by the reference sequence) are never counted or displayed in this column.
 
 Positions are 1-based.

--- a/packages/web/src/components/Results/HelpTips/HelpTipsColumnStopCodons.mdx
+++ b/packages/web/src/components/Results/HelpTips/HelpTipsColumnStopCodons.mdx
@@ -2,11 +2,7 @@
 
 Displays number of unexpected premature stop codons in the sequence.
 
-Hovering mouse over a cell in this column will display a tooltip with detailed information about the detected premature stop codons in each gene.
-
-Note that the dataset authors may define a list of known good (expected) premature stop codons in the quality control (QC) configuration. These stop codons are not included in the displayed number and are listed separately in the tooltip.
-
-The meaning of the notation with parenteses: first number is a number of unexpected changes and the second is grand total (unexpected + known).
+Displayed in parentheses are the total number of premature stop codons, including known stop codons. Dataset authors may define a list of known good (expected) premature stop codons in the quality control (QC) configuration to prevent them from causing a bad QC score. These stop codons are only included in the number in parentheses.
 
 The usual stop condons at the end of genes (as defined by the reference sequence) are never counted or displayed in this column.
 


### PR DESCRIPTION
The notation now uses parentheses: first number is a number of unexpected changes and the second is total (unexpected+known). Help tips are adjusted to explain this.

![localhost_3000_(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/9403403/134393084-12d0237b-6396-4b0e-af6e-04e773354846.png)
