### PR TITLE
feat: skip alignment of empty peptides

### DIFF
--- a/packages/nextalign/src/translate/translateGenes.cpp
+++ b/packages/nextalign/src/translate/translateGenes.cpp
@@ -152,6 +152,15 @@ PeptidesInternal translateGenes(                               //
     debug_trace("Translating gene '{:}'\n", geneName);
     const auto queryPeptide = translate(queryGeneSeq, options.translatePastStop);
 
+    // Bail out if the peptide is empty
+    if (queryPeptide.empty()) {
+      const auto message = fmt::format(
+        "When processing gene \"{:s}\". Translated peptide is empty. "
+        "Note that this gene will not be included in the results of the sequence.",
+        geneName);
+      warnings.inGenes.push_back(GeneWarning{.geneName = geneName, .message = message});
+      continue;
+    }
 
     debug_trace("Aligning peptide '{:}'\n", geneName);
     const AlignmentParams alignmentParams = calculateAaAlignmentParams(queryGapCounts, refGapCounts);


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/674

We skip alignment of empty peptides entirely and issue a warning. To be consistent with behavior of nucleotide alignment and to not cause any additional troubles in the alignment code.
