### PR TITLE
fix: avoid race between data fetch and read when url params are used

### DIFF
--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -372,3 +372,11 @@ export interface DatasetsIndexJson {
 }
 
 export interface DatasetFlat extends Dataset, DatasetRef, DatasetVersion {}
+
+export interface UrlParams {
+  inputRootSeq?: string
+  inputTree?: string
+  inputPcrPrimers?: string
+  inputQcConfig?: string
+  inputGeneMap?: string
+}

--- a/packages/web/src/io/fetchInputsAndRunMaybe.ts
+++ b/packages/web/src/io/fetchInputsAndRunMaybe.ts
@@ -3,17 +3,9 @@ import type { ParsedUrlQuery } from 'querystring'
 
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
 import { AlgorithmInputString } from 'src/io/AlgorithmInput'
-import { axiosFetchRawMaybe } from 'src/io/axiosFetch'
+import { axiosFetchRaw } from 'src/io/axiosFetch'
 import { errorAdd } from 'src/state/error/error.actions'
-import {
-  algorithmRunAsync,
-  setGeneMap,
-  setIsDirty,
-  setPcrPrimers,
-  setQcSettings,
-  setRootSeq,
-  setTree,
-} from 'src/state/algorithm/algorithm.actions'
+import { algorithmRunAsync, setInputUrlParams, setIsDirty } from 'src/state/algorithm/algorithm.actions'
 
 export function getQueryParam(urlQuery: ParsedUrlQuery, param: string): string | undefined {
   return takeFirstMaybe(urlQuery?.[param]) ?? undefined
@@ -27,62 +19,30 @@ export async function fetchInputsAndRunMaybe(dispatch: Dispatch, urlQuery: Parse
   const inputQcConfigUrl = getQueryParam(urlQuery, 'input-qc-config')
   const inputGeneMapUrl = getQueryParam(urlQuery, 'input-gene-map')
 
-  let inputFasta: string | undefined
-  let inputRootSeq: string | undefined
-  let inputTree: string | undefined
-  let inputPcrPrimers: string | undefined
-  let inputQcConfig: string | undefined
-  let inputGeneMap: string | undefined
+  dispatch(
+    setInputUrlParams({
+      inputRootSeq: inputRootSeqUrl,
+      inputTree: inputTreeUrl,
+      inputPcrPrimers: inputPcrPrimersUrl,
+      inputQcConfig: inputQcConfigUrl,
+      inputGeneMap: inputGeneMapUrl,
+    }),
+  )
 
-  let hasError = false
-
-  try {
-    ;[inputFasta, inputRootSeq, inputTree, inputPcrPrimers, inputQcConfig, inputGeneMap] = await Promise.all([
-      axiosFetchRawMaybe(inputFastaUrl),
-      axiosFetchRawMaybe(inputRootSeqUrl),
-      axiosFetchRawMaybe(inputTreeUrl),
-      axiosFetchRawMaybe(inputPcrPrimersUrl),
-      axiosFetchRawMaybe(inputQcConfigUrl),
-      axiosFetchRawMaybe(inputGeneMapUrl),
-    ])
-  } catch (error) {
-    console.error(error)
-    if (error instanceof Error) {
-      dispatch(errorAdd({ error }))
-    } else {
-      dispatch(errorAdd({ error: new Error('Unknown error') }))
+  if (inputFastaUrl) {
+    try {
+      const inputFasta = await axiosFetchRaw(inputFastaUrl)
+      dispatch(setIsDirty(true))
+      dispatch(algorithmRunAsync.trigger(new AlgorithmInputString(inputFasta, inputFastaUrl)))
+    } catch (error) {
+      console.error(error)
+      if (error instanceof Error) {
+        dispatch(errorAdd({ error }))
+      } else {
+        dispatch(errorAdd({ error: new Error('Unknown error') }))
+      }
+      return false
     }
-    hasError = true
-  }
-
-  if (hasError) {
-    return false
-  }
-
-  // TODO: we could use AlgorithmInputUrl instead. User experience should be improved: e.g. show progress indicator
-  if (inputRootSeq) {
-    dispatch(setRootSeq.trigger(new AlgorithmInputString(inputRootSeq, inputRootSeqUrl)))
-  }
-
-  if (inputTree) {
-    dispatch(setTree.trigger(new AlgorithmInputString(inputTree, inputTreeUrl)))
-  }
-
-  if (inputPcrPrimers) {
-    dispatch(setPcrPrimers.trigger(new AlgorithmInputString(inputPcrPrimers, inputPcrPrimersUrl)))
-  }
-
-  if (inputQcConfig) {
-    dispatch(setQcSettings.trigger(new AlgorithmInputString(inputQcConfig, inputQcConfigUrl)))
-  }
-
-  if (inputGeneMap) {
-    dispatch(setGeneMap.trigger(new AlgorithmInputString(inputGeneMap, inputGeneMapUrl)))
-  }
-
-  if (inputFasta) {
-    dispatch(setIsDirty(true))
-    dispatch(algorithmRunAsync.trigger(new AlgorithmInputString(inputFasta, inputFastaUrl)))
   }
 
   return true

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -1,3 +1,4 @@
+import { UrlParams } from 'src/algorithms/types'
 import type { DatasetFlat, Gene } from 'src/algorithms/types'
 import type { Sorting } from 'src/helpers/sortResults'
 import { actionCreatorFactory } from 'src/state/util/fsaActions'
@@ -18,6 +19,7 @@ export const setDatasets = action<{
 }>('setDatasets')
 
 export const setCurrentDataset = action<DatasetFlat | undefined>('setCurrentDataset')
+export const setInputUrlParams = action<UrlParams>('setInputUrlParams')
 
 export const setFasta = action.async<AlgorithmInput, { queryStr: string; queryName: string }, Error>('setFasta')
 export const setTree = action.async<AlgorithmInput, { treeStr: string }, Error>('setTree')

--- a/packages/web/src/state/algorithm/algorithm.reducer.ts
+++ b/packages/web/src/state/algorithm/algorithm.reducer.ts
@@ -38,6 +38,7 @@ import {
   setGenomeSize,
   setCurrentDataset,
   setDatasets,
+  setInputUrlParams,
 } from './algorithm.actions'
 import { algorithmDefaultState, AlgorithmGlobalStatus, AlgorithmSequenceStatus } from './algorithm.state'
 
@@ -50,6 +51,10 @@ export const algorithmReducer = reducerWithInitialState(algorithmDefaultState)
 
   .icase(setCurrentDataset, (draft, dataset) => {
     draft.params.datasetCurrent = dataset
+  })
+
+  .icase(setInputUrlParams, (draft, urlParams) => {
+    draft.params.urlParams = urlParams
   })
 
   .icase(setGenomeSize, (draft, { genomeSize }) => {

--- a/packages/web/src/state/algorithm/algorithm.selectors.ts
+++ b/packages/web/src/state/algorithm/algorithm.selectors.ts
@@ -58,6 +58,8 @@ export const selectQcConfigStr = (state: State) => state.algorithm.params.string
 export const selectGeneMap = (state: State) => state.algorithm.params.final?.geneMap
 export const selectGenomeSize = (state: State) => state.algorithm.params.final?.genomeSize
 
+export const selectUrlParams = (state: State) => state.algorithm.params.urlParams
+
 export function selectStatus(state: State) {
   const numThreads = selectNumThreads(state)
   const statusGlobal = state.algorithm.status

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -1,4 +1,4 @@
-import type { AnalysisResult, Gene, Peptide, Warnings, DatasetFlat } from 'src/algorithms/types'
+import type { AnalysisResult, Gene, Peptide, Warnings, DatasetFlat, UrlParams } from 'src/algorithms/types'
 import type { Sorting } from 'src/helpers/sortResults'
 import type { QCFilters } from 'src/filtering/filterByQCIssues'
 
@@ -71,6 +71,7 @@ export interface AlgorithmParams {
   defaultDatasetName?: string
   defaultDatasetNameFriendly?: string
   datasetCurrent?: DatasetFlat
+  urlParams: UrlParams
   raw: {
     seqData?: AlgorithmInput
     auspiceData?: AlgorithmInput
@@ -140,6 +141,7 @@ export const algorithmDefaultState: AlgorithmState = {
     datasets: [],
     defaultDatasetName: undefined,
     datasetCurrent: undefined,
+    urlParams: {},
     raw: {},
     strings: {},
     final: {},


### PR DESCRIPTION
When datasets feature was added, a data race was introduced due to lack of synchronization between asynchronous data fetching from locations provided by URL params and reading this data before launching the algorithm.

The order of operations was as follows:
1. Retrieve URLs from URL params
2. Start fetching from these urls (asynchronously)
3. Save fetched data in redux store upon arrival
4. Read data from redux store. If it's empty, load default data from a dataset.
5. Do some other, unrelated operations.
6. Launch the algorithm.

However, step 4 was not waiting until step 3 is completed. So it could happen that the data read would yield and empty result, because fetching was still in progress. When that happened, algorithm would start with the default data, even though URL params are provided. This is a data race: the writes after data is fetched were competing with reads before the algorithm launch.

In dev mode, with the data coming from a local server, all was working as intended, because data fetches were fast and completed before the algorithm starts. However when data is served from a slower external location that was no longer the case.

In order to avoid the race, this PR changes the order of operations, and merges data fetch and data read, so that they are an atomic operation, and there is not reliance on reading asynchronously fetched data from redux store:
1. Retrieve URLs from URL params
2. Save URLs in redux store (synchronously)
3. Fetch the data from these URLs. If it's empty, fetch default data from the dataset.
4. Do some other, unrelated operations.
5. Launch the algorithm.

This avoids the race condition and ensures that the data is fetched before it's used.
