### PR TITLE
feat: extend tree extensions node clade attrs to be more descriptive

### DIFF
--- a/packages/nextclade/include/nextclade/nextclade.h
+++ b/packages/nextclade/include/nextclade/nextclade.h
@@ -636,13 +636,18 @@ namespace Nextclade {
     std::map<std::string, std::string> customNodeAttributes;
   };
 
+  struct CladeNodeAttr {
+    std::string name;
+    std::string displayName;
+    std::string description;
+  };
 
   struct AnalysisResults {
     std::string schemaVersion;
     std::string nextcladeVersion;
     std::uint64_t timestamp;
-    safe_vector<std::string> cladeNodeAttrKeys;
-    safe_vector<Nextclade::AnalysisResult> results;
+    safe_vector<CladeNodeAttr> cladeNodeAttrKeys;
+    safe_vector<AnalysisResult> results;
   };
 
 
@@ -681,7 +686,7 @@ namespace Nextclade {
   public:
     explicit NextcladeAlgorithm(const NextcladeOptions& options);
 
-    safe_vector<std::string> getCladeNodeAttrKeys() const;
+    safe_vector<CladeNodeAttr> getCladeNodeAttrKeys() const;
 
     NextcladeResult run(const std::string& seqName, const NucleotideSequence& seq);
 
@@ -752,7 +757,7 @@ namespace Nextclade {
   };
 
   std::unique_ptr<CsvWriterAbstract> createCsvWriter(const CsvWriterOptions& options = {},
-    const safe_vector<std::string>& customNodeAttrKeys = {});
+    const safe_vector<CladeNodeAttr>& customNodeAttrKeys = {});
 
   class Tree {
     std::unique_ptr<TreeImpl> pimpl;
@@ -762,7 +767,7 @@ namespace Nextclade {
 
     TreeNode root() const;
 
-    safe_vector<std::string> getCladeNodeAttrKeys() const;
+    safe_vector<CladeNodeAttr> getCladeNodeAttrKeys() const;
 
     void addMetadata();
 
@@ -798,7 +803,7 @@ namespace Nextclade {
 
   std::string serializeWarningsToString(const Warnings& warnings);
 
-  std::string serializeCladeNodeAttrKeys(const safe_vector<std::string>& keys);
+  std::string serializeCladeNodeAttrs(const safe_vector<CladeNodeAttr>& keys);
 
   std::string serializeGeneMap(const GeneMap& geneMap);
 

--- a/packages/nextclade/include/nextclade/private/nextclade_private.h
+++ b/packages/nextclade/include/nextclade/private/nextclade_private.h
@@ -38,7 +38,7 @@ namespace Nextclade {
     const VirusJson& virusJson,                                  //
     const Tree& tree,                                            //
     const NextalignOptions& nextalignOptions,                    //
-    const safe_vector<std::string>& customNodeAttrKeys           //
+    const safe_vector<CladeNodeAttr>& customNodeAttrKeys         //
   );
 
   safe_vector<RefPeptideInternal> getRefPeptidesArray(const std::map<std::string, RefPeptideInternal>& refPeptides);

--- a/packages/nextclade/src/io/CsvWriter.cpp
+++ b/packages/nextclade/src/io/CsvWriter.cpp
@@ -16,6 +16,7 @@
 #include "../utils/concat.h"
 #include "../utils/contains.h"
 #include "../utils/eraseDuplicates.h"
+#include "../utils/map.h"
 #include "../utils/safe_cast.h"
 #include "formatMutation.h"
 #include "formatQcStatus.h"
@@ -126,7 +127,7 @@ namespace Nextclade {
     }
 
   public:
-    explicit CSVWriter(const CsvWriterOptions& opt, const safe_vector<std::string>& customNodeAttrKeys)
+    explicit CSVWriter(const CsvWriterOptions& opt, const safe_vector<CladeNodeAttr>& customNodeAttrs)
         : doc{
             "",
             rapidcsv::LabelParams{/* pColumnNameIdx */ -1, /* pRowNameIdx */ -1},
@@ -144,6 +145,9 @@ namespace Nextclade {
               /* pSkipEmptyLines  */ true  //
             },
           } {
+
+      safe_vector<std::string> customNodeAttrKeys =
+        map_vector<CladeNodeAttr, std::string>(customNodeAttrs, [](const CladeNodeAttr& attr) { return attr.name; });
 
       // Merge default column names with the incoming custom ones
       auto columnNamesVec = merge(getDefaultColumnNamesUpToClades(), customNodeAttrKeys);
@@ -306,7 +310,7 @@ namespace Nextclade {
 
 
   std::unique_ptr<CsvWriterAbstract> createCsvWriter(const CsvWriterOptions& options,
-    const safe_vector<std::string>& customNodeAttrKeys) {
+    const safe_vector<CladeNodeAttr>& customNodeAttrKeys) {
     return std::make_unique<CSVWriter>(options, customNodeAttrKeys);
   }
 

--- a/packages/nextclade/src/io/parseAnalysisResults.cpp
+++ b/packages/nextclade/src/io/parseAnalysisResults.cpp
@@ -380,6 +380,14 @@ namespace Nextclade {
     };
   }
 
+  CladeNodeAttr parseCladeNodeAttr(const json& j) {
+    return CladeNodeAttr{
+      .name = at(j, "name"),
+      .displayName = at(j, "displayName"),
+      .description = at(j, "description"),
+    };
+  }
+
   AnalysisResult parseAnalysisResult(const json& j) {
     try {
       return AnalysisResult{
@@ -436,7 +444,7 @@ namespace Nextclade {
         .schemaVersion = at(j, "schemaVersion"),
         .nextcladeVersion = at(j, "nextcladeVersion"),
         .timestamp = at(j, "timestamp"),
-        .cladeNodeAttrKeys = at(j, "cladeNodeAttrKeys"),
+        .cladeNodeAttrKeys = parseArray<CladeNodeAttr>(j, "cladeNodeAttrKeys", parseCladeNodeAttr),
         .results = parseArray<AnalysisResult>(j, "results", parseAnalysisResult),
       };
     } catch (const std::exception& e) {

--- a/packages/nextclade/src/io/serializeResults.cpp
+++ b/packages/nextclade/src/io/serializeResults.cpp
@@ -445,13 +445,20 @@ namespace Nextclade {
     return j;
   }
 
+  json serializeCladeNodeAttr(const CladeNodeAttr& attr) {
+    auto j = json::object();
+    j.emplace("name", attr.name);
+    j.emplace("displayName", attr.displayName);
+    j.emplace("description", attr.description);
+    return j;
+  }
 
   std::string serializeResults(const AnalysisResults& analysisResults) {
     auto j = json::object();
     j.emplace("schemaVersion", analysisResults.schemaVersion);
     j.emplace("nextcladeVersion", analysisResults.nextcladeVersion);
     j.emplace("timestamp", analysisResults.timestamp);
-    j.emplace("cladeNodeAttrKeys", serializeArray(analysisResults.cladeNodeAttrKeys));
+    j.emplace("cladeNodeAttrKeys", serializeArray(analysisResults.cladeNodeAttrKeys, serializeCladeNodeAttr));
     j.emplace("results", serializeResultsArray(analysisResults.results));
     return jsonStringify(j);
   }
@@ -484,10 +491,11 @@ namespace Nextclade {
     return jsonStringify(j);
   }
 
-  std::string serializeCladeNodeAttrKeys(const safe_vector<std::string>& keys) {
+
+  std::string serializeCladeNodeAttrs(const safe_vector<CladeNodeAttr>& attrs) {
     auto j = json::array();
-    for (const auto& key : keys) {
-      j.push_back(key);
+    for (const auto& attr : attrs) {
+      j.push_back(serializeCladeNodeAttr(attr));
     }
     return jsonStringify(j);
   }

--- a/packages/nextclade/src/nextclade.cpp
+++ b/packages/nextclade/src/nextclade.cpp
@@ -38,7 +38,7 @@ namespace Nextclade {
     const VirusJson& virusJson,                                  //
     const Tree& tree,                                            //
     const NextalignOptions& nextalignOptions,                    //
-    const safe_vector<std::string>& customNodeAttrKeys           //
+    const safe_vector<CladeNodeAttr>& customNodeAttrKeys         //
   ) {
     const auto alignment = nextalignInternal(query, ref, refPeptides, geneMap, nextalignOptions);
 
@@ -189,7 +189,7 @@ namespace Nextclade {
       treePreprocess(tree, opt.ref, refPeptides);
     }
 
-    safe_vector<std::string> getCladeNodeAttrKeys() const {
+    safe_vector<CladeNodeAttr> getCladeNodeAttrKeys() const {
       return tree.getCladeNodeAttrKeys();
     }
 
@@ -232,7 +232,7 @@ namespace Nextclade {
 
   NextcladeAlgorithm::~NextcladeAlgorithm() {}// NOLINT(modernize-use-equals-default)
 
-  safe_vector<std::string> NextcladeAlgorithm::getCladeNodeAttrKeys() const {
+  safe_vector<CladeNodeAttr> NextcladeAlgorithm::getCladeNodeAttrKeys() const {
     return pimpl->getCladeNodeAttrKeys();
   }
 

--- a/packages/nextclade/src/tree/TreeNode.cpp
+++ b/packages/nextclade/src/tree/TreeNode.cpp
@@ -414,11 +414,14 @@ namespace Nextclade {
       j[json_pointer{"/node_attrs/clade_membership/value"}] = clade;
     }
 
-    std::map<std::string, std::string> customNodeAttributes(const safe_vector<std::string>& customNodeAttrKeys) const {
+    std::map<std::string, std::string> customNodeAttributes(
+      const safe_vector<CladeNodeAttr>& customNodeAttrKeys) const {
       ensureIsObject();
 
       std::map<std::string, std::string> attrs;
-      for (const auto& key : customNodeAttrKeys) {
+      for (const auto& attr : customNodeAttrKeys) {
+        const auto& key = attr.name;
+
         const auto& jptr = json_pointer{fmt::format("/node_attrs/{}/value", key)};
         if (!j.contains(jptr)) {
           continue;
@@ -596,7 +599,7 @@ namespace Nextclade {
   }
 
   std::map<std::string, std::string> TreeNode::customNodeAttributes(
-    const safe_vector<std::string>& customNodeAttrKeys) const {
+    const safe_vector<CladeNodeAttr>& customNodeAttrKeys) const {
     return pimpl->customNodeAttributes(customNodeAttrKeys);
   }
 

--- a/packages/nextclade/src/tree/TreeNode.h
+++ b/packages/nextclade/src/tree/TreeNode.h
@@ -4,6 +4,7 @@
 #include <nlohmann/json_fwd.hpp>
 // clang-format on
 
+#include <common/safe_vector.h>
 #include <nextalign/nextalign.h>
 #include <nextclade/nextclade.h>
 
@@ -12,7 +13,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <common/safe_vector.h>
 
 enum class Nucleotide : char;
 
@@ -87,7 +87,7 @@ namespace Nextclade {
 
     void setClade(const std::string& clade);
 
-    std::map<std::string, std::string> customNodeAttributes(const safe_vector<std::string>& customNodeAttrKeys) const;
+    std::map<std::string, std::string> customNodeAttributes(const safe_vector<CladeNodeAttr>& customNodeAttrKeys) const;
 
     void setCustomNodeAttributes(const std::map<std::string, std::string>& attrs) const;
 

--- a/packages/nextclade_wasm/src/main.cpp
+++ b/packages/nextclade_wasm/src/main.cpp
@@ -196,7 +196,7 @@ public:
   }
 
   std::string getCladeNodeAttrKeysStr() const {
-    return Nextclade::serializeCladeNodeAttrKeys(state.tree.getCladeNodeAttrKeys());
+    return Nextclade::serializeCladeNodeAttrs(state.tree.getCladeNodeAttrKeys());
   }
 };
 

--- a/packages/web/src/algorithms/types.ts
+++ b/packages/web/src/algorithms/types.ts
@@ -325,6 +325,8 @@ export function convertPrivateMutations(privateNucMutations: PrivateMutations) {
   return { reversions, labeled, unlabeled, totalMutations }
 }
 
+export type { CladeNodeAttr } from 'auspice'
+
 export interface AnalysisResult {
   seqName: string
   substitutions: NucleotideSubstitution[]

--- a/packages/web/src/components/Results/ColumnCustomNodeAttr.tsx
+++ b/packages/web/src/components/Results/ColumnCustomNodeAttr.tsx
@@ -2,19 +2,19 @@ import React from 'react'
 
 import { get } from 'lodash'
 
-import type { AnalysisResult } from 'src/algorithms/types'
+import type { AnalysisResult, CladeNodeAttr } from 'src/algorithms/types'
 import { getSafeId } from 'src/helpers/getSafeId'
 
 export interface ColumnCustomNodeAttrProps {
   sequence: AnalysisResult
-  attrKey: string
+  attr: CladeNodeAttr
 }
 
-export function ColumnCustomNodeAttr({ sequence, attrKey }: ColumnCustomNodeAttrProps) {
+export function ColumnCustomNodeAttr({ sequence, attr }: ColumnCustomNodeAttrProps) {
   const { seqName, customNodeAttributes } = sequence
-  const attrValue = get(customNodeAttributes, attrKey, '')
+  const attrValue = get(customNodeAttributes, attr.name, '')
 
-  const id = getSafeId('col-custom-attr', { seqName, attrKey })
+  const id = getSafeId('col-custom-attr', { seqName, key: attr.name })
 
   return (
     <div id={id} className="w-100">

--- a/packages/web/src/components/Results/ResultsTable.tsx
+++ b/packages/web/src/components/Results/ResultsTable.tsx
@@ -7,7 +7,7 @@ import AutoSizerBase from 'react-virtualized-auto-sizer'
 import styled from 'styled-components'
 import { mix, rgba } from 'polished'
 
-import { QcStatus } from 'src/algorithms/types'
+import { CladeNodeAttr, QcStatus } from 'src/algorithms/types'
 import { ColumnCustomNodeAttr } from 'src/components/Results/ColumnCustomNodeAttr'
 import { PeptideView } from 'src/components/SequenceView/PeptideView'
 import { SequenceView } from 'src/components/SequenceView/SequenceView'
@@ -142,7 +142,7 @@ export interface TableRowDatum extends SequenceAnalysisState {
   viewedGene: string
   columnWidthsPx: Record<keyof typeof COLUMN_WIDTHS, string>
   dynamicColumnWidthPx: string
-  cladeNodeAttrKeys: string[]
+  cladeNodeAttrKeys: CladeNodeAttr[]
 }
 
 export interface RowProps extends ListChildComponentProps {
@@ -229,9 +229,9 @@ function TableRowComponent({ index, style, data }: RowProps) {
         <ColumnClade sequence={sequence} />
       </TableCellAlignedLeft>
 
-      {cladeNodeAttrKeys.map((attrKey) => (
-        <TableCellAlignedLeft key={attrKey} basis={dynamicColumnWidthPx} grow={0} shrink={0}>
-          <ColumnCustomNodeAttr sequence={sequence} attrKey={attrKey} />
+      {cladeNodeAttrKeys.map((attr) => (
+        <TableCellAlignedLeft key={attr.name} basis={dynamicColumnWidthPx} grow={0} shrink={0}>
+          <ColumnCustomNodeAttr sequence={sequence} attr={attr} />
         </TableCellAlignedLeft>
       ))}
 
@@ -346,7 +346,7 @@ export const ResultsTable = React.memo(connect(mapStateToProps, mapDispatchToPro
 export interface ResultProps {
   columnWidthsPx: Record<keyof typeof COLUMN_WIDTHS, string>
   dynamicColumnWidthPx: string
-  cladeNodeAttrKeys: string[]
+  cladeNodeAttrKeys: CladeNodeAttr[]
 
   resultsFiltered: SequenceAnalysisState[]
   filterPanelCollapsed: boolean
@@ -488,18 +488,19 @@ export function ResultsTableDisconnected({
             </ButtonHelpStyled>
           </TableHeaderCell>
 
-          {cladeNodeAttrKeys.map((attrKey) => {
-            const sortAsc = () => resultsSortByKeyTrigger({ key: attrKey, direction: SortDirection.asc })
-            const sortDesc = () => resultsSortByKeyTrigger({ key: attrKey, direction: SortDirection.desc })
+          {cladeNodeAttrKeys.map((attr) => {
+            const sortAsc = () => resultsSortByKeyTrigger({ key: attr.name, direction: SortDirection.asc })
+            const sortDesc = () => resultsSortByKeyTrigger({ key: attr.name, direction: SortDirection.desc })
 
             return (
-              <TableHeaderCell key={attrKey} basis={dynamicColumnWidthPx} grow={0} shrink={0}>
+              <TableHeaderCell key={attr.name} basis={dynamicColumnWidthPx} grow={0} shrink={0}>
                 <TableHeaderCellContent>
-                  <TableCellText>{attrKey}</TableCellText>
+                  <TableCellText>{attr.displayName}</TableCellText>
                   <ResultsControlsSort sortAsc={sortAsc} sortDesc={sortDesc} />
                 </TableHeaderCellContent>
                 <ButtonHelpStyled identifier="btn-help-col-clade" wide>
-                  <HelpTipsColumnClade />
+                  <h5>{`Column: ${attr.displayName}`}</h5>
+                  <p>{attr.description}</p>
                 </ButtonHelpStyled>
               </TableHeaderCell>
             )

--- a/packages/web/src/io/serializeResults.ts
+++ b/packages/web/src/io/serializeResults.ts
@@ -1,3 +1,4 @@
+import type { CladeNodeAttr } from 'auspice'
 import type { StrictOmit } from 'ts-essentials'
 
 import type { AnalysisResult } from 'src/algorithms/types'
@@ -10,14 +11,14 @@ export interface Exportable extends StrictOmit<AnalysisResult, 'alignedQuery' | 
   errors: string
 }
 
-export function serializeResults(analysisResults: AnalysisResult[], cladeNodeAttrKeys: string[]) {
+export function serializeResults(analysisResults: AnalysisResult[], cladeNodeAttrs: CladeNodeAttr[]) {
   const PACKAGE_VERSION = process.env.PACKAGE_VERSION ?? 'unknown'
 
   const finalResult = {
     schemaVersion: '1.2.0',
     nextcladeVersion: `web-${PACKAGE_VERSION}`,
     timestamp: Math.floor(Date.now() / 1000),
-    cladeNodeAttrKeys,
+    cladeNodeAttrKeys: cladeNodeAttrs,
     results: analysisResults,
   }
 
@@ -35,8 +36,8 @@ export function prepareResultsJson(results: SequenceAnalysisState[]) {
     .filter(notUndefinedOrNull)
 }
 
-export function serializeResultsToJson(results: SequenceAnalysisState[], cladeNodeAttrKeys: string[]) {
+export function serializeResultsToJson(results: SequenceAnalysisState[], cladeNodeAttrs: CladeNodeAttr[]) {
   const data = prepareResultsJson(results)
-  const str = serializeResults(data, cladeNodeAttrKeys)
+  const str = serializeResults(data, cladeNodeAttrs)
   return `${str}\n`
 }

--- a/packages/web/src/state/algorithm/algorithm.actions.ts
+++ b/packages/web/src/state/algorithm/algorithm.actions.ts
@@ -1,4 +1,4 @@
-import { UrlParams } from 'src/algorithms/types'
+import { CladeNodeAttr, UrlParams } from 'src/algorithms/types'
 import type { DatasetFlat, Gene } from 'src/algorithms/types'
 import { SortingKeyBased } from 'src/helpers/sortResults'
 import type { Sorting } from 'src/helpers/sortResults'
@@ -46,7 +46,7 @@ export const setGeneMapObject = action<{ geneMap: Gene[] }>('setGeneMapObject')
 export const addParsedSequence = action<{ index: number; seqName: string }>('addParsedSequence')
 export const addNextcladeResult = action<{ nextcladeResult: NextcladeResult }>('addNextcladeResult')
 export const setTreeResult = action<{ treeStr: string }>('setTreeResult')
-export const setCladeNodeAttrKeys = action<{ cladeNodeAttrKeys: string[] }>('setCladeNodeAttrKeys')
+export const setCladeNodeAttrKeys = action<{ cladeNodeAttrKeys: CladeNodeAttr[] }>('setCladeNodeAttrKeys')
 export const setResultsJsonStr = action<{ resultsJsonStr: string }>('setResultsJsonStr')
 
 export const exportCsvTrigger = action<void>('exportCsvTrigger')

--- a/packages/web/src/state/algorithm/algorithm.selectors.ts
+++ b/packages/web/src/state/algorithm/algorithm.selectors.ts
@@ -4,6 +4,7 @@ import i18n from 'src/i18n/i18n'
 import type { State } from 'src/state/reducer'
 import { AlgorithmGlobalStatus, AlgorithmSequenceStatus } from 'src/state/algorithm/algorithm.state'
 import { selectNumThreads } from 'src/state/settings/settings.selectors'
+import { CladeNodeAttr } from 'src/algorithms/types'
 
 export const selectParams = (state: State) => state.algorithm.params
 
@@ -50,7 +51,7 @@ export const selectCanDownload = (state: State): boolean =>
   state.algorithm.treeStr !== undefined
 
 export const selectOutputTree = (state: State): string | undefined => state.algorithm.treeStr
-export const selectCladeNodeAttrKeys = (state: State): string[] => state.algorithm.cladeNodeAttrKeys
+export const selectCladeNodeAttrKeys = (state: State): CladeNodeAttr[] => state.algorithm.cladeNodeAttrKeys
 
 export const selectOutputSequences = (state: State) =>
   state.algorithm.results.map((result) => ({ seqName: result.seqName, query: result.query }))

--- a/packages/web/src/state/algorithm/algorithm.state.ts
+++ b/packages/web/src/state/algorithm/algorithm.state.ts
@@ -1,4 +1,12 @@
-import type { AnalysisResult, Gene, Peptide, Warnings, DatasetFlat, UrlParams } from 'src/algorithms/types'
+import type {
+  AnalysisResult,
+  Gene,
+  Peptide,
+  Warnings,
+  DatasetFlat,
+  UrlParams,
+  CladeNodeAttr,
+} from 'src/algorithms/types'
 import type { QCFilters } from 'src/filtering/filterByQCIssues'
 
 export enum AlgorithmGlobalStatus {
@@ -124,7 +132,7 @@ export interface AlgorithmState {
   resultsFiltered: SequenceAnalysisState[]
   treeStr?: string
   resultsJsonStr?: string
-  cladeNodeAttrKeys: string[]
+  cladeNodeAttrKeys: CladeNodeAttr[]
   errors: string[]
   filters: ResultsFilters
   exportParams: ExportParams

--- a/packages/web/src/state/algorithm/algorithmRun.sagas.ts
+++ b/packages/web/src/state/algorithm/algorithmRun.sagas.ts
@@ -493,7 +493,7 @@ export function* runAlgorithm(queryInput?: AlgorithmInput) {
   })
 
   const tree = JSON.parse(treeStr) as AuspiceJsonV2
-  const cladeNodeAttrKeys = tree.meta?.extensions?.nextclade?.clade_node_attrs_keys ?? []
+  const cladeNodeAttrKeys = tree.meta?.extensions?.nextclade?.clade_node_attrs ?? []
   yield* put(setCladeNodeAttrKeys({ cladeNodeAttrKeys }))
 
   const genomeSize = refStr.length

--- a/packages/web/src/types/auspice/index.d.ts
+++ b/packages/web/src/types/auspice/index.d.ts
@@ -196,6 +196,12 @@ declare module 'auspice' {
     name?: string
   }
 
+  export interface CladeNodeAttr {
+    name: string
+    displayName: string
+    description: string
+  }
+
   export declare interface AuspiceMetadata {
     title?: string
     description?: string
@@ -218,7 +224,7 @@ declare module 'auspice' {
     panels?: string[]
     extensions?: {
       nextclade?: {
-        clade_node_attrs_keys: string[]
+        clade_node_attrs?: CladeNodeAttr[]
       }
     }
   }


### PR DESCRIPTION
Extends the Nextclade's Augur tree extension object to provide more data (friendly name of the column and description for the tooltip).

Replaces the `meta.extensions.nextclade.clade_node_attr_keys`array of strings with `meta.extensions.nextclade.clade_node_attrs` array of objects in the auspice tree json.

The expected format is as follows:

```json
{
  "meta": {
    "extensions": {
      "nextclade": {
        "clade_node_attrs": [
          {
            "name": "pango_lineage",
            "displayName": "Pango lineage (Nextclade)",
            "description": "Pango lineage as inferred by Nextclade from the nearest neighbour in the reference tree. 98% accurate for recent sequences, for higher accuracy use dedicated pangolin software in UShER or pangoLEARN mode"
            
          },
          {
            "name": "GISAID_clade",
            "displayName": "GISAID clade",
            "description": "Clades as defined by GISAID"
          }
        ]
      }
    }
  }
}
```

All keys are optional, but if at least one key is missing, the object will be ignored. Same as if it's not an object. The entire extension object is optional as well. More fields can be added, if necessary.

Testing: paste the example from above into the existing tree `meta` object and drop it into the web's advanced mode or into cli's `--input-tree`.

![00](https://user-images.githubusercontent.com/9403403/155437532-0898f86d-4f36-4c83-a9fb-1b077d54711d.png)

![01](https://user-images.githubusercontent.com/9403403/155437540-be2fba24-b6a9-4bc3-a45a-de9b04e0c489.png)


