### PR TITLE
refactor: introduce package "common"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -pg")
 
+add_subdirectory(packages/common)
 add_subdirectory(packages/nextalign)
 add_subdirectory(packages/nextclade)
 

--- a/packages/common/CMakeLists.txt
+++ b/packages/common/CMakeLists.txt
@@ -6,41 +6,21 @@ include(CFlags)
 include(Quiet)
 include(Sanitizers)
 
-project(nextclade_common DESCRIPTION "C++ library with code shared across multiple Nextclade modules")
+project(common DESCRIPTION "Common functions used in other packages")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
-find_package(Boost 1.75.0 COMPONENTS headers REQUIRED)
 find_package(Microsoft.GSL 3.1.0 REQUIRED)
-find_package(TBB REQUIRED)
+find_package(Boost 1.75.0 COMPONENTS headers REQUIRED)
 find_package(fmt 7.1.0 REQUIRED)
-find_package(ghcFilesystem 1.4.0 REQUIRED)
-find_package(semver 0.3.0 REQUIRED)
 
-find_package(CURL 7.69.1 REQUIRED)
-find_package(OpenSSL REQUIRED)
-find_package(ZLIB 1.2.11 REQUIRED)
-find_package(c-ares 1.17.1 REQUIRED)
-find_package(Poco 1.11.0 REQUIRED)
-
-if (${APPLE})
-  set(APPLE_CXX_FLAGS " -faligned-allocation")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}${APPLE_CXX_FLAGS}")
-endif()
-
-set(SOURCE_FILES
-  include/nextclade_common/datasets.h
-  include/nextclade_common/fetch.h
-  include/nextclade_common/filesystem.h
-  include/nextclade_common/openOutputFile.h
-  src/datasets.cpp
-  src/fetch.cpp
-  src/generated/cainfo.h
-  src/getCurlCodeString.h
+add_library(${PROJECT_NAME} STATIC
+  include/common/contract.h
+  include/common/debugbreak.h
+  include/common/ieee754_comparison.h
+  src/common.cpp
   )
-
-add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES})
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
   set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS ${NEXTCLADE_EMSCRIPTEN_COMPILER_FLAGS})
@@ -50,7 +30,6 @@ endif ()
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 11)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 
-
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE
 
