### PR TITLE
fix: exit with correct exit code on exceptions

### DIFF
--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -885,12 +885,8 @@ int main(int argc, char *argv[]) {
     logger.info("| {:5s} | {:40s} | {:16s} | {:12s} |", "Index", "Seq. name", "Align. score", "Insertions");
     logger.info("{:s}", std::string(TABLE_WIDTH, '-'));
 
-    try {
-      run(parallelism, inOrder, fastaStream, refData, geneMap, options, outputFastaFile, outputInsertionsFile,
-        outputErrorsFile, outputGeneFiles, shouldWriteReference, logger);
-    } catch (const std::exception &e) {
-      logger.error("Error: {:>16s} |\n", e.what());
-    }
+    run(parallelism, inOrder, fastaStream, refData, geneMap, options, outputFastaFile, outputInsertionsFile,
+      outputErrorsFile, outputGeneFiles, shouldWriteReference, logger);
 
     logger.info("{:s}", std::string(TABLE_WIDTH, '-'));
   } catch (const std::exception &e) {

--- a/packages/nextclade_cli/src/commands/executeCommandRun.cpp
+++ b/packages/nextclade_cli/src/commands/executeCommandRun.cpp
@@ -166,13 +166,9 @@ namespace Nextclade {
 
       NextalignOptions options = cliOptionsToNextalignOptions(*cliParams);
 
-      try {
-        runNextclade(parallelism, inOrder, inputFastaStream, refData, qcRulesConfig, treeString, pcrPrimers, geneMap,
-          options, outputJsonStream, outputCsvStream, outputTsvStream, outputTreeStream, outputFastaStream,
-          outputInsertionsStream, outputErrorsFile, outputGeneStreams, shouldWriteReference, logger);
-      } catch (const std::exception& e) {
-        logger.error("Error: {:>16s} |", e.what());
-      }
+      runNextclade(parallelism, inOrder, inputFastaStream, refData, qcRulesConfig, treeString, pcrPrimers, geneMap,
+        options, outputJsonStream, outputCsvStream, outputTsvStream, outputTreeStream, outputFastaStream,
+        outputInsertionsStream, outputErrorsFile, outputGeneStreams, shouldWriteReference, logger);
 
       logger.info("{:s}", std::string(TABLE_WIDTH, '-'));
     } catch (const std::exception& e) {


### PR DESCRIPTION
It could be that some of the exceptions that occurred in Nextclade and Nextalign libraries were handled, but then the program execution would end with the default implicit 0 exit code returned from main. This was due to a redundant forgotten extra try-catch block.

This removes this try-catch block, so that the exceptions are routed to the correct outer catch clause, which exits with code 1.

Resolves https://github.com/nextstrain/nextclade/issues/679