### PR TITLE
fix: avoid potential dereference of nullopt

### DIFF
--- a/packages/nextclade/src/qc/rulePrivateMutations.cpp
+++ b/packages/nextclade/src/qc/rulePrivateMutations.cpp
@@ -65,8 +65,8 @@ namespace Nextclade {
       }
     }
 
-    // Terminate the last range with the last deletion
-    if (!privateDeletionsSorted.empty()) {
+    // Terminate the last range if any (there is an open range if `begin` is set)
+    if (!privateDeletionsSorted.empty() && begin) {
       const auto end = privateDeletionsSorted.back().pos;
       const auto length = end - *begin;
       deletionRanges.emplace_back(

--- a/packages/nextclade/src/qc/rulePrivateMutations.cpp
+++ b/packages/nextclade/src/qc/rulePrivateMutations.cpp
@@ -69,8 +69,10 @@ namespace Nextclade {
     if (!privateDeletionsSorted.empty() && begin) {
       const auto end = privateDeletionsSorted.back().pos;
       const auto length = end - *begin;
-      deletionRanges.emplace_back(
-        NucleotideRange{.begin = *begin, .end = end, .length = length, .character = Nucleotide::GAP});
+      if (length > 0) {
+        deletionRanges.emplace_back(
+          NucleotideRange{.begin = *begin, .end = end, .length = length, .character = Nucleotide::GAP});
+      }
     }
 
     return deletionRanges;

--- a/packages/nextclade/src/qc/rulePrivateMutations.cpp
+++ b/packages/nextclade/src/qc/rulePrivateMutations.cpp
@@ -61,7 +61,7 @@ namespace Nextclade {
           begin = std::optional<int>{};
         }
 
-        // Otherwise (deletion is adjacent), extend the existing range (by simply not terminating it)
+        // Otherwise, deletion is adjacent: extend the existing range (by simply not terminating it)
       }
     }
 


### PR DESCRIPTION
If there is no open range by the end of the loop, then `begin` might be `nullopt`. Then it's illegal to dereference it in the body of this conditional. I add an additional check to see if `begin` contains a value.

And while we are here, why don't we also check if the range is not empty before pushing it, as well as clarify a couple of comments? (The rule of boy scouts: Always leave the campground cleaner than you found it)