### PR TITLE
fix: mask codons containing nuc deletions before and after frame shift

### DIFF
--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -35,13 +35,33 @@ struct Range {
   int begin;
   int end;
 
-  bool contains(int x) const {
+  [[nodiscard]] bool contains(int x) const {
     return x >= begin && x < end;
   }
 };
 
-inline bool operator==(const Range& left, const Range& right) {
+[[nodiscard]] inline bool operator==(const Range& left, const Range& right) {
   return left.begin == right.begin && left.end == right.end;
+}
+
+[[nodiscard]] inline bool operator!=(const Range& left, const Range& right) {
+  return left.begin != right.begin && left.end != right.end;
+}
+
+[[nodiscard]] inline Range operator+(const Range& r, int add) {
+  return Range{.begin = r.begin + add, .end = r.end + add};
+}
+
+[[nodiscard]] inline Range operator-(const Range& r, int sub) {
+  return Range{.begin = r.begin - sub, .end = r.end - sub};
+}
+
+[[nodiscard]] inline Range operator*(const Range& r, int mul) {
+  return Range{.begin = r.begin * mul, .end = r.end * mul};
+}
+
+[[nodiscard]] inline Range operator/(const Range& r, int div) {
+  return Range{.begin = r.begin / div, .end = r.end / div};
 }
 
 struct FrameShiftContext {
@@ -63,11 +83,11 @@ struct FrameShiftResult {
 };
 
 inline bool operator==(const FrameShiftResult& left, const FrameShiftResult& right) {
-  return left.geneName == right.geneName         //
-         && left.nucRel == right.nucRel          //
-         && left.nucAbs == right.nucAbs          //
-         && left.codon == right.codon            //
-         && left.gapsLeading == right.gapsLeading//
+  return left.geneName == right.geneName           //
+         && left.nucRel == right.nucRel            //
+         && left.nucAbs == right.nucAbs            //
+         && left.codon == right.codon              //
+         && left.gapsLeading == right.gapsLeading  //
          && left.gapsTrailing == right.gapsTrailing//
     ;
 }

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -59,7 +59,7 @@ struct FrameShiftResult {
   Range nucAbs;
   Range codon;
   FrameShiftContext gapsLeading;
-  FrameShiftContext gapsTraling;
+  FrameShiftContext gapsTrailing;
 };
 
 inline bool operator==(const FrameShiftResult& left, const FrameShiftResult& right) {
@@ -68,7 +68,7 @@ inline bool operator==(const FrameShiftResult& left, const FrameShiftResult& rig
          && left.nucAbs == right.nucAbs          //
          && left.codon == right.codon            //
          && left.gapsLeading == right.gapsLeading//
-         && left.gapsTraling == right.gapsTraling//
+         && left.gapsTrailing == right.gapsTrailing//
     ;
 }
 

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -59,6 +59,17 @@ inline bool operator==(const FrameShiftResult& left, const FrameShiftResult& rig
     ;
 }
 
+struct InternalFrameShiftResultWithMask {
+  FrameShiftResult frameShift;
+  Range codonMask;// used internally during translation to mask undesired regions around the frame shift
+};
+
+inline bool operator==(const InternalFrameShiftResultWithMask& left, const InternalFrameShiftResultWithMask& right) {
+  return left.frameShift == right.frameShift //
+         && left.codonMask == right.codonMask//
+    ;
+}
+
 class Error : public std::runtime_error {
 public:
   explicit Error(const std::string& message) : std::runtime_error(message) {}

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -44,18 +44,31 @@ inline bool operator==(const Range& left, const Range& right) {
   return left.begin == right.begin && left.end == right.end;
 }
 
+struct FrameShiftContext {
+  Range codon;
+};
+
+inline bool operator==(const FrameShiftContext& left, const FrameShiftContext& right) {
+  return left.codon == right.codon//
+    ;
+}
+
 struct FrameShiftResult {
   std::string geneName;
   Range nucRel;
   Range nucAbs;
   Range codon;
+  FrameShiftContext gapsLeading;
+  FrameShiftContext gapsTraling;
 };
 
 inline bool operator==(const FrameShiftResult& left, const FrameShiftResult& right) {
-  return left.geneName == right.geneName//
-         && left.nucRel == right.nucRel //
-         && left.nucAbs == right.nucAbs //
-         && left.codon == right.codon   //
+  return left.geneName == right.geneName         //
+         && left.nucRel == right.nucRel          //
+         && left.nucAbs == right.nucAbs          //
+         && left.codon == right.codon            //
+         && left.gapsLeading == right.gapsLeading//
+         && left.gapsTraling == right.gapsTraling//
     ;
 }
 

--- a/packages/nextalign/include/nextalign/private/nextalign_private.h
+++ b/packages/nextalign/include/nextalign/private/nextalign_private.h
@@ -96,21 +96,21 @@ inline std::ostream& operator<<(std::ostream& os, const Range& f) {
 inline std::ostream& operator<<(std::ostream& os, const FrameShiftContext& f) {
   os << "{ "                        //
      << "codon: " << f.codon << ", "//
-     << " }"                        //
+     << "}"                         //
     ;
   return os;
 }
 
 
 inline std::ostream& operator<<(std::ostream& os, const FrameShiftResult& f) {
-  os << "{ "                                    //
-     << "geneName: \"" << f.geneName << "\", "  //
-     << "nucRel: " << f.nucRel << ", "          //
-     << "nucAbs: " << f.nucAbs << ", "          //
-     << "codon: " << f.codon << ", "            //
-     << "gapsLeading: " << f.gapsLeading << ", "//
+  os << "{ "                                      //
+     << "geneName: \"" << f.geneName << "\", "    //
+     << "nucRel: " << f.nucRel << ", "            //
+     << "nucAbs: " << f.nucAbs << ", "            //
+     << "codon: " << f.codon << ", "              //
+     << "gapsLeading: " << f.gapsLeading << ", "  //
      << "gapsTrailing: " << f.gapsTrailing << ", "//
-     << " }"                                    //
+     << "}"                                       //
     ;
   return os;
 }

--- a/packages/nextalign/include/nextalign/private/nextalign_private.h
+++ b/packages/nextalign/include/nextalign/private/nextalign_private.h
@@ -109,7 +109,7 @@ inline std::ostream& operator<<(std::ostream& os, const FrameShiftResult& f) {
      << "nucAbs: " << f.nucAbs << ", "          //
      << "codon: " << f.codon << ", "            //
      << "gapsLeading: " << f.gapsLeading << ", "//
-     << "gapsTraling: " << f.gapsTraling << ", "//
+     << "gapsTrailing: " << f.gapsTrailing << ", "//
      << " }"                                    //
     ;
   return os;

--- a/packages/nextalign/include/nextalign/private/nextalign_private.h
+++ b/packages/nextalign/include/nextalign/private/nextalign_private.h
@@ -93,13 +93,24 @@ inline std::ostream& operator<<(std::ostream& os, const Range& f) {
   return os;
 }
 
+inline std::ostream& operator<<(std::ostream& os, const FrameShiftContext& f) {
+  os << "{ "                        //
+     << "codon: " << f.codon << ", "//
+     << " }"                        //
+    ;
+  return os;
+}
+
+
 inline std::ostream& operator<<(std::ostream& os, const FrameShiftResult& f) {
-  os << "{ "                                  //
-     << "geneName: \"" << f.geneName << "\", "//
-     << "nucRel: " << f.nucRel << ", "        //
-     << "nucAbs: " << f.nucAbs << ", "        //
-     << "codon: " << f.codon << ", "          //
-     << " }"                                  //
+  os << "{ "                                    //
+     << "geneName: \"" << f.geneName << "\", "  //
+     << "nucRel: " << f.nucRel << ", "          //
+     << "nucAbs: " << f.nucAbs << ", "          //
+     << "codon: " << f.codon << ", "            //
+     << "gapsLeading: " << f.gapsLeading << ", "//
+     << "gapsTraling: " << f.gapsTraling << ", "//
+     << " }"                                    //
     ;
   return os;
 }

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -218,6 +218,20 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
       .end = maskNucRangeRel.end / 3,
     };
 
+    FrameShiftContext gapsLeading{
+      .codon{
+        .begin = codonMask.begin,
+        .end = codonRange.begin,
+      },
+    };
+
+    FrameShiftContext gapsTrailing{
+      .codon{
+        .begin = codonRange.end,
+        .end = codonMask.end,
+      },
+    };
+
     frameShifts.push_back(InternalFrameShiftResultWithMask{
       .frameShift =
         FrameShiftResult{
@@ -225,6 +239,8 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
           .nucRel = nucRangeRel,
           .nucAbs = nucRangeAbs,
           .codon = codonRange,
+          .gapsLeading = gapsLeading,
+          .gapsTraling = gapsTrailing,
         },
       .codonMask = codonMask,
     });

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -214,8 +214,8 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
     };
 
     Range maskNucRangeRel{
-      .begin = findMaskBegin(query, nucRangeRel),
-      .end = findMaskEnd(query, nucRangeRel),
+      .begin = at(coordMapReverse, findMaskBegin(query, nucRangeRel)),
+      .end = at(coordMapReverse, findMaskEnd(query, nucRangeRel)),
     };
 
     Range codonMask{

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -245,7 +245,7 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
           .nucAbs = nucRangeAbs,
           .codon = codonRange,
           .gapsLeading = gapsLeading,
-          .gapsTraling = gapsTrailing,
+          .gapsTrailing = gapsTrailing,
         },
       .codonMask = codonMask,
     });

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -139,14 +139,12 @@ int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRange
   // From begin, rewind back to find the first adjacent nuc deletion
   int begin = frameShiftNucRangeRel.begin - 1;
   if (begin > 0) {
-    auto nuc = seq[begin];
-    while (nuc == Nucleotide::GAP && begin >= 0) {
+    while (begin >= 0 && seq[begin] == Nucleotide::GAP) {
       --begin;
-      nuc = seq[begin];
     }
   }
 
-  // `begin` now points to the nuc that is 1 to the left of the deletion.
+  // `begin` now points to the nuc that is immediately before the deletion.
   // Go back one nuc to make it point to the deletion.
   return begin + 1;
 }
@@ -158,15 +156,11 @@ int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRe
   int length = safe_cast<int>(seq.size());
   // From end, rewind forward to find the last adjacent nuc deletion
   int end = frameShiftNucRangeRel.end;
-  if (end < length) {
-    auto nuc = seq[end];
-    while (nuc == Nucleotide::GAP && end < length) {
-      ++end;
-      nuc = seq[end];
-    }
+  while (end < length && seq[end] == Nucleotide::GAP) {
+    ++end;
   }
 
-  // `end` now points to the nuc that is 1 to the right of the deletion. Which is correct - we use semi-open ranges.
+  // `end` now points to the nuc that is 1 past the deletion. Which is correct - we use semi-open ranges.
   return end;
 }
 

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -146,7 +146,7 @@ int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRange
     }
   }
 
-  // `begin` now points to the nuc that is 1 to the right of the deletion.
+  // `begin` now points to the nuc that is 1 to the left of the deletion.
   // Go back one nuc to make it point to the deletion.
   return begin + 1;
 }
