### PR TITLE
chore: add JOSS badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ by Nextstrain team
 
   <a href="https://joss.theoj.org/papers/b0e8e7f231ddfc61616de6b56f32b79f">
     <img 
-      src="https://joss.theoj.org/papers/b0e8e7f231ddfc61616de6b56f32b79f/status.svg">
+      src="https://joss.theoj.org/papers/b0e8e7f231ddfc61616de6b56f32b79f/status.svg"
       alt="JOSS submission status"
+    />
   </a>
 
 </p>

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ by Nextstrain team
 
 </p>
 
+<p align="center">
+
+  <a href="https://joss.theoj.org/papers/b0e8e7f231ddfc61616de6b56f32b79f">
+    <img 
+      src="https://joss.theoj.org/papers/b0e8e7f231ddfc61616de6b56f32b79f/status.svg">
+      alt="JOSS submission status"
+  </a>
+
+</p>
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Adds JOSS badge to README

Looks like this:
![image](https://user-images.githubusercontent.com/25161793/135143098-466cc167-47f1-40b9-b132-e55e3b22e378.png)
