### PR TITLE
fix: sanitize parsed sequences correctly

### DIFF
--- a/packages/nextalign/CMakeLists.txt
+++ b/packages/nextalign/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(${PROJECT_NAME} STATIC
   src/io/parseGeneMapGff.cpp
   src/io/parseSequences.cpp
   src/io/parseSequencesSlow.cpp
+  src/io/sanitizeSequence.cpp
   src/match/matchAa.h
   src/match/matchNuc.h
   src/nextalign.cpp

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -389,6 +389,8 @@ inline bool isUnknown(const Aminoacid& aa) {
   return aa == Aminoacid::N;
 }
 
+std::string sanitizeSequenceString(const std::string& str);
+
 class FastaStream {
 public:
   FastaStream() = default;

--- a/packages/nextalign/src/io/kseqpp.h
+++ b/packages/nextalign/src/io/kseqpp.h
@@ -61,10 +61,6 @@ namespace klibpp {
 
     int64_t index = 0;
 
-    inline bool is_char_allowed(char_type c) {
-      return std::isalpha(c) || c == '.' || c == '?' || c == '*';
-    }
-
   public:
     explicit KStream(Reader reader_) : reader(std::move(reader_)) {
       this->buf.resize(DEFAULT_BUFSIZE);
@@ -120,10 +116,9 @@ namespace klibpp {
       }
 
       while ((c = this->getc()) && c != '>') {
-        if (!is_char_allowed(c)) {
+        if (c == '\n') {
           continue;
         }
-        c = static_cast<char_type>(std::toupper(c));
         rec.seq += c;
         this->getuntil(KStream::SEP_LINE, rec.seq, nullptr, true);// read the rest of the line
       }

--- a/packages/nextalign/src/io/sanitizeSequence.cpp
+++ b/packages/nextalign/src/io/sanitizeSequence.cpp
@@ -1,0 +1,24 @@
+#include <nextalign/nextalign.h>
+
+#include <cctype>
+#include <string>
+
+#include "../utils/safe_cast.h"
+
+namespace {
+  inline bool is_char_allowed(char c) {
+    return std::isalpha(c) || c == '.' || c == '?' || c == '*';
+  }
+}// namespace
+
+std::string sanitizeSequenceString(const std::string& str) {
+  std::string output;
+  output.reserve(str.size());
+  for (char c : str) {
+    if (is_char_allowed(c)) {
+      output += safe_cast<char>(std::toupper(c));
+    }
+  }
+  output.shrink_to_fit();
+  return output;
+}

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -697,7 +697,7 @@ void run(
   const auto transformFilters = tbb::make_filter<AlgorithmInput, AlgorithmOutput>(tbb::filter_mode::parallel,//
     [&ref, &refPeptides, &geneMap, &options](const AlgorithmInput &input) -> AlgorithmOutput {
       try {
-        const auto query = toNucleotideSequence(input.seq);
+        const auto query = toNucleotideSequence(sanitizeSequenceString(input.seq));
         const auto result = nextalignInternal(query, ref, refPeptides, geneMap, options);
         return {.index = input.index, .seqName = input.seqName, .hasError = false, .result = result, .error = nullptr};
       } catch (const std::exception &e) {

--- a/packages/nextclade_cli/src/algorithm/runNextclade.cpp
+++ b/packages/nextclade_cli/src/algorithm/runNextclade.cpp
@@ -104,7 +104,7 @@ namespace Nextclade {
         const auto &seqName = input.seqName;
 
         try {
-          const auto seq = toNucleotideSequence(input.seq);
+          const auto seq = toNucleotideSequence(sanitizeSequenceString(input.seq));
           const auto result = nextclade.run(seqName, seq);
           return {.index = input.index, .seqName = seqName, .hasError = false, .result = result, .error = nullptr};
         } catch (const std::exception &e) {

--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -148,7 +148,7 @@ public:
     };
 
     try {
-      const auto query = toNucleotideSequence(queryStr);
+      const auto query = toNucleotideSequence(sanitizeSequenceString(queryStr));
 
 
       const auto result = analyzeOneSequence(//


### PR DESCRIPTION
The new fasta parser introduced in https://github.com/nextstrain/nextclade/pull/632 is not sanitizing sequences correctly.

The check is only performed until the first valid character, and the the remainder is copied as-is. This does not match the expectations of nextalign algorithm, which assumes input sequences don't contain any gaps for example. This was leading to incorrect alignment and incorrect insertions being output (consisting entirely from gaps) by nextalign and nextclade cli. Web is not affected because it uses the old, slower parser.

In this PR I remove the sanitization from the parser and add an additional sanitization between the parser and alignment. This should ensure that sequences are still read as fast as possible in the parser thread (there is only one) and that sequences are properly sanitized before they enter alignment. The sanitation runs on alignment/analysis threads, and therefore is parallel, however a copy of the sequence string is made in the process. Both may have consequences for performance.

On my machine, running nextalign on 10k random sequences

```
reset; /usr/bin/time -f 'Time: %E\nMem:  %M KB\n' ./.out/bin/nextalign-Linux-x86_64 --sequences ../nextclade_external_data/gisaid/gisaid-10k.fasta --reference=data/sars-cov-2/reference.fasta --genemap=data/sars-cov-2/genemap.gff --genes=E,M,N,ORF1a,ORF1b,ORF3a,ORF6,ORF7a,ORF7b,ORF8,ORF9b,S --output-dir=tmp/ --output-basename=nextalign --include-reference --silent
```

completes in roughly the same time and consumes roughly the same memory:

```
Before:
Time: 0:09.58
Mem:  1337396 KB

After:
Time: 0:09.53
Mem:  1479332 KB
```

We need to verify the correctness of outputs.