@@ -166,7 +166,7 @@ int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRe
     }
   }
 
-  // `end` now points to the nuc that is 1 to the left of the deletion. Which is correct - we use semi-open ranges.
+  // `end` now points to the nuc that is 1 to the right of the deletion. Which is correct - we use semi-open ranges.
   return end;
 }
 

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -165,6 +165,14 @@ int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRe
   return end;
 }
 
+
+Range findMask(const NucleotideSequence& query, const Range& frameShiftNucRangeRel) {
+  return Range{
+    .begin = findMaskBegin(query, frameShiftNucRangeRel),
+    .end = findMaskEnd(query, frameShiftNucRangeRel),
+  };
+}
+
 /**
  * Converts relative nucleotide frame shifts to the final result, including
  * relative and absolute nucleotide frame shifts and relative aminoacid frame shifts

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -198,10 +198,14 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
 
     Range nucAbsAln = nucRelAln + geneStartAln;
     Range nucAbsRef = coordMap.alnToRef(nucAbsAln);
-    Range codon = nucRelAln / 3;
+    Range nucRelRef =  nucAbsRef - geneStartRef;
+    Range codon = nucRelRef / 3;
 
     Range maskNucRelAln = findMask(query, nucRelAln);
-    Range maskCodon = maskNucRelAln / 3;
+    Range maskNucAbsAln = maskNucRelAln + geneStartAln;
+    Range maskNucAbsRef = coordMap.alnToRef(maskNucAbsAln);
+    Range maskNucRelRef = maskNucAbsRef - geneStartRef;
+    Range maskCodon = maskNucRelRef / 3;
 
     FrameShiftContext gapsLeading{
       .codon{

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -145,7 +145,10 @@ int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRange
       nuc = seq[begin];
     }
   }
-  return begin;
+
+  // `begin` now points to the nuc that is 1 to the right of the deletion.
+  // Go back one nuc to make it point to the deletion.
+  return begin + 1;
 }
 
 /**
@@ -162,6 +165,8 @@ int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRe
       nuc = seq[end];
     }
   }
+
+  // `end` now points to the nuc that is 1 to the left of the deletion. Which is correct - we use semi-open ranges.
   return end;
 }
 

--- a/packages/nextalign/src/translate/detectFrameShifts.cpp
+++ b/packages/nextalign/src/translate/detectFrameShifts.cpp
@@ -134,7 +134,7 @@ std::vector<Range> detectFrameShifts(//
 }
 
 /**
- * Find beginning nucleotide position of a deletion that immedeatly preceeds and adjacent to the frame shift
+ * Find beginning nucleotide position of a deletion that immediately proceeds and adjacent to the frame shift
  */
 int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel) {
   // From begin, rewind back to find the first adjacent nuc deletion
@@ -151,7 +151,7 @@ int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRange
 }
 
 /**
- * Find ending nucleotide position of a deletion that immedeatly follows and adjacent to the frame shift
+ * Find ending nucleotide position of a deletion that immediately follows and adjacent to the frame shift
  */
 int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel) {
   int length = safe_cast<int>(seq.size());

--- a/packages/nextalign/src/translate/detectFrameShifts.h
+++ b/packages/nextalign/src/translate/detectFrameShifts.h
@@ -4,13 +4,14 @@
 
 
 std::vector<Range> detectFrameShifts(//
-  const NucleotideSequence& ref,               //
-  const NucleotideSequence& query              //
+  const NucleotideSequence& ref,     //
+  const NucleotideSequence& query    //
 );
 
-std::vector<FrameShiftResult> translateFrameShifts(     //
-  const std::vector<Range>& nucRelFrameShifts,//
-  const std::vector<int>& coordMap,                     //
-  const std::vector<int>& coordMapReverse,              //
-  const Gene& gene                                      //
+std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
+  const NucleotideSequence& query,                                 //
+  const std::vector<Range>& nucRelFrameShifts,                     //
+  const std::vector<int>& coordMap,                                //
+  const std::vector<int>& coordMapReverse,                         //
+  const Gene& gene                                                 //
 );

--- a/packages/nextalign/src/translate/detectFrameShifts.h
+++ b/packages/nextalign/src/translate/detectFrameShifts.h
@@ -2,6 +2,7 @@
 
 #include <nextalign/nextalign.h>
 
+class CoordinateMapper;
 
 std::vector<Range> detectFrameShifts(//
   const NucleotideSequence& ref,     //
@@ -11,8 +12,7 @@ std::vector<Range> detectFrameShifts(//
 std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
   const NucleotideSequence& query,                                 //
   const std::vector<Range>& nucRelFrameShifts,                     //
-  const std::vector<int>& coordMap,                                //
-  const std::vector<int>& coordMapReverse,                         //
+  const CoordinateMapper& coordMap,                                //
   const Gene& gene                                                 //
 );
 

--- a/packages/nextalign/src/translate/detectFrameShifts.h
+++ b/packages/nextalign/src/translate/detectFrameShifts.h
@@ -19,3 +19,5 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
 int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel);
 
 int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel);
+
+Range findMask(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel);

--- a/packages/nextalign/src/translate/detectFrameShifts.h
+++ b/packages/nextalign/src/translate/detectFrameShifts.h
@@ -15,3 +15,7 @@ std::vector<InternalFrameShiftResultWithMask> translateFrameShifts(//
   const std::vector<int>& coordMapReverse,                         //
   const Gene& gene                                                 //
 );
+
+int findMaskBegin(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel);
+
+int findMaskEnd(const NucleotideSequence& seq, const Range& frameShiftNucRangeRel);

--- a/packages/nextalign/src/translate/extractGene.cpp
+++ b/packages/nextalign/src/translate/extractGene.cpp
@@ -9,6 +9,7 @@
 #include "../utils/at.h"
 #include "../utils/safe_cast.h"
 #include "./removeGaps.h"
