### PR TITLE
fix: remove unused aa seed parameters

### DIFF
--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -236,7 +236,6 @@ struct NextalignAlignmentOptions {
 struct NextalignOptions {
   NextalignAlignmentOptions alignment;
   NextalignSeedOptions seedNuc;
-  NextalignSeedOptions seedAa;
   bool translatePastStop;
 };
 

--- a/packages/nextalign/src/align/alignPairwise.cpp
+++ b/packages/nextalign/src/align/alignPairwise.cpp
@@ -368,15 +368,13 @@ AlignmentStatus<Letter> backTrace(const Sequence<Letter>& query, const Sequence<
   // Determine the best alignment by picking the optimal score at the end of the query
   int si = 0;
   int bestScore = 0;
-  debug_trace(
-    "backtrace: rowLength={:}, querySize={:}, scoresSize={:}\n",
-    rowLength, querySize, scoresSize);
+  debug_trace("backtrace: rowLength={:}, querySize={:}, scoresSize={:}\n", rowLength, querySize, scoresSize);
   for (int i = 0; i < scoresSize; i++) {
     const auto is = indexToShift(i);
     // Determine the last index
     lastIndexByShift[i] = rowLength - 1 < querySize + is ? rowLength - 1 : querySize + is;
 
-    if (lastIndexByShift[i]>=0 && lastIndexByShift[i]<scores.num_cols()) {
+    if (lastIndexByShift[i] >= 0 && lastIndexByShift[i] < scores.num_cols()) {
       // invariant_greater(lastIndexByShift[i], 0);
       // invariant_less(lastIndexByShift[i], scores.num_cols());
       // debug_trace(
@@ -486,8 +484,8 @@ struct AlignPairwiseTag {};
 
 template<typename Letter>
 AlignmentStatus<Letter> alignPairwise(const Sequence<Letter>& query, const Sequence<Letter>& ref,
-  const std::vector<int>& gapOpenClose, const NextalignAlignmentOptions& alignmentOptions,
-  const NextalignSeedOptions& seedOptions, int bandWidth, int shift, AlignPairwiseTag) {
+  const std::vector<int>& gapOpenClose, const NextalignAlignmentOptions& alignmentOptions, int bandWidth, int shift,
+  AlignPairwiseTag) {
 
   debug_trace(
     "Align pairwise: started:\n  minimalLength={:},\n  penaltyGapExtend={:},\n  penaltyGapOpen={:},\n  "
@@ -543,12 +541,10 @@ NucleotideAlignmentStatus alignPairwise(const NucleotideSequence& query, const N
   const auto& meanShift = seedAlignmentStatus.result->meanShift;
   debug_trace("Align pairwise: after seed alignment: bandWidth={:}, meanShift={:}\n", bandWidth, meanShift);
 
-  return alignPairwise(query, ref, gapOpenClose, alignmentOptions, seedOptions, bandWidth, meanShift,
-    AlignPairwiseTag{});
+  return alignPairwise(query, ref, gapOpenClose, alignmentOptions, bandWidth, meanShift, AlignPairwiseTag{});
 }
 
 AminoacidAlignmentStatus alignPairwise(const AminoacidSequence& query, const AminoacidSequence& ref,
-  const std::vector<int>& gapOpenClose, const NextalignAlignmentOptions& alignmentOptions,
-  const NextalignSeedOptions& seedOptions, int bandWidth, int shift) {
-  return alignPairwise(query, ref, gapOpenClose, alignmentOptions, seedOptions, bandWidth, shift, AlignPairwiseTag{});
+  const std::vector<int>& gapOpenClose, const NextalignAlignmentOptions& alignmentOptions, int bandWidth, int shift) {
+  return alignPairwise(query, ref, gapOpenClose, alignmentOptions, bandWidth, shift, AlignPairwiseTag{});
 }

--- a/packages/nextalign/src/align/alignPairwise.h
+++ b/packages/nextalign/src/align/alignPairwise.h
@@ -67,5 +67,5 @@ NucleotideAlignmentStatus alignPairwise(const NucleotideSequence& query, const N
   const NextalignSeedOptions& seedOptions);
 
 AminoacidAlignmentStatus alignPairwise(const AminoacidSequence& query, const AminoacidSequence& ref,
-  const std::vector<int>& gapOpenClose, const NextalignAlignmentOptions& alignmentOptions,
-  const NextalignSeedOptions& seedOptions, const int bandWidth, const int shift);
+  const std::vector<int>& gapOpenClose, const NextalignAlignmentOptions& alignmentOptions, const int bandWidth,
+  const int shift);

--- a/packages/nextalign/src/options/options.cpp
+++ b/packages/nextalign/src/options/options.cpp
@@ -20,13 +20,6 @@ namespace {
         .seedSpacing = 100,
         .mismatchesAllowed = 3,
       },
-    .seedAa =
-      {
-        .seedLength = 12,
-        .minSeeds = 10,
-        .seedSpacing = 100,
-        .mismatchesAllowed = 2,
-      },
     .translatePastStop = false,
   };
 }//namespace

--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -161,7 +161,7 @@ PeptidesInternal translateGenes(                               //
     debug_trace("Aligning peptide '{:}'\n", geneName);
     const AlignmentParams alignmentParams = calculateAaAlignmentParams(queryGapCounts, refGapCounts);
     const auto geneAlignmentStatus = alignPairwise(queryPeptide, refPeptide->peptide, gapOpenCloseAA, options.alignment,
-      options.seedAa, alignmentParams.bandWidth, alignmentParams.shift);
+      alignmentParams.bandWidth, alignmentParams.shift);
 
     if (geneAlignmentStatus.status != Status::Success) {
       const auto message = fmt::format(

--- a/packages/nextalign/tests/alignPairwiseWithCodons.test.cpp
+++ b/packages/nextalign/tests/alignPairwiseWithCodons.test.cpp
@@ -38,7 +38,7 @@ TEST_F(AlignPairwiseWithCodons, AlignsCodonGapsQuery) {
 
   const std::vector<int> gapOpenCosts = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
 
-  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedAa);
+  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedNuc);
   EXPECT_EQ(16 * 3 - 7 - 7, result.result->alignmentScore);
   EXPECT_EQ(toString(refAln), toString(result.result->ref));
   EXPECT_EQ(toString(qryAln), toString(result.result->query));
@@ -66,7 +66,7 @@ TEST_F(AlignPairwiseWithCodons, AlignsCodonGapsRef) {
 
   const std::vector<int> gapOpenCosts = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
 
-  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedAa);
+  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedNuc);
   EXPECT_EQ(16 * 3 - 7 - 7, result.result->alignmentScore);
   EXPECT_EQ(toString(refAln), toString(result.result->ref));
   EXPECT_EQ(toString(qryAln), toString(result.result->query));
@@ -105,7 +105,7 @@ TEST_F(AlignPairwiseWithCodons, AlignsCodonTwoGenes) {
 
   const std::vector<int> gapOpenCosts = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
 
-  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedAa);
+  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedNuc);
   EXPECT_EQ(20 * 3 - 7 - 7, result.result->alignmentScore);
   EXPECT_EQ(toString(refAln), toString(result.result->ref));
   EXPECT_EQ(toString(qryAln), toString(result.result->query));
@@ -133,7 +133,7 @@ TEST_F(AlignPairwiseWithCodons, AlignsCodonGapsQuery2) {
 
   const std::vector<int> gapOpenCosts = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
 
-  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedAa);
+  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedNuc);
   EXPECT_EQ(18 * 3 - 7, result.result->alignmentScore);
   EXPECT_EQ(toString(refAln), toString(result.result->ref));
   EXPECT_EQ(toString(qryAln), toString(result.result->query));
@@ -161,7 +161,7 @@ TEST_F(AlignPairwiseWithCodons, AlignsCodonGapsRef2) {
 
   const std::vector<int> gapOpenCosts = getGapOpenCloseScoresCodonAware(ref, geneMap, options);
 
-  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedAa);
+  const auto result = alignPairwise(qry, ref, gapOpenCosts, options.alignment, options.seedNuc);
   EXPECT_EQ(18 * 3 - 7, result.result->alignmentScore);
   EXPECT_EQ(toString(refAln), toString(result.result->ref));
   EXPECT_EQ(toString(qryAln), toString(result.result->query));

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -117,11 +117,6 @@ NextalignOptions validateOptions(const cxxopts::ParseResult &cxxOptsParsed) {
   options.seedNuc.seedSpacing = getParamRequiredDefaulted<int>(cxxOptsParsed, "nuc-seed-spacing", ensureNonNegative);
   options.seedNuc.mismatchesAllowed = getParamRequiredDefaulted<int>(cxxOptsParsed, "nuc-mismatches-allowed", ensureNonNegative);
 
-  options.seedAa.seedLength = getParamRequiredDefaulted<int>(cxxOptsParsed, "aa-seed-length", ensurePositive);
-  options.seedAa.minSeeds = getParamRequiredDefaulted<int>(cxxOptsParsed, "aa-min-seeds", ensurePositive);
-  options.seedAa.seedSpacing = getParamRequiredDefaulted<int>(cxxOptsParsed, "aa-seed-spacing", ensureNonNegative);
-  options.seedAa.mismatchesAllowed = getParamRequiredDefaulted<int>(cxxOptsParsed, "aa-mismatches-allowed", ensureNonNegative);
-
   options.translatePastStop = !(getParamOptional<bool>(cxxOptsParsed, "no-translate-past-stop").value_or(false));
   // clang-format on
 
@@ -338,34 +333,6 @@ std::tuple<CliParams, cxxopts::Options, NextalignOptions> parseCommandLine(int a
       "(optional, integer, non-negative) Maximum number of mismatching nucleotides allowed for a seed to be considered a match.",
       cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().seedNuc.mismatchesAllowed)),
       "NUC_MISMATCHES_ALLOWED"
-    )
-
-    (
-      "aa-seed-length",
-      "(optional, integer, positive) Seed length for aminoacid alignment.",
-      cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().seedAa.seedLength)),
-      "AA_SEED_LENGTH"
-    )
-
-    (
-      "aa-min-seeds",
-      "(optional, integer, positive) Minimum number of seeds to search for during aminoacid alignment. Relevant for short sequences. In long sequences, the number of seeds is determined by `--aa-seed-spacing`.",
-      cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().seedAa.minSeeds)),
-      "AA_MIN_SEEDS"
-    )
-
-    (
-      "aa-seed-spacing",
-      "(optional, integer, non-negative) Spacing between seeds during aminoacid alignment.",
-      cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().seedAa.seedSpacing)),
-      "AA_SEED_SPACING"
-    )
-
-    (
-      "aa-mismatches-allowed",
-      "(optional, integer, non-negative) Maximum number of mismatching aminoacids allowed for a seed to be considered a match.",
-      cxxopts::value<int>()->default_value(std::to_string(getDefaultOptions().seedAa.mismatchesAllowed)),
-      "AA_MISMATCHES_ALLOWED"
     )
 
     (

--- a/packages/nextclade_cli/cli.json
+++ b/packages/nextclade_cli/cli.json
@@ -255,34 +255,6 @@
           "isOptional": true
         },
         {
-          "flags": ["--aa-seed-length"],
-          "desc": "Seed length for aminoacid alignment.",
-          "cppName": "aaSeedLength",
-          "cppType": "int",
-          "isOptional": true
-        },
-        {
-          "flags": ["--aa-min-seeds"],
-          "desc": "Minimum number of seeds to search for during aminoacid alignment. Relevant for short sequences. In long sequences, the number of seeds is determined by `--aa-seed-spacing`.",
-          "cppName": "aaMinSeeds",
-          "cppType": "int",
-          "isOptional": true
-        },
-        {
-          "flags": ["--aa-seed-spacing"],
-          "desc": "Spacing between seeds during aminoacid alignment.",
-          "cppName": "aaSeedSpacing",
-          "cppType": "int",
-          "isOptional": true
-        },
-        {
-          "flags": ["--aa-mismatches-allowed"],
-          "desc": "Maximum number of mismatching amino acids allowed for a seed to be considered a match.",
-          "cppName": "aaMismatchesAllowed",
-          "cppType": "int",
-          "isOptional": true
-        },
-        {
           "flags": ["--no-translate-past-stop"],
           "desc": "Whether to stop gene translation after first stop codon. It will cut the genes in places cases where mutations resulted in premature stop codons. If this flag is present, the aminoacid sequences wil be truncated at the first stop codon and analysis of aminoacid mutations will not be available for the regions after first stop codon.",
           "cppName": "noTranslatePastStop",

--- a/packages/nextclade_cli/src/io/getNextalignOptions.h
+++ b/packages/nextclade_cli/src/io/getNextalignOptions.h
@@ -23,13 +23,6 @@ namespace Nextclade {
           .seedSpacing = cliParams.nucSeedSpacing,
           .mismatchesAllowed = cliParams.nucMismatchesAllowed,
         },
-      .seedAa =
-        {
-          .seedLength = cliParams.aaSeedLength,
-          .minSeeds = cliParams.aaMinSeeds,
-          .seedSpacing = cliParams.aaSeedSpacing,
-          .mismatchesAllowed = cliParams.aaMismatchesAllowed,
-        },
       .translatePastStop = !cliParams.noTranslatePastStop,
     };
   }

--- a/packages/nextclade_cli/src/main.cpp
+++ b/packages/nextclade_cli/src/main.cpp
@@ -96,11 +96,6 @@ int main(int argc, char* argv[]) {
         .nucSeedSpacing = options.seedNuc.seedSpacing,
         .nucMismatchesAllowed = options.seedNuc.mismatchesAllowed,
 
-        .aaSeedLength = options.seedAa.seedLength,
-        .aaMinSeeds = options.seedAa.minSeeds,
-        .aaSeedSpacing = options.seedAa.seedSpacing,
-        .aaMismatchesAllowed = options.seedAa.mismatchesAllowed,
-
         .noTranslatePastStop = !options.translatePastStop,
 
         .verbosity = {},


### PR DESCRIPTION
Since https://github.com/nextstrain/nextclade/pull/613 aminoacid seed alignment parameters and flags are unused. This PR removes them.

BREAKING CHANGE: the family of CLI flags `--seed-aa-*` has been removed from the CLI interface. Migration path: remove these flags from Nextalign and Nextclade CLI invocation.

