### PR TITLE
chore(ci): fix Vercel builds

### DIFF
--- a/scripts/build_on_vercel.sh
+++ b/scripts/build_on_vercel.sh
@@ -75,6 +75,17 @@ ln -s /usr/lib/python3.6 /usr/local/lib/python3.6 || true
 export PYTHONPATH=/usr/lib/python3.6${PYTHONPATH:+":$PYTHONPATH"}
 
 
+find / -iname "python" 2>/dev/null || true
+find / -iname "python3" 2>/dev/null || true
+find / -iname "python3.6" 2>/dev/null || true
+find / -iname "python3.9" 2>/dev/null || true
+
+which "python" || true
+which "python3" || true
+which "python3.6" || true
+which "python3.9" || true
+
+
 # Make sure Python has SQLite module enabled
 which "python3"
 python3 -c "import sqlite3; print(sqlite3.sqlite_version)" || true

--- a/scripts/build_on_vercel.sh
+++ b/scripts/build_on_vercel.sh
@@ -47,8 +47,10 @@ rm /lib64/libvips-cpp.so.42
 rm /lib64/libvips.so.42
 
 # Remove default Python. It does not have SQLite module enabled required for `conan`.
-rm -rf /usr/local/bin/python3.6
-rm -rf /usr/local/lib/python3.6
+rm -rf /usr/local/bin/python3.6 /usr/local/lib/python3.6
+rm -rf /usr/local/lib/python3.9 /usr/local/include/python3.9 /usr/local/bin/python3.9
+
+rm -rf /usr/local/bin/python3
 
 # Add "UIS" repos, with more up-to-date packages (https://ius.io/)
 # Python 3.6 from IUS has SQLite enabled.
@@ -79,6 +81,8 @@ find / -iname "python" 2>/dev/null || true
 find / -iname "python3" 2>/dev/null || true
 find / -iname "python3.6" 2>/dev/null || true
 find / -iname "python3.9" 2>/dev/null || true
+
+
 
 which "python" || true
 which "python3" || true


### PR DESCRIPTION
There seems to be now Python 3.9 in the Vercel VM and, similarly to the default Python on RHEL 7, it does not contain sqlite built-in module (which should be enabled when Python binaries are built), so `conan` fails with:

```
- Create conan profile 	
Traceback (most recent call last):
  File "/usr/local/bin/conan", line 33, in <module>
    sys.exit(load_entry_point('conan==1.43.0', 'console_scripts', 'conan')())
  File "/usr/local/bin/conan", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/conans/conan.py", line 7, in <module>
    from conans.client.command import main
  File "/usr/local/lib/python3.9/site-packages/conans/client/command.py", line 16, in <module>
    from conans.client.conan_api import Conan, default_manifest_folder, _make_abs_path, ProfileData
  File "/usr/local/lib/python3.9/site-packages/conans/client/conan_api.py", line 11, in <module>
    from conans.client.cache.cache import ClientCache
  File "/usr/local/lib/python3.9/site-packages/conans/client/cache/cache.py", line 16, in <module>
    from conans.client.store.localdb import LocalDB
  File "/usr/local/lib/python3.9/site-packages/conans/client/store/localdb.py", line 2, in <module>
    import sqlite3
  File "/usr/local/lib/python3.9/sqlite3/__init__.py", line 57, in <module>
    from sqlite3.dbapi2 import *
  File "/usr/local/lib/python3.9/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ModuleNotFoundError: No module named '_sqlite3'
make[1]: *** [prod] Error 1
make: *** [prod-wasm-nowatch] Error 2
Error: Command "bash ./scripts/build_on_vercel.sh" exited with 2
```

Normaly we remove default Python 3.6 and install another one from external UIS repositories, which contains sqlite.

In this PR we aslo remove the newly appeared Python 3.9, so that the UIS Python can is the only Python in the `$PATH`.