+#include "mapCoordinates.h"
 
 namespace details {
   template<typename IntS, typename IntL>
@@ -74,23 +75,20 @@ void protectFirstCodonInPlace(NucleotideSequence& seq) {
  * Extracts gene from the query sequence according to coordinate map relative to the reference sequence
  */
 ExtractGeneStatus extractGeneQuery(const NucleotideSequenceView& query, const Gene& gene,
-  const std::vector<int>& coordMap) {
-  precondition_less(gene.start, coordMap.size());
-  precondition_less_equal(gene.end, coordMap.size());
+  const CoordinateMapper& coordMap) {
   precondition_less(gene.start, gene.end);
 
   // Transform gene coordinates according to coordinate map
-  const auto start = at(coordMap, gene.start);
+  const auto start = coordMap.refToAln(gene.start);
   // gene.end is the position after the last base of the gene (0-based indexing)
   // the corresponding base in the query is hence found by coordMap[gene.end-1]
   // we add 1 to make that end be again after the last base of the gene.
   // with this addition: length = end - start
-  const auto end = at(coordMap, gene.end - 1) + 1;
+  const auto end = coordMap.refToAln(gene.end - 1) + 1;
   const auto length = end - start;
   // Start and end should be within bounds
   invariant_less(start, query.size());
   invariant_less_equal(end, query.size());
-
 
   auto result = NucleotideSequence(details::substr(query, start, length));
   const auto resultLength = safe_cast<int>(result.size());

--- a/packages/nextalign/src/translate/extractGene.h
+++ b/packages/nextalign/src/translate/extractGene.h
@@ -9,6 +9,7 @@
 #include "nextalign/private/nextalign_private.h"
 
 struct Gene;
+class CoordinateMapper;
 
 enum ExtractGeneStatusReason { GeneEmpty };
 
@@ -20,6 +21,6 @@ struct ExtractGeneStatus {
 };
 
 ExtractGeneStatus extractGeneQuery(const NucleotideSequenceView& query, const Gene& gene,
-  const std::vector<int>& coordMap);
+  const CoordinateMapper& coordMap);
 
 void protectFirstCodonInPlace(NucleotideSequence& seq);

--- a/packages/nextalign/src/translate/mapCoordinates.cpp
+++ b/packages/nextalign/src/translate/mapCoordinates.cpp
@@ -156,3 +156,17 @@ int CoordinateMapper::alnToRef(int alnPos) const {
 int CoordinateMapper::refToAln(int refPos) const {
   return at(refToAlnMap, refPos);
 }
+
+Range CoordinateMapper::alnToRef(const Range& alnRange) const {
+  return Range{
+    .begin = alnToRef(alnRange.begin),
+    .end = alnToRef(alnRange.end),
+  };
+}
+
+Range CoordinateMapper::refToAln(const Range& refRange) const {
+  return Range{
+    .begin = refToAln(refRange.begin),
+    .end = refToAln(refRange.end),
+  };
+}

--- a/packages/nextalign/src/translate/mapCoordinates.cpp
+++ b/packages/nextalign/src/translate/mapCoordinates.cpp
@@ -8,56 +8,151 @@
 #include "utils/contract.h"
 #include "utils/safe_cast.h"
 
-/**
- * Makes a map from reference coordinates to alignment coordinates
- * (Excluding the gaps in reference).
- *
- * Example:
- *   ref pos: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
- *   ref    : A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
- *   aln pos: 0  1  2  3           7  8  9  10          14
- */
-std::vector<int> mapCoordinates(const NucleotideSequence& ref) {
-  const auto refLength = safe_cast<int>(ref.size());
 
-  std::vector<int> coordMap;
-  coordMap.reserve(refLength);
-  for (int i = 0; i < refLength; ++i) {
-    if (ref[i] != Nucleotide::GAP) {
-      coordMap.push_back(i);
+namespace {
+
+  /*****************************************************************************
+   *
+   *                 OLD IMPLEMENTATIONS
+   *
+   ****************************************************************************/
+
+
+  /**
+ * Makes the "alingnment to reference" coordinate map: from alignment coordinates to reference coordinates.
+ *
+ * Given a position of a letter in the aligned sequence, the "alingnment to reference" coordinate map allows to
+ * lookup the position of the corresponding letter in the reference sequence.
+ *
+ * @param refAln  Aligned reference sequence
+ * @return        Coordinate map from alignment coordinates to reference coordinates
+ */
+  std::vector<int> makeAlnToRefMapOld(const NucleotideSequence& ref) {
+    const auto alnLength = safe_cast<int>(ref.size());
+
+    std::vector<int> revCoordMap;
+    revCoordMap.reserve(alnLength);
+    int refPos = 0;
+    for (int i = 0; i < alnLength; ++i) {
+      if (ref[i] == Nucleotide::GAP) {
+        const auto& prev = revCoordMap.back();
+        revCoordMap.push_back(prev);
+      } else {
+        revCoordMap.push_back(refPos);
+        ++refPos;
+      }
     }
+
+    revCoordMap.shrink_to_fit();
+    return revCoordMap;
   }
 
-  coordMap.shrink_to_fit();
-  return coordMap;
+
+  /**
+ * Makes the "reference to alingnment" coordinate map: from alignment coordinates to reference coordinates.
+ *
+ * Given a position of a letter in the reference sequence, the "reference to alingnment" coordinate map allows to
+ * lookup the position of the corresponding letter in the aligned sequence.
+ *
+ * @param refAln  Aligned reference sequence
+ * @return        Coordinate map from alignment coordinates to reference coordinates
+ */
+  std::vector<int> makeRefToAlnMapOld(const NucleotideSequence& ref) {
+    const auto alnLength = safe_cast<int>(ref.size());
+
+    std::vector<int> coordMap;
+    coordMap.reserve(alnLength);
+    for (int i = 0; i < alnLength; ++i) {
+      if (ref[i] != Nucleotide::GAP) {
+        coordMap.push_back(i);
+      }
+    }
+
+    coordMap.shrink_to_fit();
+    return coordMap;
+  }
+
+
+  /*****************************************************************************
+   *
+   *                 NEW IMPLEMENTATIONS
+   *
+   ****************************************************************************/
+
+
+  /**
+ * Makes the "alingnment to reference" coordinate map: from alignment coordinates to reference coordinates.
+ *
+ * Given a position of a letter in the aligned sequence, the "alingnment to reference" coordinate map allows to
+ * lookup the position of the corresponding letter in the reference sequence.
+ *
+ * @param refAln  Aligned reference sequence
+ * @return        Coordinate map from alignment coordinates to reference coordinates
+ */
+  std::vector<int> makeAlnToRefMap(const NucleotideSequence& refAln) {
+    int alnLength = safe_cast<int>(refAln.size());
+    std::vector<int> alnToRefMap(alnLength);// TODO: Slow
+    int refPos = -1;
+    for (int alnPos = 0; alnPos < alnLength; ++alnPos) {
+      if (refAln[alnPos] != Nucleotide::GAP) {
+        refPos += 1;
+      }
+      alnToRefMap[alnPos] = refPos;
+    }
+    return alnToRefMap;
+  }
+
+  /**
+ * Makes the "reference to alingnment" coordinate map: from alignment coordinates to reference coordinates.
+ *
+ * Given a position of a letter in the reference sequence, the "reference to alingnment" coordinate map allows to
+ * lookup the position of the corresponding letter in the aligned sequence.
+ *
+ * @param refAln  Aligned reference sequence
+ * @return        Coordinate map from alignment coordinates to reference coordinates
+ */
+  std::vector<int> makeRefToAlnMap(const NucleotideSequence& refAln, const std::vector<int>& alnToRef) {
+    int refLength = safe_cast<int>(alnToRef.size());
+    std::vector<int> refToAlnMap(refLength);// TODO: Slow
+    int refPos = -1;
+    for (int alnPos = 0; alnPos < refLength; ++alnPos) {
+      if (refAln[alnPos] != Nucleotide::GAP) {
+        refPos = alnToRef[alnPos];
+        refToAlnMap[refPos] = alnPos;
+      }
+    }
+    // truncate unused values in the tail
+    refToAlnMap.resize(refPos + 1);// TODO: slow
+    return refToAlnMap;
+  }
+}// namespace
+
+CoordinateMapper::CoordinateMapper(const NucleotideSequence& refAln)
+    // old implementation
+    : alnToRefMap(makeAlnToRefMapOld(refAln)),
+      refToAlnMap(makeRefToAlnMapOld(refAln)) {}
+
+// new implementation
+//  : alnToRefMap(makeAlnToRefMap(refAln)),
+//    refToAlnMap(makeRefToAlnMap(refAln, alnToRefMap)) {}
+
+
+/**
+ * Converts position from alignment coordinates to reference coordianates
+ *
+ * @param alnPos  Position in alignment coordinates
+ * @return        Position in reference coordinates
+ */
+int CoordinateMapper::alnToRef(int alnPos) const {
+  return at(alnToRefMap, alnPos);
 }
 
-
 /**
- * Makes a map from alignment coordinates to reference coordinates
- * (reverse coordinate map).
+ * Converts position from reference coordinates to alignment coordianates
  *
- * Example:
- *   aln pos: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
- *   ref    : A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
- *   ref pos: 0  1  2  3  3  3  3  4  5  6  7  7  7  7  8
+ * @param refPos  Position in reference coordinates
+ * @return        Position in alignment coordinates
  */
-std::vector<int> mapReverseCoordinates(const NucleotideSequence& ref) {
-  const auto refLength = safe_cast<int>(ref.size());
-
-  std::vector<int> revCoordMap;
-  revCoordMap.reserve(refLength);
-  int refPos = 0;
-  for (int i = 0; i < refLength; ++i) {
-    if (ref[i] == Nucleotide::GAP) {
-      const auto& prev = revCoordMap.back();
-      revCoordMap.push_back(prev);
-    } else {
-      revCoordMap.push_back(refPos);
-      ++refPos;
-    }
-  }
-
-  revCoordMap.shrink_to_fit();
-  return revCoordMap;
+int CoordinateMapper::refToAln(int refPos) const {
+  return at(refToAlnMap, refPos);
 }

--- a/packages/nextalign/src/translate/mapCoordinates.h
+++ b/packages/nextalign/src/translate/mapCoordinates.h
@@ -21,5 +21,9 @@ public:
 
   [[nodiscard]] int alnToRef(int alnPos) const;
 
+  [[nodiscard]] Range alnToRef(const Range& alnRange) const;
+
   [[nodiscard]] int refToAln(int refPos) const;
+
+  [[nodiscard]] Range refToAln(const Range& refRange) const;
 };

--- a/packages/nextalign/src/translate/mapCoordinates.h
+++ b/packages/nextalign/src/translate/mapCoordinates.h
@@ -2,8 +2,24 @@
 
 #include <nextalign/nextalign.h>
 
+#include <string_view>
 #include <vector>
 
-std::vector<int> mapCoordinates(const NucleotideSequence& ref);
+#include "../utils/at.h"
+#include "../utils/contract.h"
+#include "../utils/safe_cast.h"
+#include "mapCoordinates.h"
 
-std::vector<int> mapReverseCoordinates(const NucleotideSequence& ref);
+/** Handles conversion of positions between different coordinate systems */
+class CoordinateMapper {
+protected:
+  const std::vector<int> alnToRefMap;// maps alignment positions to reference positions
+  const std::vector<int> refToAlnMap;// maps reference positions to alignment positions
+
+public:
+  explicit CoordinateMapper(const NucleotideSequence& refAln);
+
+  [[nodiscard]] int alnToRef(int alnPos) const;
+
+  [[nodiscard]] int refToAln(int refPos) const;
+};

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -59,11 +59,11 @@ void maskPeptideFrameShiftsInPlace(AminoacidSequence& seq,
   for (const auto& frameShift : frameShifts) {
     const auto& gapsLeading = frameShift.frameShift.gapsLeading.codon;
     const auto& frameShiftBody = frameShift.frameShift.codon;
-    const auto& gapsTraling = frameShift.frameShift.gapsTrailing.codon;
+    const auto& gapsTrailing = frameShift.frameShift.gapsTrailing.codon;
 
     fillRangeInplace(seq, gapsLeading, Aminoacid::GAP);
     fillRangeInplace(seq, frameShiftBody, Aminoacid::X);
-    fillRangeInplace(seq, gapsTraling, Aminoacid::GAP);
+    fillRangeInplace(seq, gapsTrailing, Aminoacid::GAP);
   }
 }
 

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -26,9 +26,9 @@ void maskNucFrameShiftsInPlace(NucleotideSequence& seq,
   for (const auto& frameShift : frameShifts) {
     auto current = frameShift.frameShift.nucRel.begin;
     const auto end = frameShift.frameShift.nucRel.end;
-    invariant_greater(current, 0);
-    invariant_less_equal(end, seq.size());
     while (current < end) {
+      invariant_greater(current, 0);
+      invariant_less_equal(current, seq.size());
       if (seq[current] != Nucleotide::GAP) {
         seq[current] = Nucleotide::N;
       }
@@ -46,9 +46,9 @@ void maskPeptideFrameShiftsInPlace(AminoacidSequence& seq,
   for (const auto& frameShift : frameShifts) {
     auto current = frameShift.codonMask.begin;
     const auto end = frameShift.codonMask.end;
-    invariant_greater(current, 0);
-    invariant_less_equal(end, seq.size());
     while (current < end) {
+      invariant_greater(current, 0);
+      invariant_less_equal(current, seq.size());
       if (seq[current] == Aminoacid::GAP) {
         seq[current] = Aminoacid::X;
       }

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -27,10 +27,8 @@ void maskNucFrameShiftsInPlace(NucleotideSequence& seq,
     auto current = frameShift.frameShift.nucRel.begin;
     const auto end = frameShift.frameShift.nucRel.end;
     while (current < end) {
-      invariant_greater(current, 0);
-      invariant_less_equal(current, seq.size());
-      if (seq[current] != Nucleotide::GAP) {
-        seq[current] = Nucleotide::N;
+      if (at(seq, current) != Nucleotide::GAP) {
+        at(seq, current) = Nucleotide::N;
       }
       ++current;
     }
@@ -42,10 +40,8 @@ template<typename Letter>
 void fillRangeInplace(Sequence<Letter>& seq, const Range& range, Letter letter) {
   auto current = range.begin;
   const auto end = range.end;
-  invariant_greater(current, 0);
-  invariant_less_equal(end, seq.size());
   while (current < end) {
-    seq[current] = letter;
+    at(seq, current) = letter;
     ++current;
   }
 }

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -140,7 +140,7 @@ PeptidesInternal translateGenes(         //
 
     // NOTE: frame shift detection should be performed on unstripped genes
     const auto nucRelFrameShifts = detectFrameShifts(refGeneSeq, queryGeneSeq);
-    const auto frameShiftResults = translateFrameShifts(query, nucRelFrameShifts, coordMap, gene);
+    const auto frameShiftResults = translateFrameShifts(queryGeneSeq, nucRelFrameShifts, coordMap, gene);
 
     maskNucFrameShiftsInPlace(queryGeneSeq, frameShiftResults);
 

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -156,7 +156,7 @@ PeptidesInternal translateGenes(         //
     const auto queryPeptide = translate(queryGeneSeq, options.translatePastStop);
 
 
-    auto geneAlignmentStatus =
+    const auto geneAlignmentStatus =
       alignPairwise(queryPeptide, refPeptide, gapOpenCloseAA, options.alignment, options.seedAa);
 
     if (geneAlignmentStatus.status != Status::Success) {
@@ -169,9 +169,9 @@ PeptidesInternal translateGenes(         //
       continue;
     }
 
-    maskPeptideFrameShiftsInPlace(geneAlignmentStatus.result->query, frameShiftResults);
-
     auto stripped = stripInsertions(geneAlignmentStatus.result->ref, geneAlignmentStatus.result->query);
+
+    maskPeptideFrameShiftsInPlace(stripped.queryStripped, frameShiftResults);
 
     std::vector<FrameShiftResult> frameShiftResultsFinal = toExternal(frameShiftResults);
 

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -156,7 +156,7 @@ PeptidesInternal translateGenes(         //
     const auto queryPeptide = translate(queryGeneSeq, options.translatePastStop);
 
 
-    const auto geneAlignmentStatus =
+    auto geneAlignmentStatus =
       alignPairwise(queryPeptide, refPeptide, gapOpenCloseAA, options.alignment, options.seedAa);
 
     if (geneAlignmentStatus.status != Status::Success) {
@@ -169,9 +169,9 @@ PeptidesInternal translateGenes(         //
       continue;
     }
 
-    auto stripped = stripInsertions(geneAlignmentStatus.result->ref, geneAlignmentStatus.result->query);
+    maskPeptideFrameShiftsInPlace(geneAlignmentStatus.result->query, frameShiftResults);
 
-    maskPeptideFrameShiftsInPlace(stripped.queryStripped, frameShiftResults);
+    auto stripped = stripInsertions(geneAlignmentStatus.result->ref, geneAlignmentStatus.result->query);
 
     std::vector<FrameShiftResult> frameShiftResultsFinal = toExternal(frameShiftResults);
 

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -133,6 +133,8 @@ PeptidesInternal translateGenes(         //
       continue;
     }
 
+    bool isBreak = geneName == "ORF6";
+
     auto& refGeneSeq = *extractRefGeneStatus.result;
     auto& queryGeneSeq = *extractQueryGeneStatus.result;
 
@@ -142,8 +144,7 @@ PeptidesInternal translateGenes(         //
 
     // NOTE: frame shift detection should be performed on unstripped genes
     const auto nucRelFrameShifts = detectFrameShifts(refGeneSeq, queryGeneSeq);
-    const auto frameShiftResults =
-      translateFrameShifts(query, nucRelFrameShifts, coordMap, gene);
+    const auto frameShiftResults = translateFrameShifts(query, nucRelFrameShifts, coordMap, gene);
 
     maskNucFrameShiftsInPlace(queryGeneSeq, frameShiftResults);
 

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -81,8 +81,7 @@ PeptidesInternal translateGenes(         //
   NucleotideSequence newRefMemory(ref.size(), Nucleotide::GAP);
   NucleotideSequenceSpan newRef{newRefMemory};
 
-  const auto coordMap = mapCoordinates(ref);
-  const auto coordMapReverse = mapReverseCoordinates(ref);
+  const CoordinateMapper coordMap{ref};
 
   std::vector<PeptideInternal> queryPeptides;
   queryPeptides.reserve(geneMap.size());
@@ -134,7 +133,7 @@ PeptidesInternal translateGenes(         //
     // NOTE: frame shift detection should be performed on unstripped genes
     const auto nucRelFrameShifts = detectFrameShifts(refGeneSeq, queryGeneSeq);
     const auto frameShiftResults =
-      translateFrameShifts(queryGeneSeq, nucRelFrameShifts, coordMap, coordMapReverse, gene);
+      translateFrameShifts(query, nucRelFrameShifts, coordMap, gene);
 
     maskNucFrameShiftsInPlace(queryGeneSeq, frameShiftResults);
 

--- a/packages/nextalign/src/utils/at.h
+++ b/packages/nextalign/src/utils/at.h
@@ -10,3 +10,11 @@ inline const typename Container::value_type& at(const Container& container, Inde
   invariant_less(i, container.size());
   return container[i];
 }
+
+template<typename Container, typename Index>
+inline typename Container::value_type& at(Container& container, Index index) {
+  const auto i = safe_cast<typename Container::size_type>(index);
+  invariant_greater_equal(i, 0);
+  invariant_less(i, container.size());
+  return container[i];
+}

--- a/packages/nextalign/tests/CMakeLists.txt
+++ b/packages/nextalign/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${PROJECT_NAME}
   data/sampleGeneMap.h
   decode.test.cpp
   extractGene.test.cpp
+  findMask.test.cpp
   frameshiftDetector.test.cpp
   mapCoordinates.test.cpp
   nucToString.test.cpp

--- a/packages/nextalign/tests/CMakeLists.txt
+++ b/packages/nextalign/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(${PROJECT_NAME}
   nucToString.test.cpp
   parseGeneMapGff.test.cpp
   parseSequences.test.cpp
+  range.test.cpp
   removeGaps.test.cpp
   stripInsertions.test.cpp
   translate.test.cpp

--- a/packages/nextalign/tests/extractGene.test.cpp
+++ b/packages/nextalign/tests/extractGene.test.cpp
@@ -29,7 +29,7 @@ TEST(extractGeneQuery, ExtractsQueryGene) {
     .length = 12,
   };
 
-  const auto coordMap = mapCoordinates(toNucleotideSequence(ref));
+  const CoordinateMapper coordMap{toNucleotideSequence(ref)};
   const auto gene_query = extractGeneQuery(toNucleotideSequence(query_aligned), gene, coordMap);
 
   EXPECT_EQ(toString(*gene_query.result), expected_gene_query);

--- a/packages/nextalign/tests/findMask.test.cpp
+++ b/packages/nextalign/tests/findMask.test.cpp
@@ -73,8 +73,7 @@ TEST(FindMask, Detects2xDeletionLeading1xTralingAroundCompensatedShift) {
   // clang-format on
 
   const Range frameShiftNucRangeRel = {.begin = 20, .end = 31};
-  const auto begin = findMaskBegin(qryAln, frameShiftNucRangeRel);
-  const auto end = findMaskEnd(qryAln, frameShiftNucRangeRel);
-  EXPECT_EQ(begin, 18);
-  EXPECT_EQ(end, 32);
+  const auto actual = findMask(qryAln, frameShiftNucRangeRel);
+  const auto expected = Range{.begin = 18, .end = 32};
+  EXPECT_EQ(actual, expected);
 }

--- a/packages/nextalign/tests/findMask.test.cpp
+++ b/packages/nextalign/tests/findMask.test.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include <nextalign/nextalign.h>
+#include <nextalign/private/nextalign_private.h>
+
+#include <string>
+
+#include "../src/align/getGapOpenCloseScores.h"
+#include "../src/translate/detectFrameShifts.h"
+
+
+TEST(FindMask, ZeroIfEmptyLeading) {
+  const auto seq = toNucleotideSequence("");
+  const Range frameShiftNucRangeRel = {.begin = 0, .end = 0};
+  const auto begin = findMaskEnd(seq, frameShiftNucRangeRel);
+  EXPECT_EQ(begin, 0);
+}
+
+TEST(FindMask, ZeroIfEmptyTrailing) {
+  const auto seq = toNucleotideSequence("");
+  const Range frameShiftNucRangeRel = {.begin = 0, .end = 0};
+  const auto end = findMaskEnd(seq, frameShiftNucRangeRel);
+  EXPECT_EQ(end, 0);
+}
+
+TEST(FindMask, Detects1xDeletionLeading) {
+  // clang-format off
+  //                                                   10        20        30        40        50
+  //                                                   |         |         |         |         |
+  //                                         012345678901234567890123456789012345678901234567890
+  const auto qryAln = toNucleotideSequence( "CTTGGAGGTTCCGTGGCT-TAGATAACAGAACATTCTTGGAATGCTGATC" );
+  // indel                                                     d
+  // frame                                                     11111111111111111111111111111111
+  // frame shift ranges                                         xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  //                                                            ^                              ^
+  //                                                            19                             50
+  // clang-format on
+
+  const Range frameShiftNucRangeRel = {.begin = 19, .end = 50};
+  const auto begin = findMaskBegin(qryAln, frameShiftNucRangeRel);
+  EXPECT_EQ(begin, 18);
+}
+
+TEST(FindMask, Detects2xDeletionLeading) {
+  // clang-format off
+  //                                                   10        20        30        40        50
+  //                                                   |         |         |         |         |
+  //                                         012345678901234567890123456789012345678901234567890
+  const auto qryAln = toNucleotideSequence( "CTTGGAGGTTCCGTGGCT--AGATAACAGAACATTCTTGGAATGCTGATC" );
+  // indel                                                     dd
+  // frame                                                     12222222222222222222222222222222
+  // frame shift ranges                                          xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  //                                                             ^                             ^
+  //                                                             20                            50
+  // clang-format on
+
+  const Range frameShiftNucRangeRel = {.begin = 20, .end = 50};
+  const auto begin = findMaskBegin(qryAln, frameShiftNucRangeRel);
+  EXPECT_EQ(begin, 18);
+}
+
+
+TEST(FindMask, Detects2xDeletionLeading1xTralingAroundCompensatedShift) {
+  // clang-format off
+  //                                                   10        20        30        40        50
+  //                                                   |         |         |         |         |
+  //                                         012345678901234567890123456789012345678901234567890
+  const auto qryAln = toNucleotideSequence( "CTTGGAGGTTCCGTGGCT--AGATAACAGAA-ATTCTTGGAATGCTGATC" );
+  // indel                                                     dd           d
+  // frame                                   00000000000000000012222222222220000000000000000000
+  // frame shift ranges                                          xxxxxxxxxxx
+  //                                                             ^          ^
+  //                                                             20         31
+  // clang-format on
+
+  const Range frameShiftNucRangeRel = {.begin = 20, .end = 31};
+  const auto begin = findMaskBegin(qryAln, frameShiftNucRangeRel);
+  const auto end = findMaskEnd(qryAln, frameShiftNucRangeRel);
+  EXPECT_EQ(begin, 18);
+  EXPECT_EQ(end, 32);
+}

--- a/packages/nextalign/tests/mapCoordinates.test.cpp
+++ b/packages/nextalign/tests/mapCoordinates.test.cpp
@@ -5,32 +5,66 @@
 
 #include <array>
 
-TEST(mapCoordinates, MapsSimple) {
+namespace {
+  /** Wraps the original class to expose internal arrays for testing purposes */
+  class CoordinateMapperExposed : public CoordinateMapper {
+  public:
+    explicit CoordinateMapperExposed(const NucleotideSequence& refAln) : CoordinateMapper(refAln) {}
+
+    [[nodiscard]] inline const std::vector<int>& getAlnToRefMap() const {
+      return alnToRefMap;
+    }
+
+    [[nodiscard]] inline const std::vector<int>& getRefToAlnMap() const {
+      return refToAlnMap;
+    }
+  };
+}//namespace
+
+TEST(mapCoordCoordinateMappe, MapsRefToAlnSimple) {
   // ref pos: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
   // ref    : A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
   // aln pos: 0  1  2  3           7  8  9  10          14
 
   const auto ref = toNucleotideSequence("ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const auto& actual = coordMap.getRefToAlnMap();
   const auto expected = std::vector<int>{0, 1, 2, 3, 7, 8, 9, 10, 14};
-  EXPECT_THAT(mapCoordinates(ref), testing::ElementsAreArray(expected));
+  EXPECT_THAT(actual, testing::ElementsAreArray(expected));
 }
 
-TEST(mapCoordinates, MapsReverseSimple) {
+TEST(mapCoordinates, MapsRefToAlnWithLeadingInsertions) {
+  // ref pos:  0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
+  // ref    :  -  -  A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
+  // aln pos:  -  -  2  3  4  5           9  10 11 12          16
+
+  const auto ref = toNucleotideSequence("--ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const auto& actual = coordMap.getRefToAlnMap();
+  const auto expected = std::vector<int>{2, 3, 4, 5, 9, 10, 11, 12, 16};
+  EXPECT_THAT(actual, testing::ElementsAreArray(expected));
+}
+
+TEST(mapCoordinates, MapsAlnToRefSimple) {
   // ref pos: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
   // ref    : A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
   // aln pos: 0  1  2  3  3  3  3  4  5  6  7  7  7  7  8
 
   const auto ref = toNucleotideSequence("ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const auto& actual = coordMap.getAlnToRefMap();
   const auto expected = std::vector<int>{0, 1, 2, 3, 3, 3, 3, 4, 5, 6, 7, 7, 7, 7, 8};
-  EXPECT_THAT(mapReverseCoordinates(ref), expected);
+  EXPECT_THAT(actual, testing::ElementsAreArray(expected));
 }
 
-TEST(mapCoordinates, MapsReverseSimpleWithLeadingInsertions) {
+TEST(mapCoordinates, MapsAlnToRefWithLeadingInsertions) {
   // ref pos: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
   // ref    : -  -  A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
   // aln pos: 0  0  0  1  2  3  3  3  3  4  5  6  7  7  7  7  8
 
   const auto ref = toNucleotideSequence("--ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const auto& actual = coordMap.getAlnToRefMap();
   const auto expected = std::vector<int>{0, 0, 0, 1, 2, 3, 3, 3, 3, 4, 5, 6, 7, 7, 7, 7, 8};
-  EXPECT_THAT(mapReverseCoordinates(ref), expected);
+  EXPECT_THAT(actual, testing::ElementsAreArray(expected));
 }

--- a/packages/nextalign/tests/mapCoordinates.test.cpp
+++ b/packages/nextalign/tests/mapCoordinates.test.cpp
@@ -21,7 +21,7 @@ namespace {
   };
 }//namespace
 
-TEST(mapCoordCoordinateMappe, MapsRefToAlnSimple) {
+TEST(mapCoordinates, MapsRefToAlnSimple) {
   // ref pos: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
   // ref    : A  C  T  C  -  -  -  C  G  T  G  -  -  -  A
   // aln pos: 0  1  2  3           7  8  9  10          14
@@ -67,4 +67,38 @@ TEST(mapCoordinates, MapsAlnToRefWithLeadingInsertions) {
   const auto& actual = coordMap.getAlnToRefMap();
   const auto expected = std::vector<int>{0, 0, 0, 1, 2, 3, 3, 3, 3, 4, 5, 6, 7, 7, 7, 7, 8};
   EXPECT_THAT(actual, testing::ElementsAreArray(expected));
+}
+
+
+TEST(mapCoordinates, MapsRangeRefToAlnSimple) {
+  const auto ref = toNucleotideSequence("ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const Range actual = coordMap.refToAln({.begin = 3, .end = 6});
+  const Range expected{.begin = 3, .end = 9};
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(mapCoordinates, MapsRangeAlnToRefSimple) {
+  const auto ref = toNucleotideSequence("ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const Range actual = coordMap.alnToRef({.begin = 3, .end = 9});
+  const Range expected{.begin = 3, .end = 6};
+  EXPECT_EQ(actual, expected);
+}
+
+
+TEST(mapCoordinates, MapsRangeRefToAlnWithLeadingInsertions) {
+  const auto ref = toNucleotideSequence("--ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const Range actual = coordMap.refToAln({.begin = 3, .end = 6});
+  const Range expected{.begin = 5, .end = 11};
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(mapCoordinates, MapsRangeAlnToRefWithLeadingInsertions) {
+  const auto ref = toNucleotideSequence("--ACTC---CGTG---A");
+  CoordinateMapperExposed coordMap(ref);
+  const Range actual = coordMap.alnToRef({.begin = 5, .end = 11});
+  const Range expected{.begin = 3, .end = 6};
+  EXPECT_EQ(actual, expected);
 }

--- a/packages/nextalign/tests/range.test.cpp
+++ b/packages/nextalign/tests/range.test.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+#include <nextalign/nextalign.h>
+#include <nextalign/private/nextalign_private.h>
+
+
+TEST(Range, Constructs) {
+  Range range{.begin = 3, .end = 5};
+  EXPECT_EQ(range.begin, 3);
+  EXPECT_EQ(range.end, 5);
+}
+
+TEST(Range, EqualsTrue) {
+  Range range1{.begin = 3, .end = 5};
+  Range range2{.begin = 3, .end = 5};
+  EXPECT_TRUE(range1 == range2);
+  EXPECT_TRUE(range2 == range1);
+}
+
+TEST(Range, EqualsFalse) {
+  Range range1{.begin = 3, .end = 5};
+  Range range2{.begin = 7, .end = 8};
+  EXPECT_FALSE(range1 == range2);
+  EXPECT_FALSE(range2 == range1);
+}
+
+TEST(Range, NotEqualsTrue) {
+  Range range1{.begin = 3, .end = 5};
+  Range range2{.begin = 7, .end = 8};
+  EXPECT_TRUE(range1 != range2);
+  EXPECT_TRUE(range2 != range1);
+}
+
+TEST(Range, NotEqualsFalse) {
+  Range range1{.begin = 3, .end = 5};
+  Range range2{.begin = 3, .end = 5};
+  EXPECT_FALSE(range1 != range2);
+  EXPECT_FALSE(range2 != range1);
+}
+
+TEST(Range, AddScalar) {
+  Range range1{.begin = 3, .end = 5};
+  Range expected{.begin = 6, .end = 8};
+  EXPECT_EQ(range1 + 3, expected);
+}
+
+TEST(Range, SubScalar) {
+  Range range1{.begin = 3, .end = 5};
+  Range expected{.begin = 0, .end = 2};
+  EXPECT_EQ(range1 - 3, expected);
+}
+
+TEST(Range, MulByScalar) {
+  Range range1{.begin = 3, .end = 5};
+  Range expected{.begin = 9, .end = 15};
+  EXPECT_EQ(range1 * 3, expected);
+}
+
+TEST(Range, DivByScalar) {
+  Range range1{.begin = 9, .end = 21};
+  Range expected{.begin = 3, .end = 7};
+  EXPECT_EQ(range1 / 3, expected);
+}
+
+TEST(Range, DivByScalarUneven) {
+  Range range1{.begin = 9, .end = 21};
+  Range expected{.begin = 4, .end = 10};
+  EXPECT_EQ(range1 / 2, expected);
+}

--- a/packages/nextalign/tests/translateGenes.test.cpp
+++ b/packages/nextalign/tests/translateGenes.test.cpp
@@ -80,7 +80,7 @@ TEST_F(TranslateGenes, DetectsTrailingFrameShift) {
   const auto peptides = translateGenes(qryAln, refAln, geneMap, gapOpenCloseAA, options);
 
   const auto peptideActual = peptides.queryPeptides[0].seq;
-  const auto peptideExpected = toAminoacidSequence("SKXXXXX");
+  const auto peptideExpected = toAminoacidSequence("SK-XXXX");
   EXPECT_EQ(peptideActual, peptideExpected);
 
   const auto frameShiftResult = peptides.queryPeptides[0].frameShiftResults[0];
@@ -115,7 +115,7 @@ TEST_F(TranslateGenes, DetectsTrailingFrameShiftWithPriorInsertion) {
   const auto peptides = translateGenes(qryAln, refAln, geneMap, gapOpenCloseAA, options);
 
   const auto peptideActual = peptides.queryPeptides[0].seq;
-  const auto peptideExpected = toAminoacidSequence("SKXXXXX");
+  const auto peptideExpected = toAminoacidSequence("SK-XXXX");
   EXPECT_EQ(peptideActual, peptideExpected);
 
   const auto frameShiftResult = peptides.queryPeptides[0].frameShiftResults[0];
@@ -150,7 +150,7 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShift) {
   const auto peptides = translateGenes(qryAln, refAln, geneMap, gapOpenCloseAA, options);
 
   const auto peptideActual = peptides.queryPeptides[0].seq;
-  const auto peptideExpected = toAminoacidSequence("-SXXXI*");
+  const auto peptideExpected = toAminoacidSequence("-XXX-I*");
   EXPECT_EQ(peptideActual, peptideExpected);
 
   const auto frameShiftResult = peptides.queryPeptides[0].frameShiftResults[0];
@@ -185,7 +185,7 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShiftWithPriorInsertion) {
   const auto peptides = translateGenes(qryAln, refAln, geneMap, gapOpenCloseAA, options);
 
   const auto peptideActual = peptides.queryPeptides[0].seq;
-  const auto peptideExpected = toAminoacidSequence("-SXXXI*");
+  const auto peptideExpected = toAminoacidSequence("-XXX-I*");
   EXPECT_EQ(peptideActual, peptideExpected);
 
   const auto frameShiftResult = peptides.queryPeptides[0].frameShiftResults[0];
@@ -225,7 +225,7 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShiftWithInsertion) {
   const auto peptides = translateGenes(qryAln, refAln, geneMap, gapOpenCloseAA, options);
 
   const auto peptideActual = peptides.queryPeptides[0].seq;
-  const auto peptideExpected = toAminoacidSequence("-SXXXI*");
+  const auto peptideExpected = toAminoacidSequence("--XX-I*");
   EXPECT_EQ(peptideActual, peptideExpected);
 
   const auto frameShiftResult = peptides.queryPeptides[0].frameShiftResults[0];

--- a/packages/nextalign/tests/translateGenes.test.cpp
+++ b/packages/nextalign/tests/translateGenes.test.cpp
@@ -90,7 +90,7 @@ TEST_F(TranslateGenes, DetectsTrailingFrameShift) {
     .nucAbs = {.begin = 19, .end = 30},
     .codon = {.begin = 3, .end = 7},
     .gapsLeading = {.codon = {.begin = 2, .end = 3}},
-    .gapsTraling = {.codon = {.begin = 7, .end = 7}},
+    .gapsTrailing = {.codon = {.begin = 7, .end = 7}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -125,7 +125,7 @@ TEST_F(TranslateGenes, DetectsTrailingFrameShiftWithPriorInsertion) {
     .nucAbs = {.begin = 19, .end = 30},
     .codon = {.begin = 3, .end = 7},
     .gapsLeading = {.codon = {.begin = 2, .end = 3}},
-    .gapsTraling = {.codon = {.begin = 7, .end = 7}},
+    .gapsTrailing = {.codon = {.begin = 7, .end = 7}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -160,7 +160,7 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShift) {
     .nucAbs = {.begin = 14, .end = 22},
     .codon = {.begin = 1, .end = 4},
     .gapsLeading = {.codon = {.begin = 1, .end = 1}},
-    .gapsTraling = {.codon = {.begin = 4, .end = 5}},
+    .gapsTrailing = {.codon = {.begin = 4, .end = 5}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -195,7 +195,7 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShiftWithPriorInsertion) {
     .nucAbs = {.begin = 14, .end = 22},
     .codon = {.begin = 1, .end = 4},
     .gapsLeading = {.codon = {.begin = 1, .end = 1}},
-    .gapsTraling = {.codon = {.begin = 4, .end = 5}},
+    .gapsTrailing = {.codon = {.begin = 4, .end = 5}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -235,7 +235,7 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShiftWithInsertion) {
     .nucAbs = {.begin = 15, .end = 22},
     .codon = {.begin = 2, .end = 4},
     .gapsLeading = {.codon = {.begin = 1, .end = 2}},
-    .gapsTraling = {.codon = {.begin = 4, .end = 5}},
+    .gapsTrailing = {.codon = {.begin = 4, .end = 5}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }

--- a/packages/nextalign/tests/translateGenes.test.cpp
+++ b/packages/nextalign/tests/translateGenes.test.cpp
@@ -89,6 +89,8 @@ TEST_F(TranslateGenes, DetectsTrailingFrameShift) {
     .nucRel = {.begin = 10, .end = 21},
     .nucAbs = {.begin = 19, .end = 30},
     .codon = {.begin = 3, .end = 7},
+    .gapsLeading = {.codon = {.begin = 2, .end = 3}},
+    .gapsTraling = {.codon = {.begin = 7, .end = 7}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -122,6 +124,8 @@ TEST_F(TranslateGenes, DetectsTrailingFrameShiftWithPriorInsertion) {
     .nucRel = {.begin = 10, .end = 21},
     .nucAbs = {.begin = 19, .end = 30},
     .codon = {.begin = 3, .end = 7},
+    .gapsLeading = {.codon = {.begin = 2, .end = 3}},
+    .gapsTraling = {.codon = {.begin = 7, .end = 7}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -155,6 +159,8 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShift) {
     .nucRel = {.begin = 5, .end = 13},
     .nucAbs = {.begin = 14, .end = 22},
     .codon = {.begin = 1, .end = 4},
+    .gapsLeading = {.codon = {.begin = 1, .end = 1}},
+    .gapsTraling = {.codon = {.begin = 4, .end = 5}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -188,6 +194,8 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShiftWithPriorInsertion) {
     .nucRel = {.begin = 5, .end = 13},
     .nucAbs = {.begin = 14, .end = 22},
     .codon = {.begin = 1, .end = 4},
+    .gapsLeading = {.codon = {.begin = 1, .end = 1}},
+    .gapsTraling = {.codon = {.begin = 4, .end = 5}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }
@@ -226,6 +234,8 @@ TEST_F(TranslateGenes, DetectsCompensatedFrameShiftWithInsertion) {
     .nucRel = {.begin = 6, .end = 14},
     .nucAbs = {.begin = 15, .end = 22},
     .codon = {.begin = 2, .end = 4},
+    .gapsLeading = {.codon = {.begin = 1, .end = 2}},
+    .gapsTraling = {.codon = {.begin = 4, .end = 5}},
   };
   EXPECT_EQ(frameShiftResult, frameShiftExpected);
 }

--- a/packages/nextclade/src/io/parseAnalysisResults.cpp
+++ b/packages/nextclade/src/io/parseAnalysisResults.cpp
@@ -125,12 +125,20 @@ namespace Nextclade {
     };
   }
 
+  FrameShiftContext parseFrameShiftContext(const json& j) {
+    return FrameShiftContext{
+      .codon = parseFrameShiftRange(at(j, "codon")),
+    };
+  }
+
   FrameShiftResult parseFrameShiftResult(const json& j) {
     return FrameShiftResult{
       .geneName = at(j, "geneName").get<std::string>(),
       .nucRel = parseFrameShiftRange(at(j, "nucRel")),
       .nucAbs = parseFrameShiftRange(at(j, "nucAbs")),
       .codon = parseFrameShiftRange(at(j, "codon")),
+      .gapsLeading = parseFrameShiftContext(at(j, "gapsLeading")),
+      .gapsTraling = parseFrameShiftContext(at(j, "gapsTraling")),
     };
   }
 

--- a/packages/nextclade/src/io/parseAnalysisResults.cpp
+++ b/packages/nextclade/src/io/parseAnalysisResults.cpp
@@ -138,7 +138,7 @@ namespace Nextclade {
       .nucAbs = parseFrameShiftRange(at(j, "nucAbs")),
       .codon = parseFrameShiftRange(at(j, "codon")),
       .gapsLeading = parseFrameShiftContext(at(j, "gapsLeading")),
-      .gapsTraling = parseFrameShiftContext(at(j, "gapsTraling")),
+      .gapsTrailing = parseFrameShiftContext(at(j, "gapsTrailing")),
     };
   }
 

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -117,12 +117,20 @@ namespace Nextclade {
       return j;
     }
 
+    json serializeFrameShiftContext(const FrameShiftContext& fsc) {
+      auto j = json::object();
+      j.emplace("codon", serializeFrameShiftRange(fsc.codon));
+      return j;
+    }
+
     json serializeFrameShiftResult(const FrameShiftResult& fs) {
       auto j = json::object();
       j.emplace("geneName", fs.geneName);
       j.emplace("nucRel", serializeFrameShiftRange(fs.nucRel));
       j.emplace("nucAbs", serializeFrameShiftRange(fs.nucAbs));
       j.emplace("codon", serializeFrameShiftRange(fs.codon));
+      j.emplace("gapsLeading", serializeFrameShiftContext(fs.gapsLeading));
+      j.emplace("gapsTraling", serializeFrameShiftContext(fs.gapsTraling));
       return j;
     }
 

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -130,7 +130,7 @@ namespace Nextclade {
       j.emplace("nucAbs", serializeFrameShiftRange(fs.nucAbs));
       j.emplace("codon", serializeFrameShiftRange(fs.codon));
       j.emplace("gapsLeading", serializeFrameShiftContext(fs.gapsLeading));
-      j.emplace("gapsTraling", serializeFrameShiftContext(fs.gapsTraling));
+      j.emplace("gapsTrailing", serializeFrameShiftContext(fs.gapsTrailing));
       return j;
     }
 

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -205,7 +205,7 @@ export interface FrameShift {
   nucAbs: Range
   codon: Range
   gapsLeading: FrameShiftContext
-  gapsTraling: FrameShiftContext
+  gapsTrailing: FrameShiftContext
 }
 
 export interface QcResultFrameShifts {

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -195,11 +195,17 @@ export interface QcResultPrivateMutations {
   cutoff: number
 }
 
+export interface FrameShiftContext {
+  codon: Range
+}
+
 export interface FrameShift {
   geneName: string
   nucRel: Range
   nucAbs: Range
   codon: Range
+  gapsLeading: FrameShiftContext
+  gapsTraling: FrameShiftContext
 }
 
 export interface QcResultFrameShifts {

--- a/packages/web/src/components/Common/TableSlim.tsx
+++ b/packages/web/src/components/Common/TableSlim.tsx
@@ -1,3 +1,5 @@
+import React, { HTMLProps } from 'react'
+
 import { Table as ReactstrapTable } from 'reactstrap'
 import styled from 'styled-components'
 
@@ -26,3 +28,16 @@ export const TableSlimWithBorders = styled(TableSlim)`
     border: 1px solid #ccc;
   }
 `
+
+export const TableColumnSpacer = styled.td`
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+`
+
+export function TableRowSpacer(props: HTMLProps<HTMLTableRowElement>) {
+  return (
+    <tr {...props}>
+      <TableColumnSpacer className="table-td-spacer" />
+    </tr>
+  )
+}

--- a/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
@@ -10,8 +10,8 @@ import type { State } from 'src/state/reducer'
 import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 
 import { Tooltip } from 'src/components/Results/Tooltip'
-import { TableSlim } from 'src/components/Common/TableSlim'
-import { formatRange } from 'src/helpers/formatRange'
+import { TableRowSpacer, TableSlim } from 'src/components/Common/TableSlim'
+import { formatRange, formatRangeMaybeEmpty } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 
 const frameShiftColor = '#eb0d2a'
@@ -49,7 +49,7 @@ function PeptideMarkerFrameShiftDisconnected({
     return null
   }
 
-  const { geneName, nucAbs, codon } = frameShift
+  const { geneName, nucAbs, codon, gapsLeading, gapsTraling } = frameShift
   const id = getSafeId('frame-shift-aa-marker', { seqName, ...frameShift })
 
   const gene = geneMap.find((gene) => geneName === gene.geneName)
@@ -118,6 +118,18 @@ function PeptideMarkerFrameShiftDisconnected({
               <tr>
                 <td>{t('Codon length')}</td>
                 <td>{codonLength}</td>
+              </tr>
+
+              <TableRowSpacer />
+
+              <tr>
+                <td>{t('Leading gaps codon range')}</td>
+                <td>{formatRangeMaybeEmpty(gapsLeading.codon.begin, gapsLeading.codon.end)}</td>
+              </tr>
+
+              <tr>
+                <td>{t('Trailing gaps codon range')}</td>
+                <td>{formatRangeMaybeEmpty(gapsTraling.codon.begin, gapsTraling.codon.end)}</td>
               </tr>
             </tbody>
           </TableSlim>

--- a/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
@@ -123,12 +123,12 @@ function PeptideMarkerFrameShiftDisconnected({
               <TableRowSpacer />
 
               <tr>
-                <td>{t('Leading gaps codon range')}</td>
+                <td>{t('Leading deleted codon range')}</td>
                 <td>{formatRangeMaybeEmpty(gapsLeading.codon.begin, gapsLeading.codon.end)}</td>
               </tr>
 
               <tr>
-                <td>{t('Trailing gaps codon range')}</td>
+                <td>{t('Trailing deleted codon range')}</td>
                 <td>{formatRangeMaybeEmpty(gapsTrailing.codon.begin, gapsTrailing.codon.end)}</td>
               </tr>
             </tbody>

--- a/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
@@ -49,7 +49,7 @@ function PeptideMarkerFrameShiftDisconnected({
     return null
   }
 
-  const { geneName, nucAbs, codon, gapsLeading, gapsTraling } = frameShift
+  const { geneName, nucAbs, codon, gapsLeading, gapsTrailing } = frameShift
   const id = getSafeId('frame-shift-aa-marker', { seqName, ...frameShift })
 
   const gene = geneMap.find((gene) => geneName === gene.geneName)
@@ -129,7 +129,7 @@ function PeptideMarkerFrameShiftDisconnected({
 
               <tr>
                 <td>{t('Trailing gaps codon range')}</td>
-                <td>{formatRangeMaybeEmpty(gapsTraling.codon.begin, gapsTraling.codon.end)}</td>
+                <td>{formatRangeMaybeEmpty(gapsTrailing.codon.begin, gapsTrailing.codon.end)}</td>
               </tr>
             </tbody>
           </TableSlim>

--- a/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -49,7 +49,7 @@ function SequenceMarkerFrameShiftDisconnected({
     return null
   }
 
-  const { geneName, nucAbs, codon, gapsTraling, gapsLeading } = frameShift
+  const { geneName, nucAbs, codon, gapsTrailing, gapsLeading } = frameShift
   const id = getSafeId('frame-shift-nuc-marker', { seqName, ...frameShift })
 
   const gene = geneMap.find((gene) => geneName === gene.geneName)
@@ -129,7 +129,7 @@ function SequenceMarkerFrameShiftDisconnected({
 
               <tr>
                 <td>{t('Trailing gaps codon range')}</td>
-                <td>{formatRangeMaybeEmpty(gapsTraling.codon.begin, gapsTraling.codon.end)}</td>
+                <td>{formatRangeMaybeEmpty(gapsTrailing.codon.begin, gapsTrailing.codon.end)}</td>
               </tr>
             </tbody>
           </TableSlim>

--- a/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -10,8 +10,8 @@ import type { State } from 'src/state/reducer'
 import { selectGeneMap } from 'src/state/algorithm/algorithm.selectors'
 
 import { Tooltip } from 'src/components/Results/Tooltip'
-import { TableSlim } from 'src/components/Common/TableSlim'
-import { formatRange } from 'src/helpers/formatRange'
+import { TableRowSpacer, TableSlim } from 'src/components/Common/TableSlim'
+import { formatRange, formatRangeMaybeEmpty } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 
 const frameShiftColor = '#eb0d2a'
@@ -49,7 +49,7 @@ function SequenceMarkerFrameShiftDisconnected({
     return null
   }
 
-  const { geneName, nucAbs, codon } = frameShift
+  const { geneName, nucAbs, codon, gapsTraling, gapsLeading } = frameShift
   const id = getSafeId('frame-shift-nuc-marker', { seqName, ...frameShift })
 
   const gene = geneMap.find((gene) => geneName === gene.geneName)
@@ -115,9 +115,21 @@ function SequenceMarkerFrameShiftDisconnected({
                 <td>{codonRangeStr}</td>
               </tr>
 
-              <tr>
+              <tr className="pb-3">
                 <td>{t('Codon length')}</td>
                 <td>{codonLength}</td>
+              </tr>
+
+              <TableRowSpacer />
+
+              <tr>
+                <td>{t('Leading gaps codon range')}</td>
+                <td>{formatRangeMaybeEmpty(gapsLeading.codon.begin, gapsLeading.codon.end)}</td>
+              </tr>
+
+              <tr>
+                <td>{t('Trailing gaps codon range')}</td>
+                <td>{formatRangeMaybeEmpty(gapsTraling.codon.begin, gapsTraling.codon.end)}</td>
               </tr>
             </tbody>
           </TableSlim>

--- a/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -123,12 +123,12 @@ function SequenceMarkerFrameShiftDisconnected({
               <TableRowSpacer />
 
               <tr>
-                <td>{t('Leading gaps codon range')}</td>
+                <td>{t('Leading deleted codon range')}</td>
                 <td>{formatRangeMaybeEmpty(gapsLeading.codon.begin, gapsLeading.codon.end)}</td>
               </tr>
 
               <tr>
-                <td>{t('Trailing gaps codon range')}</td>
+                <td>{t('Trailing deleted codon range')}</td>
                 <td>{formatRangeMaybeEmpty(gapsTrailing.codon.begin, gapsTrailing.codon.end)}</td>
               </tr>
             </tbody>

--- a/packages/web/src/helpers/formatRange.ts
+++ b/packages/web/src/helpers/formatRange.ts
@@ -15,3 +15,11 @@ export function formatRange(begin: number, end: number) {
   }
   return `${beginOne}-${endOne}`
 }
+
+export function formatRangeMaybeEmpty(begin: number, end: number) {
+  if (begin >= end) {
+    return '-'
+  }
+
+  return formatRange(begin, end)
+}


### PR DESCRIPTION
In this PR for every frame shift we find:
 - (A) position of the beginning of the immediately preceding adjacent nuc deletion 
 - (B) position of the end of the immediately following adjacent nuc deletion 

We extend codon masking of the aligned peptide to cover the range A to B, which might be wider than the range of the frame shift.

We also obtain the 2 ranges:
 - leading: from (A) to frame shift begin
 - trailing: from frame shift end to (B)

(in codon coordinates)

These ranges are now being written into results JSON and displayed in the Web UI:

![01](https://user-images.githubusercontent.com/9403403/134722364-3058983d-daa8-4246-ba64-477732a2f388.png)

![02](https://user-images.githubusercontent.com/9403403/134722371-be5782fa-affc-4fbf-a51d-9100e9b6c9c3.png)



