### PR TITLE
fix: fix compiler error in dev mode

### DIFF
--- a/packages/common/include/common/safe_string.h
+++ b/packages/common/include/common/safe_string.h
@@ -81,15 +81,15 @@ public:
 
   inline ~safe_string() noexcept = default;
 
-  operator safe_string_view<T, CharTraits>() const noexcept {// NOLINT(google-explicit-constructor)
+  inline operator safe_string_view<T, CharTraits>() const noexcept {// NOLINT(google-explicit-constructor)
     return safe_string_view<T, CharTraits>{base.operator std::basic_string_view<T, CharTraits>()};
   }
 
-  inline const std::basic_string<T, CharTraits, Alloc>& to_std() const {
+  inline operator const std::basic_string<T, CharTraits, Alloc>&() const {// NOLINT(google-explicit-constructor)
     return base;
   }
 
-  inline std::basic_string<T, CharTraits, Alloc>& to_std_ref() {
+  inline operator std::basic_string<T, CharTraits, Alloc>&() {// NOLINT(google-explicit-constructor)
     return base;
   }
 

--- a/packages/nextalign/src/translate/decode.cpp
+++ b/packages/nextalign/src/translate/decode.cpp
@@ -149,7 +149,7 @@ constexpr const frozen::map<NucleotideSequenceFrozen, Aminoacid, 65> codonTable 
 Aminoacid decode(const NucleotideSequenceView& codon) {
   invariant_equal(3, codon.size());
 
-  const auto* it = codonTable.find(codon);
+  const auto* it = codonTable.find(NucleotideSequenceFrozen{codon});
   if (it != codonTable.end()) {
     return it->second;
   }


### PR DESCRIPTION
I overlooked a couple of places in https://github.com/nextstrain/nextclade/pull/678 and it did not manifest due to conditional compilation. This adds the 2 remaining conversions from safe containers back to std containers. Only relevant in dev mode.

