### PR TITLE
fix: undefined behavior in tree json acccess

### DIFF
--- a/packages/nextclade/src/tree/Tree.cpp
+++ b/packages/nextclade/src/tree/Tree.cpp
@@ -54,14 +54,7 @@ namespace Nextclade {
             divergenceUnitsInt)) {}
   };
 
-  const json& get(const json& js, const std::string& key, const json& defaultValue = json::object()) {
-    if (!js.contains(key)) {
-      return defaultValue;
-    }
-    return js.at(key);
-  }
-
-  json& get(json& js, const std::string& key, const json& defaultValue = json::object()) {
+  json& get(json& js, const std::string& key, const json& defaultValue) {
     if (!js.contains(key)) {
       js[key] = defaultValue;
     }
@@ -97,10 +90,16 @@ namespace Nextclade {
       if (!j.is_object()) {
         throw ErrorAuspiceJsonV2Invalid(j);
       }
-      const auto& meta = get(j, "meta", json::object());
-      const auto& metaExtensions = get(meta, "extensions", json::object());
-      const auto& nextcladeMetaExtensions = get(metaExtensions, "nextclade", json::object());
-      const auto& cladeNodeAttrKeysJson = get(nextcladeMetaExtensions, "clade_node_attrs_keys", json::array());
+
+      const auto ptr = json_pointer{"/meta/extensions/nextclade/clade_node_attrs_keys"};
+      if (!j.contains(ptr)) {
+        return {};
+      }
+
+      const auto& cladeNodeAttrKeysJson = j.at(ptr);
+      if (!cladeNodeAttrKeysJson.is_array()) {
+        return {};
+      }
 
       std::vector<std::string> cladeNodeAttrKeys;
       for (const auto& key : cladeNodeAttrKeysJson) {


### PR DESCRIPTION
**HOTFIX** goes directly to staging and release, to bypass unreleased master. Reason: urgent fix for a 100% guaranteed crash in production Nextclade CLI.

In case where the key is not present the const version of the get function:

```
const json& get(...) const
```
was returning `defaultValue` which is a reference to a temporary, and hence was destroyed after return, thus the returned reference was dangling.

Here I remove the get function, and move conditionals to the caller. I also simplify the chained access with a json pointer.

