### PR TITLE
fix: use safe containers only in dev mode

### DIFF
--- a/packages/common/include/common/safe_string.h
+++ b/packages/common/include/common/safe_string.h
@@ -1,18 +1,21 @@
 #pragma once
 
+#include <string>
+
+#include "safe_string_view.h"
+
+#if !defined(NDEBUG)
+
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedStructInspection"
 #pragma ide diagnostic ignored "OCUnusedTypeAliasInspection"
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 
-
 #include <algorithm>
 #include <memory>
-#include <string>
 
 #include "contract.h"
 #include "copy.h"
-#include "safe_string_view.h"
 
 
 /**
@@ -342,3 +345,10 @@ bool operator==(const safe_string<T, CharTraits, Alloc>& left, const safe_string
 }
 
 #pragma clang diagnostic pop
+
+#else
+
+template<typename T, typename CharTraits = std::char_traits<T>, typename Alloc = std::allocator<T>>
+using safe_string = std::basic_string<T, CharTraits, Alloc>;
+
+#endif

--- a/packages/common/include/common/safe_string_view.h
+++ b/packages/common/include/common/safe_string_view.h
@@ -1,20 +1,23 @@
+#pragma once
+
+#include <string_view>
+
+#if !defined(NDEBUG)
+
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedStructInspection"
 #pragma ide diagnostic ignored "OCUnusedTypeAliasInspection"
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 
-#pragma once
-
 #include <algorithm>
 #include <memory>
-#include <string_view>
 
 #include "contract.h"
 #include "copy.h"
 
 
 /**
- * Wraps std::basic_string with debug checks (preconditions) added.
+ * Wraps std::basic_string_view with debug checks (preconditions) added.
  * Only implements some of the methods, the ones we use.
  */
 template<typename T, typename CharTraits = std::char_traits<T>>
@@ -277,6 +280,10 @@ public:
   inline safe_string_view substr(size_type pos = 0, size_type n = Base::npos) const noexcept(false) {
     return base.substr(pos, n);
   }
+
+  inline operator std::basic_string_view<T, CharTraits>() const {// NOLINT(google-explicit-constructor)
+    return base;
+  }
 };
 
 template<typename T, typename CharTraits>
@@ -285,3 +292,10 @@ bool operator==(const safe_string_view<T, CharTraits>& left, const safe_string_v
 }
 
 #pragma clang diagnostic pop
+
+#else
+
+template<typename T, typename CharTraits = std::char_traits<T>>
+using safe_string_view = std::basic_string_view<T, CharTraits>;
+
+#endif

