### PR TITLE
fix: off-by-one errors in insertion positions

### DIFF
--- a/packages/nextalign/include/nextalign/private/nextalign_private.h
+++ b/packages/nextalign/include/nextalign/private/nextalign_private.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "nextalign/private/nextalign_private.h"
 
 template<typename Letter>
 using SequenceSpan = gsl::basic_string_span<Letter, gsl::dynamic_extent>;
@@ -15,27 +14,6 @@ using NucleotideSequenceSpan = SequenceSpan<Nucleotide>;
 
 using AminoacidSequenceSpan = SequenceSpan<Aminoacid>;
 
-
-struct PeptideInternal {
-  std::string name;
-  AminoacidSequence seq;
-  std::vector<InsertionInternal<Aminoacid>> insertions;
-  std::vector<FrameShiftResult> frameShiftResults;
-};
-
-struct PeptidesInternal {
-  std::vector<PeptideInternal> queryPeptides;
-  Warnings warnings;
-};
-
-struct NextalignResultInternal {
-  NucleotideSequence query;
-  NucleotideSequence ref;
-  int alignmentScore;
-  std::vector<PeptideInternal> queryPeptides;
-  std::vector<InsertionInternal<Nucleotide>> insertions;
-  Warnings warnings;
-};
 
 Nucleotide toNucleotide(char nuc);
 
