### PR TITLE
fix: exclude reversions of dels when calculating divergence

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -374,6 +374,16 @@ namespace Nextclade {
     return deletion < labeled.deletion;
   }
 
+  // A naive way to erase mutations from a vector of mutations, that are present in another vector of mutations
+  inline safe_vector<NucleotideSubstitutionSimple> eraseIntersection(
+    const safe_vector<NucleotideSubstitutionSimple>& big, const safe_vector<NucleotideSubstitutionSimple>& small) {
+    safe_vector<NucleotideSubstitutionSimple> result;
+    std::copy_if(big.begin(), big.end(), std::back_inserter(result), [&small](const NucleotideSubstitutionSimple& b) {
+      return small.end() == std::find_if(small.cbegin(), small.cend(),
+                              [&b](const NucleotideSubstitutionSimple& s) { return b.pos == s.pos; });
+    });
+    return result;
+  }
 
   template<typename Letter>
   struct CharacterRange {

--- a/packages/nextclade/src/qc/ruleSnpClusters.cpp
+++ b/packages/nextclade/src/qc/ruleSnpClusters.cpp
@@ -13,20 +13,6 @@
 
 
 namespace Nextclade {
-  namespace {
-    // A naive way to erase mutations from a vector of mutations, that are present in another vector of mutations
-    safe_vector<NucleotideSubstitutionSimple> eraseIntersection(const safe_vector<NucleotideSubstitutionSimple>& big,
-      const safe_vector<NucleotideSubstitutionSimple>& small) {
-      safe_vector<NucleotideSubstitutionSimple> result;
-      std::copy_if(big.begin(), big.end(), std::back_inserter(result), [&small](const NucleotideSubstitutionSimple& b) {
-        return small.end() == std::find_if(small.cbegin(), small.cend(),
-                                [&b](const NucleotideSubstitutionSimple& s) { return b.pos == s.pos; });
-      });
-      return result;
-    }
-
-  }// namespace
-
   safe_vector<safe_vector<int>> findSnpClusters(                         //
     const safe_vector<NucleotideSubstitutionSimple>& privateMutationsRaw,//
     const QCRulesConfigSnpClusters& config                               //

--- a/packages/nextclade/src/tree/calculateDivergence.cpp
+++ b/packages/nextclade/src/tree/calculateDivergence.cpp
@@ -1,8 +1,8 @@
 #include "calculateDivergence.h"
 
+#include <common/contract.h>
 #include <nextclade/nextclade.h>
 
-#include <common/contract.h>
 #include "../utils/safe_cast.h"
 #include "TreeNode.h"
 
@@ -28,8 +28,12 @@ namespace Nextclade {
     // The parent node has this much divergence
     const double baseDiv = nearestNode.divergence().value_or(0.0);
 
+    // NOTE: we exclude reversions of deletions
+    const auto privateSubstitutions = eraseIntersection(result.privateNucMutations.privateSubstitutions,
+      result.privateNucMutations.reversionsOfDeletions);
+
     // Divergence is just number of substitutions compared to the parent
-    auto thisDiv = safe_cast<double>(result.privateNucMutations.privateSubstitutions.size());
+    auto thisDiv = safe_cast<double>(privateSubstitutions.size());
 
     // If divergence is measured per site, divide by the length of reference sequence.
     // The unit of measurement is deduced from what's already is used in the reference tree nodes.


### PR DESCRIPTION
Followup of #710 

We exclude reversions of deletions from mutations considered when calculating divergence. By convention used in the Nextstrain project.
