### PR TITLE
feat: sort private mutations

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -182,7 +182,7 @@ namespace Nextclade {
 
     /** Converts deletion into substitution. Note: deletion is a substitution to GAP character */
     explicit operator SubstitutionSimple<Letter>() const {
-      return SubstitutionSimple<Letter>{.ref = ref, .pos = pos, .qry = Nucleotide::GAP};
+      return SubstitutionSimple<Letter>{.ref = ref, .pos = pos, .qry = Letter::GAP};
     }
   };
 

--- a/packages/nextclade/src/tree/TreeNode.cpp
+++ b/packages/nextclade/src/tree/TreeNode.cpp
@@ -363,12 +363,15 @@ namespace Nextclade {
           mutObj[geneName] = json::array();
         }
 
-        for (const auto& mut : privateAaSubstitutions) {
-          mutObj[geneName].push_back(formatAminoacidMutationSimpleWithoutGene(mut));
-        }
 
-        for (const auto& mut : privateAaDeletions) {
-          mutObj[geneName].push_back(formatAminoacidDeletionSimpleWithoutGene(mut));
+        // Merge aa subs and dels and sort them in unison
+        const auto aaDelsAsSubs = map_vector<AminoacidDeletionSimple, AminoacidSubstitutionSimple>(privateAaDeletions,
+          convertDelToSub<Aminoacid>);
+        auto allAaMutations = merge(privateAaSubstitutions, aaDelsAsSubs);
+        std::sort(allAaMutations.begin(), allAaMutations.end());
+
+        for (const auto& mut : allAaMutations) {
+          mutObj[geneName].push_back(formatAminoacidMutationSimpleWithoutGene(mut));
         }
       }
 

--- a/packages/nextclade/src/tree/TreeNode.cpp
+++ b/packages/nextclade/src/tree/TreeNode.cpp
@@ -1,5 +1,6 @@
 #include "TreeNode.h"
 
+#include <common/contract.h>
 #include <fmt/format.h>
 #include <nextalign/private/nextalign_private.h>
 #include <nextclade/nextclade.h>
@@ -10,7 +11,8 @@
 
 #include "../../../nextalign/src/alphabet/nucleotides.h"
 #include "../io/parseMutation.h"
-#include <common/contract.h>
+#include "../utils/concat.h"
+#include "../utils/map.h"
 #include "../utils/safe_cast.h"
 
 namespace Nextclade {
@@ -338,13 +340,14 @@ namespace Nextclade {
     ) {
       auto mutObj = json::object();
 
+      // Merge nuc subs and dels and sort them in unison
+      const auto delsAsSubs = map_vector<NucleotideDeletionSimple, NucleotideSubstitutionSimple>(
+        nucMutations.privateDeletions, convertDelToSub<Nucleotide>);
+      auto allNucMutations = merge(nucMutations.privateSubstitutions, delsAsSubs);
+      std::sort(allNucMutations.begin(), allNucMutations.end());
 
-      for (const auto& mut : nucMutations.privateSubstitutions) {
+      for (const auto& mut : allNucMutations) {
         mutObj["nuc"].push_back(formatMutationSimple(mut));
-      }
-
-      for (const auto& mut : nucMutations.privateDeletions) {
-        mutObj["nuc"].push_back(formatDeletionSimple(mut));
       }
 
       for (const auto& [geneName, aaMutationsForGene] : aaMutations) {

--- a/packages/nextclade/src/tree/findPrivateMutations.cpp
+++ b/packages/nextclade/src/tree/findPrivateMutations.cpp
@@ -359,6 +359,8 @@ namespace Nextclade {
 
       auto privateSubstitutions = merge(privateReversionSubstitutions, privateNonReversionSubstitutions);
       privateSubstitutions = merge(privateSubstitutions, privateReversionsOfDeletions);
+      std::sort(privateSubstitutions.begin(), privateSubstitutions.end());
+
       auto privateDeletions = privateNonReversionDeletions;
 
       auto totalPrivateSubstitutions = safe_cast<int>(privateSubstitutions.size());


### PR DESCRIPTION
Sorts private substitutions by position in 2 places:

 - after merging different types of them right after detection (code is shared for nuc and aa)
 - in unison with deletions before attaching to the tree, as opposed to attaching subs first, then dels sequentially (code is different for nuc and aa, because auspice expect aa attachments to be per gene)

This is to improve readability in various lists and in the tree UI.
