### PR TITLE
fix: segfault in coordinate mapper due to out-of-bounds array access

### DIFF
--- a/packages/nextalign/src/translate/mapCoordinates.cpp
+++ b/packages/nextalign/src/translate/mapCoordinates.cpp
@@ -27,8 +27,12 @@ namespace {
     int refPos = 0;
     for (int i = 0; i < alnLength; ++i) {
       if (ref[i] == Nucleotide::GAP) {
-        const auto& prev = revCoordMap.back();
-        revCoordMap.push_back(prev);
+        if (revCoordMap.empty()) {
+          revCoordMap.push_back(0);
+        } else {
+          const auto& prev = revCoordMap.back();
+          revCoordMap.push_back(prev);
+        }
       } else {
         revCoordMap.push_back(refPos);
         ++refPos;


### PR DESCRIPTION
This was manifesting as a crash in macOS. Like all memory bugs, it was hard to reproduce, but @corneliusroemer eventually found that it was crashing in the `CoordinateMapper` constructor. After some long staring into the code I found an unguarded access to an empty array.

