### PR TITLE
fix: error when `--genes` flag contains a subset of genes

### DIFF
--- a/packages/nextclade/src/tree/treePreprocess.cpp
+++ b/packages/nextclade/src/tree/treePreprocess.cpp
@@ -111,7 +111,7 @@ namespace Nextclade {
 
         const auto& refPeptide = mapFind(refPeptides, geneName);
         if (!refPeptide) {
-          throw RefPeptideNotFound(geneName);
+          continue;
         }
 
         // If mutation reverts aminoacid back to what reference had, remove it from the map


### PR DESCRIPTION
When `--genes` flag was provided to Nextclade CLI, which contains a list with only a subset of genes present in gene map, it would result in an error "Reference peptide not found".

This was caused by the incorrect assumption in this part of code, that all ref genes are always present, which is not the case when genes are excluded with some of the genes omitted in the `--genes` flag.

Here  I made it so that if a reference peptide is not found, we now simply continue iterating, ignoring that gene.

