### PR TITLE
fix: reduce number of webworker timeout errors

### DIFF
--- a/packages/web/src/workers/run.ts
+++ b/packages/web/src/workers/run.ts
@@ -1,4 +1,4 @@
-import { Pool, spawn, Worker } from 'threads'
+import { Pool, spawn as spawnBase, Worker } from 'threads'
 import { concurrent } from 'fasy'
 
 import type { SequenceParserResult } from 'src/algorithms/types'
@@ -14,6 +14,13 @@ import type { TreeFinalizeThread } from 'src/workers/worker.treeFinalize'
 import type { TreePrepareThread } from 'src/workers/worker.treePrepare'
 import type { SerializeToCsvThread } from 'src/workers/worker.serializeToCsv'
 import type { SerializeInsertionsToCsvThread } from './worker.serializeInsertionsToCsv'
+
+const WORKER_TIMEOUT_MS = 60 * 1000
+
+/** Wraps `spawn()` from `threads` package to provide a custom initialization timeout interval */
+export const spawn: typeof spawnBase = (worker: Worker) => {
+  return spawnBase(worker, { timeout: WORKER_TIMEOUT_MS })
+}
 
 /**
  * Creates and initializes the analysis webworker pool.


### PR DESCRIPTION
On a busy computer/browser Nextclade Web sometimes crashes with a webworker timeout message.

![image](https://user-images.githubusercontent.com/9403403/143723118-05f1900d-50ec-4dca-ae38-5676c5f2cb50.png)

This is due to either webworker or the main thread being busy for an extended period of time, leading to communication delays between them. This can happen if a large set of sequences is analyzed on an underpowered machine, or on a machine with most of the resources (CPU, RAM) already occupied by other  browser tabs and processes.

Additionally, the wasm modules for workers are lazy-loaded from the server, so if there are network problems or if network is too slow, the initialization of a new worker, might be additionally delayed by the network overhead. In particular, after fresh releases, when these modules are not yet in the browser's cache.

In rare cases, when there are bugs in the C++ code of the wasm module, it might crash internally and the lack of reply is due to the code is not running anymore. However I believe most of the errors should now arise in the form of exceptions, transferred over to the JS side, so that a more specific error is reported. It is recommended to keep an eye on the browser console when timeout errors appear, because the unhanded errors may also manifest there.

---

In this PR we increase the timeout, so that there is some more room for webworkers to communicate. The default timeout is 10 seconds, now it's 60 seconds.

A better fix would be:
 - to reduce number of workers to be initialized, by reusing existing workers and wasm modules
 - to reduce number and volume of communication required between workers and the main thread (by structuring function calls better and using more efficient data formats for messages)
 - to preemptively initialize workers in background during idle periods


It is hard to tell whether this PR helps or not. This issues are hard to reproduce and circumstances of these errors are very resource- and timing-dependent.
