### PR TITLE
refactor: use safe_string and safe_string_view

### DIFF
--- a/packages/common/CMakeLists.txt
+++ b/packages/common/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(${PROJECT_NAME} STATIC
   include/common/debug_trace.h
   include/common/debugbreak.h
   include/common/ieee754_comparison.h
+  include/common/safe_string.h
+  include/common/safe_string_view.h
   include/common/safe_vector.h
   src/common.cpp
   )

--- a/packages/common/include/common/safe_string.h
+++ b/packages/common/include/common/safe_string.h
@@ -1,36 +1,35 @@
+#pragma once
+
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedStructInspection"
 #pragma ide diagnostic ignored "OCUnusedTypeAliasInspection"
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 
-#pragma once
 
 #include <algorithm>
 #include <memory>
-#include <vector>
+#include <string>
 
 #include "contract.h"
 #include "copy.h"
+#include "safe_string_view.h"
 
 
 /**
- * Wraps std::vector with some of the functionality removed and additional
- * debug checks (preconditions) added.
- *
- * Removed functionality:
- *
- *  - at(). Reason: operator[] provides faster access and there are
- *    preconditions in place to catch out-of-bounds accesses in debug mode.
- *
+ * Wraps std::basic_string with debug checks (preconditions) added.
+ * Only implements some of the methods, the ones we use.
  */
