### PR TITLE
fix: off-by-one and illegal array access in findCharacterRanges

### DIFF
--- a/packages/nextclade/src/analyze/findNucleotideRanges.cpp
+++ b/packages/nextclade/src/analyze/findNucleotideRanges.cpp
@@ -1,10 +1,9 @@
 #include "findNucleotideRanges.h"
 
+#include <common/safe_vector.h>
 #include <nextalign/nextalign.h>
 #include <nextclade/nextclade.h>
 #include <nextclade/private/nextclade_private.h>
-
-#include <common/safe_vector.h>
 
 #include "analyze/calculateTotalLength.h"
 #include "utils/safe_cast.h"
@@ -12,6 +11,15 @@
 
 namespace Nextclade {
 
+  /**
+   * Finds contiguous ranges (segments) in the sequence, such that for every character inside every range,
+   * the predicate function returns true and every range contains only the same letter.
+   *
+   * The predicate is a function that takes a character and returns boolean.
+   *
+   * For example if predicate returns `true` for characters A and C, this function will find ranges `AAAA` and `CCCCC`,
+   * but not `ZZZ` or `ACCCAC`.
+   */
   template<typename Letter>
   safe_vector<CharacterRange<Letter>> findCharacterRanges(const Sequence<Letter>& str,
     const std::function<bool(const Letter&)>& pred) {
@@ -24,25 +32,28 @@ namespace Nextclade {
     while (i < length) {
       auto c = str[i];
 
-      // find beginning of matching range
+      // Find beginning of a range
       if (pred(c)) {
         begin = i;
         found = c;
       }
 
+      // If there's a current range we are working on (for which we found a `begin`), extend it
       if (found) {
-        // rewind forward to the end of matching range
-        // TODO: the `i < length` was added to avoid buffer overrun. Double-check algorithmic correctness.
+        // Rewind forward until we find a mismatch
         while (i < length && str[i] == *found) {
           ++i;
         }
 
+        // We found the end of the current range, so now it's complete
         const auto& end = i;
+
+        // Remember the range
         result.push_back(
           CharacterRange<Letter>{.begin = begin, .end = end, .length = end - begin, .character = *found});
-        found = {};
 
-        // TODO: the `i < length` was added to avoid buffer overrun. Double-check algorithmic correctness.
+        // Set current range to `nullopt`, meaning there is no current range we are working on
+        found = {};
       } else if (i < length) {
         ++i;
       }
@@ -51,24 +62,42 @@ namespace Nextclade {
     return result;
   }
 
+  /**
+   * Finds contiguous ranges (segments) in the sequence. Version for nucleotide sequences.
+   * See the detailed explanation for the generic version above.
+   */
   safe_vector<NucleotideRange> findNucleotideRanges(const NucleotideSequence& str,
     const std::function<bool(const Nucleotide&)>& pred) {
     return findCharacterRanges<Nucleotide>(str, pred);
   }
 
+  /**
+   * Finds contiguous ranges (segments) of a particular nucleotide in nucleotide sequence.
+   */
   safe_vector<NucleotideRange> findNucleotideRanges(const NucleotideSequence& str, Nucleotide nuc) {
     return findNucleotideRanges(str, [&nuc](const Nucleotide& candidate) { return candidate == nuc; });
   }
 
+  /**
+   * Finds contiguous ranges (segments) in the sequence. Version for aminoacid sequences.
+   * See the detailed explanation for the generic version above.
+   */
   safe_vector<AminoacidRange> findAminoacidRanges(const AminoacidSequence& str,
     const std::function<bool(const Aminoacid&)>& pred) {
     return findCharacterRanges<Aminoacid>(str, pred);
   }
 
+  /**
+   * Finds contiguous ranges (segments) of a particular aminoacid in aminoacid sequence.
+   */
   safe_vector<AminoacidRange> findAminoacidRanges(const AminoacidSequence& str, Aminoacid aa) {
     return findAminoacidRanges(str, [&aa](const Aminoacid& candidate) { return candidate == aa; });
   }
 
+  /**
+   * Finds contiguous ranges (segments) of a particular aminoacid in each gene.
+   * See explanation for `findAminoacidRanges()` above.
+   */
   safe_vector<GeneAminoacidRange> findAminoacidRangesPerGene(const safe_vector<PeptideInternal>& peptides,
     Aminoacid aa) {
     safe_vector<GeneAminoacidRange> geneAminoacidRanges;

--- a/packages/nextclade/src/analyze/findNucleotideRanges.cpp
+++ b/packages/nextclade/src/analyze/findNucleotideRanges.cpp
@@ -33,9 +33,8 @@ namespace Nextclade {
       if (found) {
         // rewind forward to the end of matching range
         // TODO: the `i < length` was added to avoid buffer overrun. Double-check algorithmic correctness.
-        while ((c == *found) && (i < length)) {
+        while (i < length && str[i] == *found) {
           ++i;
-          c = str[i];
         }
 
         const auto& end = i;


### PR DESCRIPTION
In the inner loop we check for `i < length` but then `i++` and then access the array with this `i` . So it read at least 1 character after the end.

I modified this loop to not go off by 1 and also simplified it.

Before:
https://github.com/nextstrain/nextclade/blob/7e48d224b6c4782f48b8347201c1355430b0a4f1/packages/nextclade/src/analyze/findNucleotideRanges.cpp#L34-L39

After:
https://github.com/nextstrain/nextclade/blob/f85e2b8c600b289c7be1d22788757a2c070a334a/packages/nextclade/src/analyze/findNucleotideRanges.cpp#L43-L46


Tests are passing unmodified and it no longer crashes on sample data.

Additionally, following the boy-scout rule: "Always leave the campground cleaner than you found it", I removed unnecessary comments and added doc comments.

