### PR TITLE
fix: enforce precondition on stripped sequences, replace invalid test

### DIFF
--- a/packages/nextclade/src/__tests__/findNucChanges.test.cpp
+++ b/packages/nextclade/src/__tests__/findNucChanges.test.cpp
@@ -1,10 +1,10 @@
 #include "../analyze/findNucChanges.h"
 
+#include <common/safe_vector.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <string>
-#include <common/safe_vector.h>
 
 #include "../../include/nextclade/nextclade.h"
 #include "../../include/nextclade/private/nextclade_private.h"
@@ -19,14 +19,14 @@ TEST(FindNucChanges, ReportsAlignmentStartAndEnd) {
   std::stringstream input;
 
   // clang-format off
-  const auto ref   = toNucleotideSequence(      "AAA"      );
-  const auto query = toNucleotideSequence("---" "AAA" "---");
-  // clang-format on                       012   345   678
+  const auto ref   = toNucleotideSequence("ACGTCAGTG");
+  const auto query = toNucleotideSequence("--CTC-GT-");
+  // clang-format on                       012345678
 
   const auto results = findNucChanges(ref, query);
 
-  EXPECT_EQ(3, results.alignmentStart);
-  EXPECT_EQ(6, results.alignmentEnd);
+  EXPECT_EQ(2, results.alignmentStart);
+  EXPECT_EQ(8, results.alignmentEnd);
 }
 
 TEST(FindNucChanges, ReportsSubstitutions) {

--- a/packages/nextclade/src/analyze/findNucChanges.cpp
+++ b/packages/nextclade/src/analyze/findNucChanges.cpp
@@ -7,10 +7,18 @@
 
 
 namespace Nextclade {
+  /**
+   * Finds nucleotide changes (nucleotide substitutions and deletions) as well
+   * as the beginning and end of the alignment range.
+   *
+   * @pre Precondition: sequences are expected to be stripped from insertions.
+   */
   NucleotideChangesReport findNucChanges(  //
     const NucleotideSequence& refStripped, //
     const NucleotideSequence& queryStripped//
   ) {
+    precondition_equal(refStripped.length(), queryStripped.length());
+
     int nDel = 0;
     int delPos = -1;
     bool beforeAlignment = true;


### PR DESCRIPTION
The test `ReportsAlignmentStartAndEnd`
https://github.com/nextstrain/nextclade/blob/b007490e0107a07b65534b175a4ffd6350685963/packages/nextclade/src/__tests__/findNucChanges.test.cpp#L22-L26
was crashing here
https://github.com/nextstrain/nextclade/blob/b007490e0107a07b65534b175a4ffd6350685963/packages/nextclade/src/analyze/findNucChanges.cpp#L40
accesing string `refStripped` at index 3 while it's  length is 3.

This is caused by the fact that the function assumes that query and ref sequences have the same length and cab be indexed in unison, but in the test they were different length.

This should have never happened, as the function is meant to be used on stripped sequences.

We don't want to add any runtime checks for performance reasons, and Nextclade only has access to stripped sequences as of now. But I added a precondition to check that the query and ref lengths are equal.

I also replaced the invalid test with what Richard suggested, and that test resembles the reality a bit more and most importantly does not crash.

Also added a doc comment to the function, because why not.
