### PR TITLE
fix: improve error message when virus properties flag is missing

### DIFF
--- a/packages/nextclade_cli/src/io/getInputPaths.h
+++ b/packages/nextclade_cli/src/io/getInputPaths.h
@@ -100,6 +100,15 @@ namespace Nextclade {
         "Either `--input-dataset` or `--input-qc-config` is required. Cannot proceed without QC config.");
     }
 
+    if (cliParams->inputDataset.empty() && inputVirusJson.empty()) {
+      throw ErrorFatal(
+        "Either `--input-dataset` or `--input-virus-properties` is required. Cannot proceed without virus properties. "
+        "Note: the new required file `virus_properties.json` was introduced in version 1.10.0. You can obtain it from "
+        "the latest Nextclade dataset. See `nextclade dataset get --help` and "
+        "https://docs.nextstrain.org/projects/nextclade for more information");
+    }
+
+
     if (!cliParams->inputDataset.empty()) {
       auto inputDataset = std::string{cliParams->inputDataset};
 


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/703

Adds missing CLI args check for a situation where `--input-dataset` is not provided and neither the `--input-virus-properties`.

Now the error message reads as follows:


> [ERROR] Nextclade: Error: Either `--input-dataset` or `--input-virus-properties` is required. Cannot proceed without virus properties. Note: the new required file `virus_properties.json` was introduced in version 1.10.0. You can obtain it from the latest Nextclade dataset. See `nextclade dataset get --help` and https://docs.nextstrain.org/projects/nextclade for more information

