### PR TITLE
fix: exclude reversions of deletions from private substitutions

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -374,16 +374,6 @@ namespace Nextclade {
     return deletion < labeled.deletion;
   }
 
-  // A naive way to erase mutations from a vector of mutations, that are present in another vector of mutations
-  inline safe_vector<NucleotideSubstitutionSimple> eraseIntersection(
-    const safe_vector<NucleotideSubstitutionSimple>& big, const safe_vector<NucleotideSubstitutionSimple>& small) {
-    safe_vector<NucleotideSubstitutionSimple> result;
-    std::copy_if(big.begin(), big.end(), std::back_inserter(result), [&small](const NucleotideSubstitutionSimple& b) {
-      return small.end() == std::find_if(small.cbegin(), small.cend(),
-                              [&b](const NucleotideSubstitutionSimple& s) { return b.pos == s.pos; });
-    });
-    return result;
-  }
 
   template<typename Letter>
   struct CharacterRange {

--- a/packages/nextclade/src/qc/ruleSnpClusters.cpp
+++ b/packages/nextclade/src/qc/ruleSnpClusters.cpp
@@ -13,6 +13,20 @@
 
 
 namespace Nextclade {
+  namespace {
+    // A naive way to erase mutations from a vector of mutations, that are present in another vector of mutations
+    safe_vector<NucleotideSubstitutionSimple> eraseIntersection(const safe_vector<NucleotideSubstitutionSimple>& big,
+      const safe_vector<NucleotideSubstitutionSimple>& small) {
+      safe_vector<NucleotideSubstitutionSimple> result;
+      std::copy_if(big.begin(), big.end(), std::back_inserter(result), [&small](const NucleotideSubstitutionSimple& b) {
+        return small.end() == std::find_if(small.cbegin(), small.cend(),
+                                [&b](const NucleotideSubstitutionSimple& s) { return b.pos == s.pos; });
+      });
+      return result;
+    }
+
+  }// namespace
+
   safe_vector<safe_vector<int>> findSnpClusters(                         //
     const safe_vector<NucleotideSubstitutionSimple>& privateMutationsRaw,//
     const QCRulesConfigSnpClusters& config                               //

--- a/packages/nextclade/src/qc/ruleSnpClusters.cpp
+++ b/packages/nextclade/src/qc/ruleSnpClusters.cpp
@@ -1,32 +1,17 @@
 #include "ruleSnpClusters.h"
 
-#include <common/safe_vector.h>
 #include <nextclade/nextclade.h>
 
 #include <algorithm>
 #include <deque>
 #include <optional>
+#include <common/safe_vector.h>
 
-#include "../utils/concat.h"
 #include "../utils/safe_cast.h"
 #include "getQcRuleStatus.h"
 
 
 namespace Nextclade {
-  namespace {
-    // A naive way to erase mutations from a vector of mutations, that are present in another vector of mutations
-    safe_vector<NucleotideSubstitutionSimple> eraseIntersection(const safe_vector<NucleotideSubstitutionSimple>& big,
-      const safe_vector<NucleotideSubstitutionSimple>& small) {
-      safe_vector<NucleotideSubstitutionSimple> result;
-      std::copy_if(big.begin(), big.end(), std::back_inserter(result), [&small](const NucleotideSubstitutionSimple& b) {
-        return small.end() == std::find_if(small.cbegin(), small.cend(),
-                                [&b](const NucleotideSubstitutionSimple& s) { return b.pos == s.pos; });
-      });
-      return result;
-    }
-
-  }// namespace
-
   safe_vector<safe_vector<int>> findSnpClusters(                         //
     const safe_vector<NucleotideSubstitutionSimple>& privateMutationsRaw,//
     const QCRulesConfigSnpClusters& config                               //
@@ -87,13 +72,8 @@ namespace Nextclade {
       return {};
     }
 
-    // NOTE: we exclude reversions of deletions
-    // See: https://github.com/nextstrain/nextclade/issues/707
-    const auto privateSubstitutions = eraseIntersection(query.privateNucMutations.privateSubstitutions,
-      query.privateNucMutations.reversionsOfDeletions);
-
     // TODO: should we also account for result. privateDeletions here
-    const auto snpClusters = findSnpClusters(privateSubstitutions, config);
+    const auto snpClusters = findSnpClusters(query.privateNucMutations.privateSubstitutions, config);
     const auto totalClusters = safe_cast<double>(snpClusters.size());
 
     auto clusteredSnps = processSnpClusters(snpClusters);

--- a/packages/nextclade/src/tree/TreeNode.cpp
+++ b/packages/nextclade/src/tree/TreeNode.cpp
@@ -340,11 +340,16 @@ namespace Nextclade {
     ) {
       auto mutObj = json::object();
 
-      // Merge nuc subs and dels and sort them in unison
+      // Merge nuc subs and dels and rev dels, and sort them in unison
       const auto delsAsSubs = map_vector<NucleotideDeletionSimple, NucleotideSubstitutionSimple>(
         nucMutations.privateDeletions, convertDelToSub<Nucleotide>);
       auto allNucMutations = merge(nucMutations.privateSubstitutions, delsAsSubs);
+      allNucMutations = merge(allNucMutations, nucMutations.reversionsOfDeletions);
       std::sort(allNucMutations.begin(), allNucMutations.end());
+
+      if (!mutObj.contains("nuc")) {
+        mutObj["nuc"] = json::array();
+      }
 
       for (const auto& mut : allNucMutations) {
         mutObj["nuc"].push_back(formatMutationSimple(mut));

--- a/packages/nextclade/src/tree/TreeNode.cpp
+++ b/packages/nextclade/src/tree/TreeNode.cpp
@@ -358,22 +358,22 @@ namespace Nextclade {
       for (const auto& [geneName, aaMutationsForGene] : aaMutations) {
         const auto& privateAaSubstitutions = aaMutationsForGene.privateSubstitutions;
         const auto& privateAaDeletions = aaMutationsForGene.privateDeletions;
-        const int totalPrivateAaMutations = safe_cast<int>(privateAaSubstitutions.size() + privateAaDeletions.size());
+        const auto& reversionsOfDeletions = aaMutationsForGene.reversionsOfDeletions;
 
-        if (totalPrivateAaMutations == 0) {
+        // Merge aa subs and dels and rev dels, and sort them in unison
+        const auto aaDelsAsSubs = map_vector<AminoacidDeletionSimple, AminoacidSubstitutionSimple>(privateAaDeletions,
+          convertDelToSub<Aminoacid>);
+        auto allAaMutations = merge(privateAaSubstitutions, aaDelsAsSubs);
+        allAaMutations = merge(allAaMutations, reversionsOfDeletions);
+        std::sort(allAaMutations.begin(), allAaMutations.end());
+
+        if (allAaMutations.empty()) {
           continue;
         }
 
         if (!mutObj.contains(geneName)) {
           mutObj[geneName] = json::array();
         }
-
-
-        // Merge aa subs and dels and sort them in unison
-        const auto aaDelsAsSubs = map_vector<AminoacidDeletionSimple, AminoacidSubstitutionSimple>(privateAaDeletions,
-          convertDelToSub<Aminoacid>);
-        auto allAaMutations = merge(privateAaSubstitutions, aaDelsAsSubs);
-        std::sort(allAaMutations.begin(), allAaMutations.end());
 
         for (const auto& mut : allAaMutations) {
           mutObj[geneName].push_back(formatAminoacidMutationSimpleWithoutGene(mut));

--- a/packages/nextclade/src/tree/calculateDivergence.cpp
+++ b/packages/nextclade/src/tree/calculateDivergence.cpp
@@ -1,8 +1,8 @@
 #include "calculateDivergence.h"
 
-#include <common/contract.h>
 #include <nextclade/nextclade.h>
 
+#include <common/contract.h>
 #include "../utils/safe_cast.h"
 #include "TreeNode.h"
 
@@ -28,12 +28,8 @@ namespace Nextclade {
     // The parent node has this much divergence
     const double baseDiv = nearestNode.divergence().value_or(0.0);
 
-    // NOTE: we exclude reversions of deletions
-    const auto privateSubstitutions = eraseIntersection(result.privateNucMutations.privateSubstitutions,
-      result.privateNucMutations.reversionsOfDeletions);
-
     // Divergence is just number of substitutions compared to the parent
-    auto thisDiv = safe_cast<double>(privateSubstitutions.size());
+    auto thisDiv = safe_cast<double>(result.privateNucMutations.privateSubstitutions.size());
 
     // If divergence is measured per site, divide by the length of reference sequence.
     // The unit of measurement is deduced from what's already is used in the reference tree nodes.

--- a/packages/nextclade/src/tree/findPrivateMutations.cpp
+++ b/packages/nextclade/src/tree/findPrivateMutations.cpp
@@ -358,7 +358,6 @@ namespace Nextclade {
         substitutionLabelMap, deletionLabelMap);
 
       auto privateSubstitutions = merge(privateReversionSubstitutions, privateNonReversionSubstitutions);
-      privateSubstitutions = merge(privateSubstitutions, privateReversionsOfDeletions);
       std::sort(privateSubstitutions.begin(), privateSubstitutions.end());
 
       auto privateDeletions = privateNonReversionDeletions;


### PR DESCRIPTION
This excludes reversions of deletions from the array of private substitutions.
After some discussions and trial and error the team decided that they don't belong there.

Previously:

 - divergence in Nextstrain traditionally does not account deletions in any form, so we already excluded reversions of deletions in https://github.com/nextstrain/nextclade/pull/722
 - we've excluded them earlier in SNP clusters QC rule too https://github.com/nextstrain/nextclade/pull/710
 - the only place they show up is the auspice tree
 - they are accounted in totalPrivateMutations

In this PR:
 - [x] removed rev dels globally
 - [x] added rev dels back before attaching mutations to the tree
 - [x] reverted https://github.com/nextstrain/nextclade/pull/710 and https://github.com/nextstrain/nextclade/pull/722, because the filter there is a no-op, since the rev dels are excluded already

The consequences:
 - snp clusters stay the same as it is now (after [#710](https://github.com/nextstrain/nextclade/pull/710) / 1.10.2)
 - divergence decreases, but same as in [#722](https://github.com/nextstrain/nextclade/pull/722)
 - tree still has rev dels
 - output files lose rev dels from `privateNucMutations.privateSubstitutions`, and `privateNucMutations.totalPrivateSubstitutions` decreases
