### PR TITLE
refractor: cleanup

### DIFF
--- a/packages/nextalign/src/translate/mapCoordinates.cpp
+++ b/packages/nextalign/src/translate/mapCoordinates.cpp
@@ -10,14 +10,6 @@
 
 
 namespace {
-
-  /*****************************************************************************
-   *
-   *                 OLD IMPLEMENTATIONS
-   *
-   ****************************************************************************/
-
-
   /**
  * Makes the "alingnment to reference" coordinate map: from alignment coordinates to reference coordinates.
  *
@@ -71,71 +63,12 @@ namespace {
     coordMap.shrink_to_fit();
     return coordMap;
   }
-
-
-  /*****************************************************************************
-   *
-   *                 NEW IMPLEMENTATIONS
-   *
-   ****************************************************************************/
-
-
-  /**
- * Makes the "alingnment to reference" coordinate map: from alignment coordinates to reference coordinates.
- *
- * Given a position of a letter in the aligned sequence, the "alingnment to reference" coordinate map allows to
- * lookup the position of the corresponding letter in the reference sequence.
- *
- * @param refAln  Aligned reference sequence
- * @return        Coordinate map from alignment coordinates to reference coordinates
- */
-  std::vector<int> makeAlnToRefMap(const NucleotideSequence& refAln) {
-    int alnLength = safe_cast<int>(refAln.size());
-    std::vector<int> alnToRefMap(alnLength);// TODO: Slow
-    int refPos = -1;
-    for (int alnPos = 0; alnPos < alnLength; ++alnPos) {
-      if (refAln[alnPos] != Nucleotide::GAP) {
-        refPos += 1;
-      }
-      alnToRefMap[alnPos] = refPos;
-    }
-    return alnToRefMap;
-  }
-
-  /**
- * Makes the "reference to alingnment" coordinate map: from alignment coordinates to reference coordinates.
- *
- * Given a position of a letter in the reference sequence, the "reference to alingnment" coordinate map allows to
- * lookup the position of the corresponding letter in the aligned sequence.
- *
- * @param refAln  Aligned reference sequence
- * @return        Coordinate map from alignment coordinates to reference coordinates
- */
-  std::vector<int> makeRefToAlnMap(const NucleotideSequence& refAln, const std::vector<int>& alnToRef) {
-    int refLength = safe_cast<int>(alnToRef.size());
-    std::vector<int> refToAlnMap(refLength);// TODO: Slow
-    int refPos = -1;
-    for (int alnPos = 0; alnPos < refLength; ++alnPos) {
-      if (refAln[alnPos] != Nucleotide::GAP) {
-        refPos = alnToRef[alnPos];
-        refToAlnMap[refPos] = alnPos;
-      }
-    }
-    // truncate unused values in the tail
-    refToAlnMap.resize(refPos + 1);// TODO: slow
-    return refToAlnMap;
-  }
 }// namespace
 
 CoordinateMapper::CoordinateMapper(const NucleotideSequence& refAln)
     // old implementation
     : alnToRefMap(makeAlnToRefMapOld(refAln)),
       refToAlnMap(makeRefToAlnMapOld(refAln)) {}