-template<typename T, typename Alloc = std::allocator<T>>
-class safe_vector {
-  using Base = std::vector<T, Alloc>;
+template<typename T, typename CharTraits = std::char_traits<T>, typename Alloc = std::allocator<T>>
+class safe_string {
+  using Base = std::basic_string<T, CharTraits, Alloc>;
   Base base;
 
 public:
-  template<typename Y, typename AllocY>
-  friend bool operator==(const safe_vector<Y, AllocY>& left, const safe_vector<Y, AllocY>& right);
+  template<typename Y, typename CharTraitsY, typename AllocY>
+  friend bool operator==(const safe_string<Y, CharTraitsY, AllocY>& left,
+    const safe_string<Y, CharTraitsY, AllocY>& right);
+
+  friend class safe_string_view<T, CharTraits>;
 
   using value_type = T;
   using size_type = typename Base::size_type;
@@ -45,64 +44,77 @@ public:
   using difference_type = typename Base::difference_type;
   using allocator_type = typename Base::allocator_type;
 
-  inline safe_vector() = default;
+  inline safe_string() = default;
 
-  inline explicit safe_vector(const std::vector<T, Alloc>& vec) noexcept : base(vec) {}
+  inline safe_string(const std::basic_string<T, CharTraits, Alloc>& str) noexcept : base(str) {}
 
-  inline explicit safe_vector(std::vector<T, Alloc>&& vec) noexcept : base(std::move(vec)) {}
+  inline safe_string(std::basic_string<T, CharTraits, Alloc>&& str) noexcept : base(std::move(str)) {}
 
-  inline explicit safe_vector(const allocator_type& allocator) noexcept : base(allocator) {}
+  inline safe_string(const safe_string_view<T, CharTraits>& strv) noexcept : base(strv.to_std()) {}
 
-  inline explicit safe_vector(size_type n, const allocator_type& allocator = allocator_type()) : base(n, allocator) {}
+  inline explicit safe_string(const T& t, const Alloc& alloc = Alloc()) : base(t, alloc) {}
 
-  inline safe_vector(size_type n, const value_type& value, const allocator_type& allocator = allocator_type())
+  inline explicit safe_string(const allocator_type& allocator) noexcept : base(allocator) {}
+
+  inline explicit safe_string(size_type n, const allocator_type& allocator = allocator_type()) : base(n, allocator) {}
+
+  inline safe_string(size_type n, const value_type& value, const allocator_type& allocator = allocator_type())
       : base(n, value, allocator) {}
 
-  inline safe_vector(const safe_vector& other) = default;
+  inline safe_string(const safe_string& other) = default;
 
-  inline safe_vector(safe_vector&&) noexcept = default;
+  inline safe_string(safe_string&&) noexcept = default;
 
-  inline safe_vector(const safe_vector& x, const allocator_type& allocator) : base(x, allocator) {}
+  inline safe_string(const safe_string& x, const allocator_type& allocator) : base(x, allocator) {}
 
-  inline safe_vector(safe_vector&& rv, const allocator_type& allocator) noexcept : base(std::move(rv), allocator) {}
+  inline safe_string(safe_string&& rv, const allocator_type& allocator) noexcept : base(std::move(rv), allocator) {}
 
-  inline safe_vector(std::initializer_list<value_type> list, const allocator_type& allocator = allocator_type())
+  inline safe_string(std::initializer_list<value_type> list, const allocator_type& allocator = allocator_type())
       : base(list, allocator) {}
 
   template<typename InputIterator>
-  inline safe_vector(InputIterator first, InputIterator last, const allocator_type& allocator = allocator_type())
+  inline safe_string(InputIterator first, InputIterator last, const allocator_type& allocator = allocator_type())
       : base(first, last, allocator) {}
 
-  inline ~safe_vector() noexcept = default;
+  inline ~safe_string() noexcept = default;
 
-  inline const std::vector<T, Alloc>& to_std() const {
+  operator safe_string_view<T, CharTraits>() const noexcept {// NOLINT(google-explicit-constructor)
+    return safe_string_view<T, CharTraits>{base.operator std::basic_string_view<T, CharTraits>()};
+  }
+
+  inline const std::basic_string<T, CharTraits, Alloc>& to_std() const {
     return base;
   }
 
-  inline std::vector<T, Alloc>& to_std_ref() {
+  inline std::basic_string<T, CharTraits, Alloc>& to_std_ref() {
     return base;
   }
 
-  inline void swap(safe_vector& other) {
+  inline void swap(safe_string& other) {
     using std::swap;
     base.swap(other.base);
   }
 
-  inline safe_vector& operator=(std::initializer_list<value_type> other) {
+  inline safe_string& operator=(T other) {
     base = other;
     return *this;
   }
 
-  inline safe_vector& operator=(const safe_vector& other) {
+  inline safe_string& operator=(std::initializer_list<value_type> other) {
+    base = other;
+    return *this;
+  }
+
+  inline safe_string& operator=(const safe_string& other) {
     using std::swap;
     if (this != &other) {
-      safe_vector other_copy = copy(other);
+      safe_string other_copy = copy(other);
       std::swap(base, other_copy.base);
     }
     return *this;
   }
 
-  inline safe_vector& operator=(safe_vector&& other) noexcept {
+  inline safe_string& operator=(safe_string&& other) noexcept {
     if (this != &other) {
       base = std::move(other.base);
     }
@@ -170,9 +182,14 @@ public:
     return base.crend();
   }
 
+  inline size_type length() const noexcept {
+    return size();
+  }
+
   inline size_type size() const noexcept {
     return base.size();
   }
+
 
   inline size_type max_size() const noexcept {
     return base.max_size();
@@ -286,17 +303,41 @@ public:
     base.clear();
   }
 
-  pointer data() noexcept {
+  inline pointer data() noexcept {
     return base.data();
   }
 
-  const_pointer data() const noexcept {
+  inline const_pointer data() const noexcept {
     return base.data();
+  }
+
+  inline safe_string substr(size_type pos = 0, size_type n = Base::npos) const noexcept(false) {
+    return base.substr(pos, n);
+  }
+
+  inline safe_string operator+=(const safe_string& other) {
+    return base.operator+=(other);
+  }
+
+  inline safe_string operator+=(const T c) {
+    return base.operator+=(c);
+  }
+
+  inline safe_string operator+=(const T* cp) {
+    return base.operator+=(cp);
+  }
+
+  inline size_type find(const std::basic_string<T, CharTraits, Alloc>& str, size_type pos = 0) const noexcept {
+    return base.find(str, pos);
+  }
+
+  inline size_type find(const T* c, size_type pos = 0) const noexcept {
+    return base.find(c, pos);
   }
 };
 
-template<typename T, typename Alloc>
-bool operator==(const safe_vector<T, Alloc>& left, const safe_vector<T, Alloc>& right) {
+template<typename T, typename CharTraits, typename Alloc>
+bool operator==(const safe_string<T, CharTraits, Alloc>& left, const safe_string<T, CharTraits, Alloc>& right) {
   return left.base == right.base;
 }
 

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -1,6 +1,9 @@
 #pragma once
 
 
+#include <common/safe_string.h>
+#include <common/safe_vector.h>
+
 #include <algorithm>
 #include <boost/algorithm/string/join.hpp>
 #include <istream>
@@ -10,7 +13,6 @@
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <common/safe_vector.h>
 
 
 /**
@@ -135,10 +137,10 @@ public:
 
 
 template<typename Letter>
-using Sequence = std::basic_string<Letter>;
+using Sequence = safe_string<Letter>;
 
 template<typename Letter>
-using SequenceView = std::basic_string_view<Letter>;
+using SequenceView = safe_string_view<Letter>;
 
 enum class Nucleotide : char {
   U = 0,

--- a/packages/nextalign/src/alphabet/aminoacids.cpp
+++ b/packages/nextalign/src/alphabet/aminoacids.cpp
@@ -1,12 +1,12 @@
 #include "aminoacids.h"
 
+#include <common/contract.h>
 #include <fmt/format.h>
 #include <frozen/map.h>
 
 #include <stdexcept>
 
 #include "../utils/contains.h"
-#include <common/contract.h>
 #include "../utils/map.h"
 #include "../utils/safe_cast.h"
 
@@ -117,5 +117,5 @@ AminoacidSequence toAminoacidSequence(const std::string& seq) {
 }
 
 std::string toString(const AminoacidSequence& seq) {
-  return map(seq, std::function<char(Aminoacid)>(aaToChar));
+  return map(seq, std::function<char(Aminoacid)>(aaToChar)).to_std();
 }

--- a/packages/nextalign/src/alphabet/nucleotides.cpp
+++ b/packages/nextalign/src/alphabet/nucleotides.cpp
@@ -96,5 +96,5 @@ NucleotideSequence toNucleotideSequence(const std::string& seq) {
 }
 
 std::string toString(const NucleotideSequence& seq) {
-  return map(seq, std::function<char(Nucleotide)>(nucToChar));
+  return map(seq, std::function<char(Nucleotide)>(nucToChar)).to_std();
 }

--- a/packages/nextalign/src/translate/decode.cpp
+++ b/packages/nextalign/src/translate/decode.cpp
@@ -149,7 +149,7 @@ constexpr const frozen::map<NucleotideSequenceFrozen, Aminoacid, 65> codonTable 
 Aminoacid decode(const NucleotideSequenceView& codon) {
   invariant_equal(3, codon.size());
 
-  const auto* it = codonTable.find(codon);
+  const auto* it = codonTable.find(codon.to_std());
   if (it != codonTable.end()) {
     return it->second;
   }

--- a/packages/nextalign/src/translate/extractGene.cpp
+++ b/packages/nextalign/src/translate/extractGene.cpp
@@ -1,9 +1,8 @@
 #include "extractGene.h"
 
+#include <common/safe_vector.h>
 #include <frozen/string.h>
 #include <nextalign/nextalign.h>
-
-#include <common/safe_vector.h>
 
 #include "../align/alignPairwise.h"
 #include "../utils/at.h"
@@ -12,15 +11,6 @@
 #include "mapCoordinates.h"
 
 namespace details {
-  template<typename IntS, typename IntL>
-  inline NucleotideSequenceView substr(const NucleotideSequenceView& s, IntS start, IntL length) noexcept(false) {
-    invariant_greater_equal(start, 0);
-    invariant_less(start, s.size());
-    invariant_greater_equal(length, 0);
-    invariant_less_equal(start + length, s.size());
-    return s.substr(safe_cast<size_t>(start), safe_cast<size_t>(length));
-  }
-
   template<typename IntS, typename IntL>
   inline NucleotideSequenceSpan subspan(const NucleotideSequenceSpan& s, IntS start, IntL length) {
     invariant_greater_equal(start, 0);
@@ -85,7 +75,7 @@ ExtractGeneStatus extractGeneQuery(const NucleotideSequenceView& query, const Ge
   invariant_less(geneAln.begin, query.size());
   invariant_less_equal(geneAln.end, query.size());
 
-  auto result = NucleotideSequence(details::substr(query, geneAln.begin, geneAln.length()));
+  auto result = NucleotideSequence(query.substr(geneAln.begin, geneAln.length()));
   const auto resultLength = safe_cast<int>(result.size());
 
   if (resultLength == 0) {

--- a/packages/nextalign/src/utils/map.h
+++ b/packages/nextalign/src/utils/map.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <common/safe_string.h>
+#include <common/safe_vector.h>
+
 #include <algorithm>
 #include <functional>
 #include <string>
-#include <common/safe_vector.h>
+
 
 //template<typename Input, typename Output, template<typename> typename Container>
 //Container<Output> map(const Container<Input>& input, std::function<Output(Input)> op) {
@@ -12,6 +15,14 @@
 //  std::transform(input.cbegin(), input.cend(), std::back_inserter(result), op);
 //  return result;
 //}
+
+template<typename Input, typename Output>
+inline safe_string<Output> map(const safe_string<Input>& input, std::function<Output(Input)> op) {
+  safe_string<Output> result = {};
+  result.reserve(input.size());
+  std::transform(input.cbegin(), input.cend(), std::back_inserter(result), op);
+  return result;
+}
 
 template<typename Input, typename Output>
 inline std::basic_string<Output> map(const std::basic_string<Input>& input, std::function<Output(Input)> op) {


### PR DESCRIPTION
Simlarly to https://github.com/nextstrain/nextclade/pull/671, adds wrappers for string classes. Only used for sequence data.

