### PR TITLE
fix(web): center markers in sequence views

### DIFF
--- a/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
@@ -60,9 +60,10 @@ function PeptideMarkerFrameShiftDisconnected({
   const nucLength = nucAbs.end - nucAbs.begin
   const codonLength = codon.end - codon.begin
 
-  const x = codon.begin * pixelsPerAa - pixelsPerAa / 2
   let width = codonLength * pixelsPerAa
   width = Math.max(width, BASE_MIN_WIDTH_PX)
+  const halfAa = Math.max(pixelsPerAa, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first AA
+  const x = codon.begin * pixelsPerAa - halfAa
 
   const codonRangeStr = formatRange(codon.begin, codon.end)
   const nucRangeStr = formatRange(nucAbs.begin, nucAbs.end)

--- a/packages/web/src/components/SequenceView/PeptideMarkerUnknown.tsx
+++ b/packages/web/src/components/SequenceView/PeptideMarkerUnknown.tsx
@@ -1,7 +1,7 @@
 import React, { SVGProps, useState } from 'react'
 
 import { useTranslation } from 'react-i18next'
-import { AMINOACID_UNKNOWN, AA_MIN_WIDTH_PX } from 'src/constants'
+import { AMINOACID_UNKNOWN, AA_MIN_WIDTH_PX, BASE_MIN_WIDTH_PX } from 'src/constants'
 
 import type { AminoacidRange } from 'src/algorithms/types'
 import { TableSlim } from 'src/components/Common/TableSlim'
@@ -25,9 +25,10 @@ export function PeptideMarkerUnknownUnmemoed({ seqName, range, pixelsPerAa, ...r
   const { begin, end } = range // prettier-ignore
 
   const id = getSafeId('unknown-marker', { seqName, ...range })
-  const x = begin * pixelsPerAa - pixelsPerAa / 2
   let width = (end - begin) * pixelsPerAa
   width = Math.max(width, AA_MIN_WIDTH_PX)
+  const halfAa = Math.max(pixelsPerAa, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first AA
+  const x = begin * pixelsPerAa - halfAa
 
   const rangeStr = formatRange(begin, end)
   const length = end - begin

--- a/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -60,9 +60,10 @@ function SequenceMarkerFrameShiftDisconnected({
   const nucLength = nucAbs.end - nucAbs.begin
   const codonLength = codon.end - codon.begin
 
-  const x = nucAbs.begin * pixelsPerBase - pixelsPerBase / 2
   let width = nucLength * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
+  const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = nucAbs.begin * pixelsPerBase - halfNuc
 
   const codonRangeStr = formatRange(codon.begin, codon.end)
   const nucRangeStr = formatRange(nucAbs.begin, nucAbs.end)

--- a/packages/web/src/components/SequenceView/SequenceMarkerGap.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerGap.tsx
@@ -47,9 +47,10 @@ function SequenceMarkerGapDisconnected({ seqName, deletion, pixelsPerBase, geneM
 
   const id = getSafeId('gap-marker', { seqName, ...deletion })
 
-  const x = begin * pixelsPerBase - pixelsPerBase / 2
   let width = (end - begin) * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
+  const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = begin * pixelsPerBase - halfNuc
 
   const rangeStr = formatRange(begin, end)
 

--- a/packages/web/src/components/SequenceView/SequenceMarkerMissing.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMissing.tsx
@@ -24,9 +24,10 @@ export function SequenceMarkerMissingUnmemoed({ seqName, missing, pixelsPerBase,
   const { begin, end } = missing // prettier-ignore
 
   const id = getSafeId('missing-marker', { seqName, ...missing })
-  const x = begin * pixelsPerBase - pixelsPerBase / 2
   let width = (end - begin) * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
+  const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = begin * pixelsPerBase - halfNuc
 
   const rangeStr = formatRange(begin, end)
 

--- a/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerMutation.tsx
@@ -56,7 +56,8 @@ function SequenceMarkerMutationDisconnected({
 
   const fill = getNucleotideColor(queryNuc)
   const width = Math.max(BASE_MIN_WIDTH_PX, pixelsPerBase)
-  const x = pos * pixelsPerBase - width / 2
+  const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = pos * pixelsPerBase - halfNuc
 
   const totalAaChanges = aaSubstitutions.length + aaDeletions.length
 

--- a/packages/web/src/components/SequenceView/SequenceMarkerUnsequenced.tsx
+++ b/packages/web/src/components/SequenceView/SequenceMarkerUnsequenced.tsx
@@ -26,9 +26,10 @@ export const SequenceMarker = memo(function SequenceMarkerImpl({
 }: PropsWithChildren<SequenceMarkerProps>) {
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const x = begin * pixelsPerBase - pixelsPerBase / 2
   let width = (end - begin) * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
+  const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = begin * pixelsPerBase - halfNuc
 
   if (begin >= end) {
     console.warn(


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/631 https://github.com/nextstrain/nextclade/issues/708 
Followup of https://github.com/nextstrain/nextclade/pull/638 https://github.com/nextstrain/nextclade/pull/644

Continues on the adventure of centering various markers in sequence views, started in https://github.com/nextstrain/nextclade/pull/638 and https://github.com/nextstrain/nextclade/pull/644. 

The goal is to make the different markers to be aligned to their positions in the sequence properly, as well as to be aligned between different other types of markers. The challenge is that there's not enough space to display them and that some of the markers are single positions (substitutions), while others are ranges (Ns), and they can overlap, hide each other, and cause all kinds of other visual anomalies.

This time I adjusted markers:
 - for all ranges (peptide fs, nuc fs, aa Xs, nuc Ns, nuc dels, unsequenced nucs)
 - for nucleotide substitutions (they are non-range, 1-nuc markers)

by subtracting  half of a width of the nuc/aa from their left positions, so that they are shifted left by a half a nuc/aa, ensuring they are anchored at the center of the first nuc/aa in the range. It is important to note that the width of a nuc/aa is variable, so the max of pixel-per-item and min-item-width need to be considered as a width.

We need to check how it plays with the AA mutation groups (which are the single-aa markers aggregated into groups), which has a more complex formula for positions (see https://github.com/nextstrain/nextclade/pull/638, https://github.com/nextstrain/nextclade/pull/644).


I believe that the proper fix would be to add  pan and zoom (#295).