-
-// new implementation
-//  : alnToRefMap(makeAlnToRefMap(refAln)),
-//    refToAlnMap(makeRefToAlnMap(refAln, alnToRefMap)) {}
-
 
 /**
  * Converts position from alignment coordinates to reference coordianates

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -527,7 +527,9 @@ GeneMap filterGeneMap(const std::set<std::string> &genes, const GeneMap &geneMap
 }
 
 std::string formatCliParams(const CliParams &cliParams) {
-  fmt::memory_buffer buf;
+  fmt::memory_buffer bufRaw;
+  auto buf = std::back_inserter(bufRaw);
+
   fmt::format_to(buf, "\nCLI Parameters:\n");
   fmt::format_to(buf, "{:>20s}=\"{:<d}\"\n", "--jobs", cliParams.jobs);
   fmt::format_to(buf, "{:>20s}=\"{:<s}\"\n", "--sequences", cliParams.sequences);
@@ -558,7 +560,7 @@ std::string formatCliParams(const CliParams &cliParams) {
     fmt::format_to(buf, "{:>20s}=\"{:<s}\"\n", "--output-errors", *cliParams.outputErrors);
   }
 
-  return fmt::to_string(buf);
+  return fmt::to_string(bufRaw);
 }
 
 Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
@@ -612,18 +614,21 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
 }
 
 std::string formatPaths(const Paths &paths) {
-  fmt::memory_buffer buf;
+  fmt::memory_buffer bufRaw;
+  auto buf = std::back_inserter(bufRaw);
+
   fmt::format_to(buf, "\nOutput files:\n");
   fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Aligned sequences", paths.outputFasta.string());
   fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Stripped insertions", paths.outputInsertions.string());
 
   for (const auto &[geneName, outputGenePath] : paths.outputGenes) {
-    fmt::memory_buffer bufGene;
+    fmt::memory_buffer bufRawGene;
+    auto bufGene = std::back_inserter(bufRawGene);
     fmt::format_to(bufGene, "{:s} {:>10s}", "Translated genes", geneName);
-    fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", fmt::to_string(bufGene), outputGenePath.string());
+    fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", fmt::to_string(bufRawGene), outputGenePath.string());
   }
 
-  return fmt::to_string(buf);
+  return fmt::to_string(bufRaw);
 }
 
 std::string formatRef(const ReferenceSequenceData &refData, bool shouldWriteReference) {
@@ -634,7 +639,9 @@ std::string formatRef(const ReferenceSequenceData &refData, bool shouldWriteRefe
 std::string formatGeneMap(const GeneMap &geneMap, const std::set<std::string> &genes) {
   constexpr const auto TABLE_WIDTH = 86;
 
-  fmt::memory_buffer buf;
+  fmt::memory_buffer bufRaw;
+  auto buf = std::back_inserter(bufRaw);
+
   fmt::format_to(buf, "\nGene map:\n");
   fmt::format_to(buf, "{:s}\n", std::string(TABLE_WIDTH, '-'));
   fmt::format_to(buf, "| {:8s} | {:16s} | {:8s} | {:8s} | {:8s} | {:8s} | {:8s} |\n", "Selected", "   Gene Name",
@@ -647,7 +654,8 @@ std::string formatGeneMap(const GeneMap &geneMap, const std::set<std::string> &g
       gene.start + 1, gene.end, gene.length, gene.frame + 1, gene.strand);
   }
   fmt::format_to(buf, "{:s}\n", std::string(TABLE_WIDTH, '-'));
-  return fmt::to_string(buf);
+
+  return fmt::to_string(bufRaw);
 }
 
 std::string formatInsertions(const std::vector<Insertion> &insertions) {

--- a/packages/nextclade/src/analyze/findNucChanges.cpp
+++ b/packages/nextclade/src/analyze/findNucChanges.cpp
@@ -45,6 +45,7 @@ namespace Nextclade {
           .qry = d,
           .pcrPrimersChanged = {},
           .aaSubstitutions = {},
+          .aaDeletions = {},
         });
       } else if (isGap(d) && !beforeAlignment) {
         if (!nDel) {

--- a/packages/nextclade/src/analyze/getAminoacidChanges.cpp
+++ b/packages/nextclade/src/analyze/getAminoacidChanges.cpp
@@ -96,6 +96,8 @@ namespace Nextclade {
           .refContext = std::move(refContext),
           .queryContext = std::move(queryContext),
           .contextNucRange = Range{.begin = contextBegin, .end = contextEnd},
+          .nucSubstitutions = {},
+          .nucDeletions = {},
         });
       } else {
         // TODO: we might account for ambiguous aminoacids in this condition
@@ -110,6 +112,8 @@ namespace Nextclade {
             .refContext = std::move(refContext),
             .queryContext = std::move(queryContext),
             .contextNucRange = Range{.begin = contextBegin, .end = contextEnd},
+            .nucSubstitutions = {},
+            .nucDeletions = {},
           });
         }
       }

--- a/packages/nextclade/src/io/CsvWriter.cpp
+++ b/packages/nextclade/src/io/CsvWriter.cpp
@@ -234,7 +234,6 @@ namespace Nextclade {
     }
 
     void addErrorRow(const std::string& seqName, const std::string& errorFormatted) override {
-      const auto& rowIndex = numRows;
       doc.SetCell(getColumnIndex("seqName"), numRows, seqName);
       doc.SetCell(getColumnIndex("errors"), numRows, errorFormatted);
       ++numRows;

--- a/packages/nextclade/src/io/parseAnalysisResults.cpp
+++ b/packages/nextclade/src/io/parseAnalysisResults.cpp
@@ -67,6 +67,8 @@ namespace Nextclade {
       .refContext = toNucleotideSequence(at(j, "refContext")),
       .queryContext = toNucleotideSequence(at(j, "queryContext")),
       .contextNucRange = parseRange(at(j, "contextNucRange")),
+      .nucSubstitutions = {},// FIXME: this field is not parsed. Looks like it was forgotten.
+      .nucDeletions = {},    // FIXME: this field is not parsed. Looks like it was forgotten.
     };
   }
 
@@ -79,6 +81,8 @@ namespace Nextclade {
       .refContext = toNucleotideSequence(at(j, "refContext")),
       .queryContext = toNucleotideSequence(at(j, "queryContext")),
       .contextNucRange = parseRange(at(j, "contextNucRange")),
+      .nucSubstitutions = {},// FIXME: this field is not parsed. Looks like it was forgotten.
+      .nucDeletions = {},    // FIXME: this field is not parsed. Looks like it was forgotten.
     };
   }
 

--- a/packages/nextclade_cli/src/io/format.h
+++ b/packages/nextclade_cli/src/io/format.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <fmt/format.h>
 #include <nextclade/nextclade.h>
 
+#include <iterator>
 #include <string>
 
 #include "getInputPaths.h"
@@ -11,7 +13,8 @@
 namespace Nextclade {
 
   inline std::string formatInputPaths(const InputPaths &paths) {
-    fmt::memory_buffer buf;
+    fmt::memory_buffer bufRaw;
+    auto buf = std::back_inserter(bufRaw);
     fmt::format_to(buf, "\nInput files:\n");
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Sequences (query)", paths.inputFasta);
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Root (reference) sequence", paths.inputRootSeq);
@@ -19,23 +22,25 @@ namespace Nextclade {
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Quality control configuration", paths.inputQcConfig);
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Gene map", paths.inputGeneMap.value_or("-"));
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "PCR primers", paths.inputPcrPrimers.value_or("-"));
-    return fmt::to_string(buf);
+    return fmt::to_string(bufRaw);
   }
 
   inline std::string formatOutputPaths(const OutputPaths &paths) {
-    fmt::memory_buffer buf;
+    fmt::memory_buffer bufRaw;
+    auto buf = std::back_inserter(bufRaw);
     fmt::format_to(buf, "\nOutput files:\n");
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Aligned sequences", paths.outputFasta.string());
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Stripped insertions", paths.outputInsertions.string());
     fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", "Errors and warnings", paths.outputErrors.string());
 
     for (const auto &[geneName, outputGenePath] : paths.outputGenes) {
-      fmt::memory_buffer bufGene;
+      fmt::memory_buffer bufRawGene;
+      auto bufGene = std::back_inserter(bufRawGene);
       fmt::format_to(bufGene, "{:s} {:>10s}", "Translated genes", geneName);
-      fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", fmt::to_string(bufGene), outputGenePath.string());
+      fmt::format_to(buf, "{:>30s}: \"{:<s}\"\n", fmt::to_string(bufRawGene), outputGenePath.string());
     }
 
-    return fmt::to_string(buf);
+    return fmt::to_string(bufRaw);
   }
 
   inline std::string formatRef(const ReferenceSequenceData &refData, bool shouldWriteReference) {
@@ -46,7 +51,8 @@ namespace Nextclade {
   inline std::string formatGeneMap(const GeneMap &geneMap, const std::set<std::string> &genes) {
     constexpr const auto TABLE_WIDTH = 86;
 
-    fmt::memory_buffer buf;
+    fmt::memory_buffer bufRaw;
+    auto buf = std::back_inserter(bufRaw);
     fmt::format_to(buf, "\nGene map:\n");
     fmt::format_to(buf, "{:s}\n", std::string(TABLE_WIDTH, '-'));
     fmt::format_to(buf, "| {:8s} | {:16s} | {:8s} | {:8s} | {:8s} | {:8s} | {:8s} |\n", "Selected", "   Gene Name",
@@ -59,7 +65,7 @@ namespace Nextclade {
         gene.start + 1, gene.end, gene.length, gene.frame + 1, gene.strand);
     }
     fmt::format_to(buf, "{:s}\n", std::string(TABLE_WIDTH, '-'));
-    return fmt::to_string(buf);
+    return fmt::to_string(bufRaw);
   }
 
 }// namespace Nextclade

--- a/packages/nextclade_cli/src/main.cpp
+++ b/packages/nextclade_cli/src/main.cpp
@@ -101,6 +101,8 @@ int main(int argc, char* argv[]) {
         .aaSeedSpacing = options.seedAa.seedSpacing,
         .aaMismatchesAllowed = options.seedAa.mismatchesAllowed,
 
+        .noTranslatePastStop = !options.translatePastStop,
+
         .verbosity = {},
         .verbose = {},
         .silent = {},

--- a/packages/nextclade_common/include/nextclade_common/datasets.h
+++ b/packages/nextclade_common/include/nextclade_common/datasets.h
@@ -51,7 +51,6 @@ namespace Nextclade {
     bool enabled;
     std::string name;
     std::string nameFriendly;
-    std::string description;
     std::vector<DatasetRef> datasetRefs;
     std::string defaultRef;
   };

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -359,7 +359,6 @@ export interface Dataset {
   enabled: boolean
   name: string
   nameFriendly: string
-  description: string
   datasetRefs: DatasetRef[]
   defaultRef: string
   defaultGene: string

--- a/packages/web/src/components/Data/DataPage.tsx
+++ b/packages/web/src/components/Data/DataPage.tsx
@@ -177,7 +177,6 @@ export function DatasetView({ dataset, isDefault }: DatasetViewProps) {
           {dataset.nameFriendly}
           {isDefault && <sup className="text-small ml-2">{t('(default)')}</sup>}
         </h3>
-        <p>{dataset.description}</p>
 
         {dataset.datasetRefs.map((ref) => (
           <DatasetRefView key={ref.reference.accession} datasetRef={ref} />


### PR DESCRIPTION
This PR aims to clean up the C++ parts of the codebase a little, but fixing compiler warnings and removing unused code. There should be no change of the behavior.