### PR TITLE
fix: prevent buffer overflow in coord map

### DIFF
--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -41,6 +41,10 @@ struct Range {
   [[nodiscard]] bool contains(int x) const {
     return x >= begin && x < end;
   }
+
+  [[nodiscard]] int length() const {
+    return end - begin;
+  }
 };
 
 [[nodiscard]] inline Range nucRangeToCodonRange(const Range& range) {

--- a/packages/nextalign/src/translate/extractGene.cpp
+++ b/packages/nextalign/src/translate/extractGene.cpp
@@ -79,18 +79,13 @@ ExtractGeneStatus extractGeneQuery(const NucleotideSequenceView& query, const Ge
   precondition_less(gene.start, gene.end);
 
   // Transform gene coordinates according to coordinate map
-  const auto start = coordMap.refToAln(gene.start);
-  // gene.end is the position after the last base of the gene (0-based indexing)
-  // the corresponding base in the query is hence found by coordMap[gene.end-1]
-  // we add 1 to make that end be again after the last base of the gene.
-  // with this addition: length = end - start
-  const auto end = coordMap.refToAln(gene.end - 1) + 1;
-  const auto length = end - start;
-  // Start and end should be within bounds
-  invariant_less(start, query.size());
-  invariant_less_equal(end, query.size());
+  const auto geneAln = coordMap.refToAln(Range{gene.start, gene.end});
 
-  auto result = NucleotideSequence(details::substr(query, start, length));
+  // Start and end should be within bounds
+  invariant_less(geneAln.begin, query.size());
+  invariant_less_equal(geneAln.end, query.size());
+
+  auto result = NucleotideSequence(details::substr(query, geneAln.begin, geneAln.length()));
   const auto resultLength = safe_cast<int>(result.size());
 
   if (resultLength == 0) {

--- a/packages/nextalign/src/translate/mapCoordinates.cpp
+++ b/packages/nextalign/src/translate/mapCoordinates.cpp
@@ -98,7 +98,7 @@ Range CoordinateMapper::alnToRef(const Range& alnRange) const {
   precondition_less(alnRange.begin, alnRange.end);
   const Range refRange{
     .begin = alnToRef(alnRange.begin),
-    .end = alnToRef(alnRange.end),
+    .end = alnToRef(alnRange.end - 1) + 1,
   };
   postcondition_less(refRange.begin, refRange.end);
   return refRange;
@@ -108,7 +108,7 @@ Range CoordinateMapper::refToAln(const Range& refRange) const {
   precondition_less(refRange.begin, refRange.end);
   const Range alnRange{
     .begin = refToAln(refRange.begin),
-    .end = refToAln(refRange.end),
+    .end = refToAln(refRange.end - 1) + 1,
   };
   postcondition_less(alnRange.begin, alnRange.end);
   return alnRange;

--- a/packages/nextalign/src/translate/mapCoordinates.cpp
+++ b/packages/nextalign/src/translate/mapCoordinates.cpp
@@ -95,7 +95,9 @@ int CoordinateMapper::refToAln(int refPos) const {
 }
 
 Range CoordinateMapper::alnToRef(const Range& alnRange) const {
-  precondition_less(alnRange.begin, alnRange.end);
+  if (alnRange.begin >= alnRange.end) {
+    return Range{alnRange.begin, alnRange.begin};
+  }
   const Range refRange{
     .begin = alnToRef(alnRange.begin),
     .end = alnToRef(alnRange.end - 1) + 1,
@@ -105,7 +107,9 @@ Range CoordinateMapper::alnToRef(const Range& alnRange) const {
 }
 
 Range CoordinateMapper::refToAln(const Range& refRange) const {
-  precondition_less(refRange.begin, refRange.end);
+  if (refRange.begin >= refRange.end) {
+    return Range{refRange.begin, refRange.begin};
+  }
   const Range alnRange{
     .begin = refToAln(refRange.begin),
     .end = refToAln(refRange.end - 1) + 1,


### PR DESCRIPTION
This accounts for the fact that the ranges are half-one on the right. So dereferencing `end` index overflows the buffer.