@@ -88,10 +66,6 @@ std::vector<Insertion> toInsertionsExternal(const std::vector<InsertionInternal<
 std::vector<Peptide> toPeptidesExternal(const std::vector<PeptideInternal>& peptides);
 
 std::vector<RefPeptide> toRefPeptidesExternal(const std::vector<RefPeptideInternal>& peptides);
-
-NextalignResultInternal nextalignInternal(const NucleotideSequence& query, const NucleotideSequence& ref,
-  const std::map<std::string, RefPeptideInternal>& refPeptides, const GeneMap& geneMap,
-  const NextalignOptions& options);
 
 
 inline std::ostream& operator<<(std::ostream& os, const Nucleotide& nuc) {

--- a/packages/nextalign/src/strip/stripInsertions.h
+++ b/packages/nextalign/src/strip/stripInsertions.h
@@ -34,7 +34,9 @@ inline StripInsertionsResult<Letter> stripInsertions(const Sequence<Letter>& ref
     if (c == Letter::GAP) {
       if (currentInsertion.empty()) {
         currentInsertion = query[i];
-        insertionStart = i;
+        // NOTE: by convention we set position of insertion to be the index of a character that precedes the insertion,
+        // i.e. a position of reference nucleotide *after* which the insertion have happened.
+        insertionStart = i - 1;
       } else {
         currentInsertion += query[i];
       }

--- a/packages/nextalign/tests/stripInsertions.test.cpp
+++ b/packages/nextalign/tests/stripInsertions.test.cpp
@@ -13,7 +13,7 @@ TEST(stripInsertions, StripsAnInsertion) {
 
   EXPECT_EQ(toString(res.queryStripped), toString(expected));
   EXPECT_EQ(res.insertions.size(), 1);
-  EXPECT_EQ(res.insertions[0].pos, 3);
+  EXPECT_EQ(res.insertions[0].pos, 2);
   EXPECT_EQ(res.insertions[0].length, 3);
   EXPECT_EQ(toString(res.insertions[0].ins), "GCG");
 }

--- a/packages/nextalign_cli/CMakeLists.txt
+++ b/packages/nextalign_cli/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
 find_package(Boost 1.75.0 COMPONENTS headers REQUIRED)
+find_package(Microsoft.GSL 3.1.0 REQUIRED)
 find_package(TBB REQUIRED)
 find_package(cxxopts 2.2.1 REQUIRED)
 find_package(fmt 7.1.0 REQUIRED)
@@ -82,6 +83,7 @@ target_link_libraries(${PROJECT_NAME}
   PRIVATE
   ${STATIC_BUILD_FLAGS}
   Boost::headers
+  Microsoft.GSL::GSL
   TBB::tbb
   cxxopts::cxxopts
   fmt::fmt-header-only

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -1,5 +1,5 @@
 #include <fmt/format.h>
-#include <nextalign/nextalign.h>
+#include <nextalign/private/nextalign_private.h>
 #include <tbb/global_control.h>
 #include <tbb/parallel_pipeline.h>
 
@@ -703,7 +703,7 @@ void run(
     [&ref, &refPeptides, &geneMap, &options](const AlgorithmInput &input) -> AlgorithmOutput {
       try {
         const auto query = toNucleotideSequence(input.seq);
-        const auto result = nextalign(query, ref, refPeptides, geneMap, options);
+        const auto result = nextalignInternal(query, ref, refPeptides, geneMap, options);
         return {.index = input.index, .seqName = input.seqName, .hasError = false, .result = result, .error = nullptr};
       } catch (const std::exception &e) {
         const auto &error = std::current_exception();
@@ -761,10 +761,10 @@ void run(
       outputErrorsFile << fmt::format("\"{:s}\",\"{:s}\",\"{:s}\",\"{:s}\"\n", seqName, "", warningsJoined,
         failedGeneNamesJoined);
 
-      outputFastaStream << fmt::format(">{:s}\n{:s}\n", seqName, queryAligned);
+      outputFastaStream << fmt::format(">{:s}\n{:s}\n", seqName, toString(queryAligned));
 
       for (const auto &peptide : queryPeptides) {
-        outputGeneStreams[peptide.name] << fmt::format(">{:s}\n{:s}\n", seqName, peptide.seq);
+        outputGeneStreams[peptide.name] << fmt::format(">{:s}\n{:s}\n", seqName, toString(peptide.seq));
       }
 
       outputInsertionsStream << fmt::format("\"{:s}\",\"{:s}\"\n", seqName, formatInsertions(insertions));

--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -288,8 +288,6 @@ namespace Nextclade {
     return lhs.start == rhs.start && lhs.length == rhs.length;
   }
 
-  using NucleotideInsertion = InsertionInternal<Nucleotide>;
-
   template<>
   struct Substitution<Aminoacid> {
     std::string gene;
@@ -604,10 +602,6 @@ namespace Nextclade {
   std::string formatMutation(const NucleotideSubstitution& mut);
 
   std::string formatDeletion(const NucleotideDeletion& del);
-
-  std::string formatInsertion(const NucleotideInsertion& insertion);
-
-  std::string formatInsertions(const std::vector<NucleotideInsertion>& insertions);
 
   std::string formatMissing(const NucleotideRange& missing);
 

--- a/packages/nextclade/src/__tests__/findNucChanges.test.cpp
+++ b/packages/nextclade/src/__tests__/findNucChanges.test.cpp
@@ -13,7 +13,6 @@
 
 using Nextclade::findNucChanges;
 using Nextclade::NucleotideDeletion;
-using Nextclade::NucleotideInsertion;
 using Nextclade::NucleotideSubstitution;
 
 TEST(FindNucChanges, ReportsAlignmentStartAndEnd) {

--- a/packages/nextclade/src/io/formatMutation.cpp
+++ b/packages/nextclade/src/io/formatMutation.cpp
@@ -66,17 +66,6 @@ namespace Nextclade {
     return formatRange(Range{.begin = del.start, .end = del.start + del.length});
   }
 
-  std::string formatInsertion(const NucleotideInsertion& insertion) {
-    // NOTE: by convention, in bioinformatics, nucleotides are numbered starting from 1, however our arrays are 0-based
-    const auto positionOneBased = insertion.pos + 1;
-    const auto insertedSequence = toString(insertion.ins);
-    return fmt::format("{}:{}", positionOneBased, insertedSequence);
-  }
-
-  std::string formatInsertions(const std::vector<NucleotideInsertion>& insertions) {
-    return formatAndJoin(insertions, formatInsertion, ";");
-  }
-
   std::string formatMissing(const NucleotideRange& missing) {
     return formatRange({.begin = missing.begin, .end = missing.end});
   }

--- a/packages/nextclade/src/io/formatMutation.h
+++ b/packages/nextclade/src/io/formatMutation.h
@@ -2,15 +2,7 @@
 
 #include <nextclade/nextclade.h>
 
-#include <boost/algorithm/string/join.hpp>
 #include <string>
 #include <vector>
 
-namespace Nextclade {
-  template<typename Container, typename Formatter, typename Delimiter>
-  std::string formatAndJoin(const Container& elements, Formatter formatter, Delimiter delimiter) {
-    std::vector<std::string> formatted;
-    std::transform(elements.cbegin(), elements.cend(), std::back_inserter(formatted), formatter);
-    return boost::algorithm::join(formatted, delimiter);
-  }
-}// namespace Nextclade
+namespace Nextclade {}// namespace Nextclade

--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -259,7 +259,7 @@ std::string serializeInsertionsToCsv(const std::string& analysisResultsStr) {
   for (const auto& result : analysisResults.results) {
     const auto& seqName = result.seqName;
     const auto& insertions = result.insertions;
-    outputInsertionsStream << fmt::format("\"{:s}\",\"{:s}\"\n", seqName, Nextclade::formatInsertions(insertions));
+    outputInsertionsStream << fmt::format("\"{:s}\",\"{:s}\"\n", seqName, formatInsertions(insertions));
   }
   return outputInsertionsStream.str();
 }

--- a/packages/web/src/components/Results/ListOfInsertions.tsx
+++ b/packages/web/src/components/Results/ListOfInsertions.tsx
@@ -44,7 +44,7 @@ export function ListOfInsertions({ insertions, totalInsertions }: ListOfInsertio
         <TableSlimWithBorders className="mb-1">
           <thead>
             <tr>
-              <th className="text-center">{t('After pos.')}</th>
+              <th className="text-center">{t('After ref pos.')}</th>
               <th className="text-center">{t('Length')}</th>
               <th className="text-center">{t('Nuc. fragment')}</th>
             </tr>
@@ -53,7 +53,7 @@ export function ListOfInsertions({ insertions, totalInsertions }: ListOfInsertio
           <tbody>
             {insertions.map(({ pos, ins }) => (
               <tr key={pos}>
-                <td className="text-center">{pos}</td>
+                <td className="text-center">{pos + 1}</td>
                 <td className="text-center">{ins.length}</td>
                 <td className="text-left">{truncateString(ins, INSERTION_MAX_LENGTH)}</td>
               </tr>


### PR DESCRIPTION
Multiple related defects were identified:

 1. The `pos` field in the internal objects representing insertions was of by one. `1` needed to be subtracted in insertion detection code to adjust for the fact that `pos` represents a position in reference ***\*after\**** which the insertion occurred. But it did not.
 2. The formatting in the results table in Nextclade Web was incorrectly not converting insertion positions to 1-based, which resulted in off-by-one in the opposite direction, "compensating" the mistake
 3. Nextalign erroneously used a duplicated implementation of the formatting function different from the one in (3) that erroneously did not convert position to 1-based, similar to (2), so the mistake in (1) was not manifesting in insertions CSV file and manifesting in JSON results files (which does not use formatting).
 4. Nextclade CLI formatted the insertion position correctly, and the mistake in (1) was manifesting in insertion CSV and JSON results files.

This PR:
  - A. Fixes the off-by-one error in insertion detection code by subtracting 1 from the `pos`. Addressing (1).

 - B. Adds conversion to 1-based position in insertions, by adding 1 in formatting code in Nextclade Web. Addressing (2). The visible result haven't changed due to combination of (A) and (B). 

 - C. Deduplicates insertion formatting function in Nextalign and Nextclade C++ libraries, by taking the version from Nextclade (case (4) above), which is the correct one. So now the CSV output should be consistent and correct. Addressing (3) and (4).

Additionally, this required to perform some refactoring, because of deduplication and because of the fact functions have moved across library boundaries.

To make this transition cleaner, Nextalign CLI now also converts data structures only before they are output to files, in the executable code, instead of returning pre-formatted ("external") structures from the library. This is for symmetry with Nextclade (the now shared formatting functions expect non-formatted, "internal" inputs) and for convenience.


Note that JSON results are not formatted, but just dump the internal representation, with 0-based positions. This is by design. Insertion positions in JSON have now changed due to (A).