@@ -59,9 +38,11 @@ target_compile_definitions(${PROJECT_NAME}
 
   -DENABLE_DEBUG_TRACE=${ENABLE_DEBUG_TRACE}
 
-  -DDATA_FULL_DOMAIN="${DATA_FULL_DOMAIN}"
-
   -DFMT_HEADER_ONLY=1
+
+  # Workaround for GCC 9 error in type_safe.
+  # See: https://github.com/foonathan/debug_assert/issues/17
+  -DDEBUG_ASSERT_PURE_FUNCTION=
   )
 
 target_include_directories(${PROJECT_NAME}
@@ -75,7 +56,7 @@ target_include_directories(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} SYSTEM
   PRIVATE
   "${CMAKE_SOURCE_DIR}/3rdparty/frozen/include"
-  "${CMAKE_SOURCE_DIR}/3rdparty/json/include"
+  "${CMAKE_SOURCE_DIR}/3rdparty/boost/include"
   )
 
 target_include_directories(${PROJECT_NAME}
@@ -84,20 +65,7 @@ target_include_directories(${PROJECT_NAME}
   )
 
 target_link_libraries(${PROJECT_NAME}
-  PUBLIC
-  common
-  nextclade_json
-  ghcFilesystem::ghc_filesystem
-
   PRIVATE
-  Boost::headers
   Microsoft.GSL::GSL
-  fmt::fmt-header-only
-  semver::semver
-  TBB::tbb
-  CURL::libcurl
-  OpenSSL::OpenSSL
-  ZLIB::ZLIB
-  c-ares::c-ares
-  Poco::Poco
+  Boost::headers
   )

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,7 @@
+# Common
+
+Helper package containing common functions used in other packages
+
+Contains functionality shared across all other packages. Mostly very generic and lightweight things, like small utilities and extensions to standard library. This package should not get any large dependencies, because they will propagate to all packages, whether they need them or not.
+
+If you are looking for a place where to start getting familiar with the codebase, this is NOT the right place. Instead, take a look at packages with `_cli` at the end.

--- a/packages/common/include/common/config.h
+++ b/packages/common/include/common/config.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <boost/current_function.hpp>
+
+#if defined DEBUG || defined _DEBUG || !defined(NDEBUG) || !defined(_NDEBUG)
+#define NA_DEBUG//NOLINT(OCUnusedMacroInspection)
+#endif
+
+#define NA_FUNCTION BOOST_CURRENT_FUNCTION//NOLINT(OCUnusedMacroInspection)

--- a/packages/common/include/common/contract.h
+++ b/packages/common/include/common/contract.h
@@ -1,0 +1,333 @@
+#pragma once
+
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "readability-convert-member-functions-to-static"
+#pragma ide diagnostic ignored "cppcoreguidelines-macro-usage"
+
+#include "config.h"
+
+#if !defined(NDEBUG)
+#include <iomanip>
+#include <sstream>
+
+#include "debugbreak.h"
+#include "ieee754_comparison.h"
+#include "macro_overload.h"
+
+struct op_equal {
+  template<typename T, typename U>
+  inline bool operator()(const T& left, const U& right) const {
+    return left == right;
+  }
+
+  template<typename T>
+  inline bool operator()(const T& left, const float& right) const {
+    return almost_equal(left, right, ulps);
+  }
+
+  template<typename T>
+  inline bool operator()(const float& left, const T& right) const {
+    return almost_equal(left, right, ulps);
+  }
+
+  template<typename T>
+  inline bool operator()(const T& left, const double& right) const {
+    return almost_equal(left, right, ulps);
+  }
+
+  template<typename T>
+  inline bool operator()(const double& left, const T& right) const {
+    return almost_equal(left, right, ulps);
+  }
+
+  inline bool operator()(double left, float right) const {
+    return almost_equal(left, static_cast<double>(right), ulps);
+  }
+
+  inline bool operator()(float left, double right) const {
+    return almost_equal(static_cast<double>(left), right, ulps);
+  }
+
+  inline bool operator()(float left, float right) const {
+    return almost_equal(left, right, ulps);
+  }
+
+  inline bool operator()(double left, double right) const {
+    return almost_equal(left, right, ulps);
+  }
+
+  inline const char* c_str() const {
+    return "==";
+  }
+
+private:
+  const int ulps = 4;
+};
+
+struct op_not_equal {
+  template<typename T, typename U>
+  inline bool operator()(const T& left, const U& right) const {
+    return left != right;
+  }
+
+  template<typename T>
+  inline bool operator()(const T& left, const float& right) const {
+    return !almost_equal(left, right, ulps);
+  }
+
+  template<typename T>
+  inline bool operator()(const float& left, const T& right) const {
+    return !almost_equal(left, right, ulps);
+  }
+
+  template<typename T>
+  inline bool operator()(const T& left, const double& right) const {
+    return !almost_equal(left, right, ulps);
+  }
+
+  template<typename T>
+  inline bool operator()(const double& left, const T& right) const {
+    return !almost_equal(left, right, ulps);
+  }
+
+  inline bool operator()(double left, float right) const {
+    return !almost_equal(left, static_cast<double>(right), ulps);
+  }
+
+  inline bool operator()(float left, double right) const {
+    return !almost_equal(static_cast<double>(left), right, ulps);
+  }
+
+  inline bool operator()(float left, float right) const {
+    return !almost_equal(left, right, ulps);
+  }
+
+  inline bool operator()(double left, double right) const {
+    return !almost_equal(left, right, ulps);
+  }
+
+  inline const char* c_str() const {
+    return "!=";
+  }
+
+private:
+  const int ulps = 4;
+};
+
+struct op_less {
+  template<typename T, typename U>
+  bool operator()(const T& left, const U& right) {
+    return left < right;
+  }
+
+  const char* c_str() {
+    return "<";
+  }
+};
+
+struct op_greater {
+  template<typename T, typename U>
+  bool operator()(const T& left, const U& right) {
+    return left > right;
+  }
+
+  const char* c_str() {
+    return ">";
+  }
+};
+
+struct op_less_equal {
+  template<typename T, typename U>
+  bool operator()(const T& left, const U& right) {
+    return left <= right;
+  }
+
+  const char* c_str() {
+    return "<=";
+  }
+};
+
+struct op_greater_equal {
+  template<typename T, typename U>
+  bool operator()(const T& left, const U& right) {
+    return left >= right;
+  }
+
+  const char* c_str() {
+    return ">=";
+  }
+};
+
+struct op_divisible_by {
+  template<typename T, typename U>
+  bool operator()(const T& left, const U& right) {
+    return left % right == 0;
+  }
+
+  const char* c_str() {
+    return "to be divisible by";
+  }
+};
+
+
+#define print_error(filePath, line, functionName, msgtype, errMsg)                                             \
+  do {                                                                                                         \
+    fflush(stdout);                                                                                            \
+    fflush(stderr);                                                                                            \
+    fprintf(stderr, "%s:%i:\nin function \"%s\":\n%s: %s\n\n", filePath, line, functionName, msgtype, errMsg); \
+    fflush(stderr);                                                                                            \
+  } while (0);
+
+template<typename T, typename U, typename Stream>
+inline void debug_assert_print_impl(const T& left, const U& right, const char* left_str, const char* right_str,
+  const char* op_str, Stream& ss) {
+  ss << "expected " << left_str << " " << op_str << " " << right_str << ", but got:\n"
+     << left_str << " is " << left << "\n"
+     << "and\n"
+     << right_str << " is " << right << std::endl;
+}
+
+template<typename T, typename U>
+inline std::string debug_assert_print(const T& left, const U& right, const char* left_str, const char* right_str,
+  const char* op_str) {
+  std::stringstream ss;
+  debug_assert_print_impl(left, right, left_str, right_str, op_str, ss);
+  return ss.str();
+}
+
+inline std::string debug_assert_print(float left, float right, const char* left_str, const char* right_str,
+  const char* op_str) {
+  std::stringstream ss;
+  ss << std::fixed << std::setw(10) << std::setprecision(10);//NOLINT:cppcoreguidelines-avoid-magic-numbers
+  debug_assert_print_impl(left, right, left_str, right_str, op_str, ss);
+  ss << "(The difference is " << ulps_distance(left, right) << " ULPs)\n";
+  return ss.str();
+}
+
+inline std::string debug_assert_print(double left, double right, const char* left_str, const char* right_str,
+  const char* op_str) {
+  std::stringstream ss;
+  ss << std::fixed << std::setw(20) << std::setprecision(20);//NOLINT:cppcoreguidelines-avoid-magic-numbers
+  debug_assert_print_impl(left, right, left_str, right_str, op_str, ss);
+  ss << "(The difference is " << ulps_distance(left, right) << " ULPs)\n";
+  return ss.str();
+}
+
+#define debug_assert3(what_happened, cond, msg)                                    \
+  do {                                                                             \
+    if (!(cond)) {                                                                 \
+      print_error(__FILE__, __LINE__, NA_FUNCTION, what_happened, #cond "\n" msg); \
+      debug_break();                                                               \
+    }                                                                              \
+  } while (0)
+
+#define debug_assert2(what_happened, cond)                                \
+  do {                                                                    \
+    if (!(cond)) {                                                        \
+      print_error(__FILE__, __LINE__, NA_FUNCTION, what_happened, #cond); \
+      debug_break();                                                      \
+    }                                                                     \
+  } while (0)
+
+#define debug_assert1(what_happened)                                 \
+  do {                                                               \
+    print_error(__FILE__, __LINE__, NA_FUNCTION, what_happened, ""); \
+    debug_break();                                                   \
+  } while (0)
+
+
+#define debug_assert_impl(...) MACRO_OVERLOAD(debug_assert, __VA_ARGS__)
+
+
+#define debug_assert_op(what_happened, left, right, op)                              \
+  do {                                                                               \
+    if (!(op(left, right))) {                                                        \
+      const auto msg = debug_assert_print(left, right, #left, #right, (op).c_str()); \
+      print_error(__FILE__, __LINE__, NA_FUNCTION, what_happened, (msg.c_str()));    \
+      debug_break();                                                                 \
+    }                                                                                \
+  } while (0)
+
+// clang-format off
+#define debug_assert(...) debug_assert_impl("Assertion failed", __VA_ARGS__)
+#define debug_assert_equal(left, right) debug_assert_op("Assertion failed", left, right, op_equal())
+#define debug_assert_not_equal(left, right) debug_assert_op("Assertion failed", left, right, op_not_equal())
+#define debug_assert_less(left, right) debug_assert_op("Assertion failed", left, right, op_less())
+#define debug_assert_less_equal(left, right) debug_assert_op("Assertion failed", left, right, op_less_equal())
+#define debug_assert_greater(left, right) debug_assert_op("Assertion failed", left, right, op_greater())
+#define debug_assert_greater_equal(left, right) debug_assert_op("Assertion failed", left, right, op_greater_equal())
+#define debug_assert_divisible_by(left, right) debug_assert_op("Assertion failed", left, right, op_divisible_by())
+
+#define precondition(...) debug_assert_impl("Precondition violated", __VA_ARGS__)
+#define precondition_equal(left, right) debug_assert_op("Precondition violated", left, right, op_equal())
+#define precondition_not_equal(left, right) debug_assert_op("Precondition violated", left, right, op_not_equal())
+#define precondition_less(left, right) debug_assert_op("Precondition violated", left, right, op_less())
+#define precondition_less_equal(left, right) debug_assert_op("Precondition violated", left, right, op_less_equal())
+#define precondition_greater(left, right) debug_assert_op("Precondition violated", left, right, op_greater())
+#define precondition_greater_equal(left, right) debug_assert_op("Precondition violated", left, right, op_greater_equal())
+#define precondition_divisible_by(left, right) debug_assert_op("Precondition violated", left, right, op_divisible_by())
+
+#define invariant(cond) debug_assert_impl("Invariant violated", cond)
+#define invariant_equal(left, right) debug_assert_op("Invariant violated", left, right, op_equal())
+#define invariant_not_equal(left, right) debug_assert_op("Invariant violated", left, right, op_not_equal())
+#define invariant_less(left, right) debug_assert_op("Invariant violated", left, right, op_less())
+#define invariant_less_equal(left, right) debug_assert_op("Invariant violated", left, right, op_less_equal())
+#define invariant_greater(left, right) debug_assert_op("Invariant violated", left, right, op_greater())
+#define invariant_greater_equal(left, right) debug_assert_op("Invariant violated", left, right, op_greater_equal())
+#define invariant_divisible_by(left, right) debug_assert_op("Invariant violated", left, right, op_divisible_by())
+
+#define postcondition(cond) debug_assert_impl("Postcondition violated", cond)
+#define postcondition_equal(left, right) debug_assert_op("Postcondition violated", left, right, op_equal())
+#define postcondition_not_equal(left, right) debug_assert_op("Postcondition violated", left, right, op_not_equal())
+#define postcondition_less(left, right) debug_assert_op("Postcondition violated", left, right, op_less())
+#define postcondition_less_equal(left, right) debug_assert_op("Postcondition violated", left, right, op_less_equal())
+#define postcondition_greater(left, right) debug_assert_op("Postcondition violated", left, right, op_greater())
+#define postcondition_greater_equal(left, right) debug_assert_op("Postcondition violated", left, right, op_greater_equal())
+#define postcondition_divisible_by(left, right) debug_assert_op("Postcondition violated", left, right, op_divisible_by())
+// clang-format on
+
+
+#else// not debug mode
+
+// clang-format off
+
+#define debug_assert(cond)
+#define debug_assert_equal(left, right) { (void)(left); (void)(right); }
+#define debug_assert_not_equal(left, right) { (void)(left); (void)(right); }
+#define debug_assert_less(left, right) { (void)(left); (void)(right); }
+#define debug_assert_less_equal(left, right) { (void)(left); (void)(right); }
+#define debug_assert_greater(left, right) { (void)(left); (void)(right); }
+#define debug_assert_greater_equal(left, right) { (void)(left); (void)(right); }
+#define debug_assert_divisible_by(left, right) { (void)(left); (void)(right); }
+
+#define precondition(cond)
+#define precondition_equal(left, right) { (void)(left); (void)(right); }
+#define precondition_not_equal(left, right) { (void)(left); (void)(right); }
+#define precondition_less(left, right) { (void)(left); (void)(right); }
+#define precondition_less_equal(left, right) { (void)(left); (void)(right); }
+#define precondition_greater(left, right) { (void)(left); (void)(right); }
+#define precondition_greater_equal(left, right) { (void)(left); (void)(right); }
+#define precondition_divisible_by(left, right) { (void)(left); (void)(right); }
+
+#define invariant(cond)
+#define invariant_equal(left, right) { (void)(left); (void)(right); }
+#define invariant_not_equal(left, right) { (void)(left); (void)(right); }
+#define invariant_less(left, right) { (void)(left); (void)(right); }
+#define invariant_less_equal(left, right) { (void)(left); (void)(right); }
+#define invariant_greater(left, right) { (void)(left); (void)(right); }
+#define invariant_greater_equal(left, right) { (void)(left); (void)(right); }
+#define invariant_divisible_by(left, right) { (void)(left); (void)(right); }
+
+#define postcondition(cond)
+#define postcondition_equal(left, right) { (void)(left); (void)(right); }
+#define postcondition_not_equal(left, right) { (void)(left); (void)(right); }
+#define postcondition_less(left, right) { (void)(left); (void)(right); }
+#define postcondition_less_equal(left, right) { (void)(left); (void)(right); }
+#define postcondition_greater(left, right) { (void)(left); (void)(right); }
+#define postcondition_greater_equal(left, right) { (void)(left); (void)(right); }
+#define postcondition_divisible_by(left, right) { (void)(left); (void)(right); }
+
+// clang-format on
+#endif
+
+#pragma clang diagnostic pop

--- a/packages/common/include/common/debugbreak.h
+++ b/packages/common/include/common/debugbreak.h
@@ -1,0 +1,142 @@
+#pragma once
+
+/**
+ * Taken with modifications from:
+ * https://github.com/scottt/debugbreak/blob/5d620814b1a240bbdf50c1dceed1eaf5a3fefce8/debugbreak.h
+ * Author: Scott Tsai (@scottt)
+ * License: BSD-2-Clause License
+ */
+
+/* Copyright (c) 2011-2018, Scott Tsai
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifdef _MSC_VER
+
+#define debug_break __debugbreak
+
+#else
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DEBUG_BREAK_USE_TRAP_INSTRUCTION 1
+#define DEBUG_BREAK_USE_BULTIN_TRAP 2
+#define DEBUG_BREAK_USE_SIGTRAP 3
+
+#if defined(__i386__) || defined(__x86_64__)
+
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
+#define trap_instruction() __asm__ volatile("int $0x03")
+
+#elif defined(__thumb__)
+
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
+/* FIXME: handle __THUMB_INTERWORK__ */
+#define trap_instruction() \
+  /* See 'arm-linux-tdep.c' in GDB source.
+	 * Both instruction sequences below work. */
+
+
+#if 1
+/* 'eabi_linux_thumb_le_breakpoint' */
+__asm__ volatile(".inst 0xde01");
+#else
+/* 'eabi_linux_thumb2_le_breakpoint' */
+__asm__ volatile(".inst.w 0xf7f0a000");
+#endif
+
+/* Known problem:
+	 * After a breakpoint hit, can't 'stepi', 'step', or 'continue' in GDB.
+	 * 'step' would keep getting stuck on the same instruction.
+	 *
+	 * Workaround: use the new GDB commands 'debugbreak-step' and
+	 * 'debugbreak-continue' that become available
+	 * after you source the script from GDB:
+	 *
+	 * $ gdb -x debugbreak-gdb.py <... USUAL ARGUMENTS ...>
+	 *
+	 * 'debugbreak-step' would jump over the breakpoint instruction with
+	 * roughly equivalent of:
+	 * (gdb) set $instruction_len = 2
+	 * (gdb) tbreak *($pc + $instruction_len)
+	 * (gdb) jump   *($pc + $instruction_len)
+	 */
+
+#elif defined(__arm__) && !defined(__thumb__)
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
+#define trap_instruction() \
+  /* See 'arm-linux-tdep.c' in GDB source,
+	 * 'eabi_linux_arm_le_breakpoint' */
+__asm__ volatile(".inst 0xe7f001f0");
+/* Known problem:
+	 * Same problem and workaround as Thumb mode */
+#elif defined(__aarch64__) && defined(__APPLE__)
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BULTIN_TRAP
+#elif defined(__aarch64__)
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
+#define trap_instruction() \
+  /* See 'aarch64-tdep.c' in GDB source,
+	 * 'aarch64_default_breakpoint' */
+__asm__ volatile(".inst 0xd4200000");
+#elif defined(__powerpc__)
+/* PPC 32 or 64-bit, big or little endian */
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
+#define trap_instruction() \
+  /* See 'rs6000-tdep.c' in GDB source,
+	 * 'rs6000_breakpoint' */
+__asm__ volatile(".4byte 0x7d821008");
+
+/* Known problem:
+	 * After a breakpoint hit, can't 'stepi', 'step', or 'continue' in GDB.
+	 * 'step' stuck on the same instruction ("twge r2,r2").
+	 *
+	 * The workaround is the same as ARM Thumb mode: use debugbreak-gdb.py
+	 * or manually jump over the instruction. */
+#else
+#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_SIGTRAP
+#endif
+
+
+#ifndef DEBUG_BREAK_IMPL
+#error "debugbreak.h is not supported on this target"
+#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_TRAP_INSTRUCTION
+#define debug_break() trap_instruction()
+#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_BULTIN_TRAP
+#define debug_break() __builtin_trap()
+#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_SIGTRAP
+#include <signal.h>
+#define debug_break() raise(SIGTRAP)
+#else
+#error "invalid DEBUG_BREAK_IMPL value"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ifdef _MSC_VER */

--- a/packages/common/include/common/ieee754_comparison.h
+++ b/packages/common/include/common/ieee754_comparison.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+
+inline int32_t twos_compliment(float left) {
+  int32_t l = *(reinterpret_cast<int32_t*>(&left));
+  if (l < 0)
+    l = 0x80000000 - l;
+  return l;
+}
+
+inline int64_t twos_compliment(double left) {
+  int64_t l = *(reinterpret_cast<int64_t*>(&left));
+  if (l < 0)
+    l = 0x8000000000000000 - l;
+  return l;
+}
+
+template<typename T>
+inline auto ulps_distance(const T& left, const T& right) {
+  auto l = twos_compliment(left);
+  auto r = twos_compliment(right);
+  return l - r;
+}
+
+template<typename T>
+inline bool almost_equal_impl(const T& left, const T& right, int ulps) {
+  return std::abs(ulps_distance(left, right)) <= ulps;
+}
+
+inline bool almost_equal(float left, float right, int ulps) {
+  return almost_equal_impl(left, right, ulps);
+}
+
+inline bool almost_equal(double left, double right, int ulps) {
+  return almost_equal_impl(left, right, ulps);
+}

--- a/packages/common/include/common/macro_overload.h
+++ b/packages/common/include/common/macro_overload.h
@@ -1,0 +1,24 @@
+#pragma once
+
+/**
+ * Taken with modifications from:
+ * https://stackoverflow.com/a/26408195
+ * Author: R1tschY
+ */
+
+// get number of arguments with __NARG__
+#define __NARG__(...) __NARG_I_(__VA_ARGS__, __RSEQ_N())
+#define __NARG_I_(...) __ARG_N(__VA_ARGS__)
+#define __ARG_N(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, \
+  _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, \
+  _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63, N, ...)                  \
+  N
+#define __RSEQ_N()                                                                                                     \
+  63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35,  \
+    34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, \
+    4, 3, 2, 1, 0
+
+// general definition for any function name
+#define _VFUNC_(name, n) name##n
+#define _VFUNC(name, n) _VFUNC_(name, n)
+#define MACRO_OVERLOAD(func, ...) _VFUNC(func, __NARG__(__VA_ARGS__))(__VA_ARGS__)

--- a/packages/common/src/common.cpp
+++ b/packages/common/src/common.cpp
@@ -1,0 +1,3 @@
+// Dummy file in order for CMake to pick up the package
+// without transforming it into header-only package.
+// Can be deleted once there is at least one real .cpp file.

--- a/packages/nextalign/CMakeLists.txt
+++ b/packages/nextalign/CMakeLists.txt
@@ -113,6 +113,9 @@ target_include_directories(${PROJECT_NAME}
   )
 
 target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  common
+
   PRIVATE
   Microsoft.GSL::GSL
   Boost::headers

--- a/packages/nextalign_cli/CMakeLists.txt
+++ b/packages/nextalign_cli/CMakeLists.txt
@@ -27,7 +27,7 @@ if (${NEXTALIGN_STATIC_BUILD} AND NOT APPLE)
     set(DEPENDENCIES
       ${DEPENDENCIES}
       jemalloc::jemalloc
-    )
+      )
   endif ()
 endif ()
 
@@ -79,6 +79,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
   nextalign
+  common
 
   PRIVATE
   ${STATIC_BUILD_FLAGS}

--- a/packages/nextclade/CMakeLists.txt
+++ b/packages/nextclade/CMakeLists.txt
@@ -164,6 +164,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+  common
   nextclade_json
   nextalign
 

--- a/packages/nextclade_cli/CMakeLists.txt
+++ b/packages/nextclade_cli/CMakeLists.txt
@@ -98,6 +98,9 @@ target_include_directories(${PROJECT_NAME} SYSTEM
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+  common
+  nextclade_common
+  nextclade
 
   PRIVATE
   ${STATIC_BUILD_FLAGS}
@@ -109,9 +112,6 @@ target_link_libraries(${PROJECT_NAME}
   fmt::fmt-header-only
   semver::semver
   ${DEPENDENCIES}
-
-  nextclade_common
-  nextclade
   )
 
 install(

--- a/packages/nextclade_json/CMakeLists.txt
+++ b/packages/nextclade_json/CMakeLists.txt
@@ -64,6 +64,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+  common
 
   PRIVATE
   Boost::headers

--- a/packages/nextclade_wasm/CMakeLists.txt
+++ b/packages/nextclade_wasm/CMakeLists.txt
@@ -71,6 +71,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+  common
   nextclade_json
   nextclade
 


### PR DESCRIPTION
As a part of cleanup efforts, let's introduce another package called "common".

This package will contain the functionality shared across all other packages. This will be mostly very generic and lightweight things, like small utilities and extensions to standard library. This package should not get any large dependencies.

This package is different from nextclade_common, which contains specific functionality, like datasets download, only used in nextclade and nextclade_wasm. We don't want to burden other packages with heavy dependencies, hence the new package.

Future work: we need to carefully pick the duplicated functionality and replace it with includes to this package.

