### PR TITLE
feat: tune params to improve peptide alignment

### DIFF
--- a/packages/nextalign/src/align/alignmentParams.cpp
+++ b/packages/nextalign/src/align/alignmentParams.cpp
@@ -62,10 +62,10 @@ GapCounts countGaps(const NucleotideSequence& seq) {
 }
 
 AlignmentParams calculateAaAlignmentParams(const GapCounts& queryGapCounts, const GapCounts& refGapCounts) {
-  constexpr int BASE_BAND_WIDTH = 3;// An arbitrary magic number to give some additional room for alignment
+  constexpr int BASE_BAND_WIDTH = 5;// An arbitrary magic number to give some additional room for alignment
 
-  const int bandWidth = std::max(queryGapCounts.internal, refGapCounts.internal) / 3 + BASE_BAND_WIDTH;
-  const int shift = queryGapCounts.leading / 3 + bandWidth / 2;
+  const int bandWidth = (queryGapCounts.internal + refGapCounts.internal) / 3 + BASE_BAND_WIDTH;
+  const int shift = (queryGapCounts.leading - refGapCounts.leading) / 3 + (queryGapCounts.internal - refGapCounts.internal) / 6;
 
   debug_trace("Deduced alignment params: bandWidth={:}, shift={:}\n", bandWidth, shift);
 

--- a/packages/nextalign/tests/alignmentParams.test.cpp
+++ b/packages/nextalign/tests/alignmentParams.test.cpp
@@ -47,8 +47,8 @@ TEST(AlignmentParams, QueryHasOnlyInternalGaps) {
   EXPECT_EQ(6, queryGapCounts.total);
 
   const auto alignmentParams = calculateAaAlignmentParams(queryGapCounts, refGapCounts);
-  EXPECT_EQ(5, alignmentParams.bandWidth);
-  EXPECT_EQ(2, alignmentParams.shift);
+  EXPECT_EQ(7, alignmentParams.bandWidth);
+  EXPECT_EQ(1, alignmentParams.shift);
 }
 
 
@@ -67,8 +67,8 @@ TEST(AlignmentParams, QueryHasLeadingInternalAndTrailingGaps) {
   EXPECT_EQ(16, queryGapCounts.total);
 
   const auto alignmentParams = calculateAaAlignmentParams(queryGapCounts, refGapCounts);
-  EXPECT_EQ(5, alignmentParams.bandWidth);
-  EXPECT_EQ(3, alignmentParams.shift);
+  EXPECT_EQ(7, alignmentParams.bandWidth);
+  EXPECT_EQ(2, alignmentParams.shift);
 }
 
 
@@ -87,8 +87,8 @@ TEST(AlignmentParams, QueryHasLeadingInternalAndTrailingGapsNonContiguous) {
   EXPECT_EQ(16, queryGapCounts.total);
 
   const auto alignmentParams = calculateAaAlignmentParams(queryGapCounts, refGapCounts);
-  EXPECT_EQ(5, alignmentParams.bandWidth);
-  EXPECT_EQ(3, alignmentParams.shift);
+  EXPECT_EQ(7, alignmentParams.bandWidth);
+  EXPECT_EQ(2, alignmentParams.shift);
 }
 
 
@@ -113,6 +113,6 @@ TEST(AlignmentParams, GeneralCase) {
   EXPECT_EQ(16, queryGapCounts.total);
 
   const auto alignmentParams = calculateAaAlignmentParams(queryGapCounts, refGapCounts);
-  EXPECT_EQ(5, alignmentParams.bandWidth);
-  EXPECT_EQ(3, alignmentParams.shift);
+  EXPECT_EQ(10, alignmentParams.bandWidth);
+  EXPECT_EQ(1, alignmentParams.shift);
 }


### PR DESCRIPTION
This improves calculation of bandwidth and shift for peptide alignment, previously introduced in https://github.com/nextstrain/nextclade/pull/613

In this version we ensure that the sequences with large insertions (large number of ref gaps) get a large enough band width.

