### PR TITLE
fix: don't add "truncated" suffix to inserted fragment

### DIFF
--- a/packages/web/src/components/Results/ListOfInsertions.tsx
+++ b/packages/web/src/components/Results/ListOfInsertions.tsx
@@ -97,7 +97,7 @@ export function InsertedFragmentTruncated({ insertion, isAminoacid }: InsertedFr
     let ins = insertion
     let truncatedText: string | undefined
     if (ins.length > targetLength) {
-      ins = insertion.slice(0, targetLength).concat(TRUNCATED_TEXT)
+      ins = insertion.slice(0, targetLength)
       truncatedText = TRUNCATED_TEXT
     }
     return { ins, truncatedText }


### PR DESCRIPTION
This is a leftover from the time when the fragment was displayed as a plain string. 

![image](https://user-images.githubusercontent.com/9403403/152940222-2c7f9a01-87bf-4d4e-8d57-3c10f99f4d5f.png)

At some point the fragment has become a component of its own and the "truncated" text was displayed separately, but I forgot to remove the suffix.

This PR fixes it by removing the concatenation of the suffix to the fragment.