--- a/packages/common/include/common/safe_vector.h
+++ b/packages/common/include/common/safe_vector.h
@@ -1,16 +1,19 @@
+#pragma once
+
+#include <vector>
+
+#if !defined(NDEBUG)
+
+#include <algorithm>
+#include <memory>
+
+#include "contract.h"
+#include "copy.h"
+
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedStructInspection"
 #pragma ide diagnostic ignored "OCUnusedTypeAliasInspection"
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
-
-#pragma once
-
-#include <algorithm>
-#include <memory>
-#include <vector>
-
-#include "contract.h"
-#include "copy.h"
 
 
 /**
@@ -286,12 +289,16 @@ public:
     base.clear();
   }
 
-  pointer data() noexcept {
+  inline pointer data() noexcept {
     return base.data();
   }
 
-  const_pointer data() const noexcept {
+  inline const_pointer data() const noexcept {
     return base.data();
+  }
+
+  inline operator std::vector<T, Alloc>() const noexcept {
+    return base;
   }
 };
 
@@ -301,3 +308,10 @@ bool operator==(const safe_vector<T, Alloc>& left, const safe_vector<T, Alloc>& 
 }
 
 #pragma clang diagnostic pop
+
+#else
+
+template<typename T, typename Alloc = std::allocator<T>>
+using safe_vector = std::vector<T, Alloc>;
+
+#endif

--- a/packages/nextalign/src/alphabet/aminoacids.cpp
+++ b/packages/nextalign/src/alphabet/aminoacids.cpp
@@ -117,5 +117,5 @@ AminoacidSequence toAminoacidSequence(const std::string& seq) {
 }
 
 std::string toString(const AminoacidSequence& seq) {
-  return map(seq, std::function<char(Aminoacid)>(aaToChar)).to_std();
+  return map(seq, std::function<char(Aminoacid)>(aaToChar));
 }

--- a/packages/nextalign/src/alphabet/nucleotides.cpp
+++ b/packages/nextalign/src/alphabet/nucleotides.cpp
@@ -96,5 +96,5 @@ NucleotideSequence toNucleotideSequence(const std::string& seq) {
 }
 
 std::string toString(const NucleotideSequence& seq) {
-  return map(seq, std::function<char(Nucleotide)>(nucToChar)).to_std();
+  return map(seq, std::function<char(Nucleotide)>(nucToChar));
 }

--- a/packages/nextalign/src/translate/decode.cpp
+++ b/packages/nextalign/src/translate/decode.cpp
@@ -149,7 +149,7 @@ constexpr const frozen::map<NucleotideSequenceFrozen, Aminoacid, 65> codonTable 
 Aminoacid decode(const NucleotideSequenceView& codon) {
   invariant_equal(3, codon.size());
 
-  const auto* it = codonTable.find(codon.to_std());
+  const auto* it = codonTable.find(codon);
   if (it != codonTable.end()) {
     return it->second;
   }

--- a/packages/nextalign/src/utils/map.h
+++ b/packages/nextalign/src/utils/map.h
@@ -16,6 +16,7 @@
 //  return result;
 //}
 
+#ifdef DEBUG
 template<typename Input, typename Output>
 inline safe_string<Output> map(const safe_string<Input>& input, std::function<Output(Input)> op) {
   safe_string<Output> result = {};
@@ -23,6 +24,7 @@ inline safe_string<Output> map(const safe_string<Input>& input, std::function<Ou
   std::transform(input.cbegin(), input.cend(), std::back_inserter(result), op);
   return result;
 }
+#endif
 
 template<typename Input, typename Output>
 inline std::basic_string<Output> map(const std::basic_string<Input>& input, std::function<Output(Input)> op) {

--- a/packages/nextclade/src/analyze/findNucChanges.cpp
+++ b/packages/nextclade/src/analyze/findNucChanges.cpp
@@ -1,5 +1,6 @@
 #include "findNucChanges.h"
 
+#include <common/contract.h>
 #include <common/safe_vector.h>
 
 #include "nucleotide.h"

--- a/packages/nextclade/src/io/CsvWriter.cpp
+++ b/packages/nextclade/src/io/CsvWriter.cpp
@@ -153,7 +153,7 @@ namespace Nextclade {
       const auto& rowName = numRows;
       const auto numColumns = columnNames.size();
       const safe_vector<std::string> rowData(numColumns, "");
-      doc.InsertRow<std::string>(numRows, rowData.to_std());
+      doc.InsertRow<std::string>(numRows, rowData);
 
       doc.SetCell(getColumnIndex("seqName"), rowName, result.seqName);
       doc.SetCell(getColumnIndex("clade"), rowName, result.clade);


### PR DESCRIPTION
Since introduction of `safe_vector`, `safe_string` and `save_string_view` classes in  https://github.com/nextstrain/nextclade/pull/671 and https://github.com/nextstrain/nextclade/pull/672, we've observed slowdown on master branch compared to the previous release.

Despite the safe containers being thin wrappers around std containers, they might have introduced an unwanted copy or function call, or perhaps overload resolution does not work the same way and less efficient code is generated.

In any case, these containers are only useful during debugging, so let's conditionally compile them only in debug mode, and alias to std containers in release builds.

