### PR TITLE
fix(web): ensure correct rendering of mutation at position 0

### DIFF
--- a/packages/web/src/components/Common/MutationBadge.tsx
+++ b/packages/web/src/components/Common/MutationBadge.tsx
@@ -81,7 +81,7 @@ export function NucleotideMutationBadge({ mutation }: NucleotideMutationBadgePro
             {refNuc}
           </ColoredText>
         )}
-        {pos && <PositionText>{posOneBased}</PositionText>}
+        <PositionText>{posOneBased}</PositionText>
         {queryNuc && (
           <ColoredText $background={queryBg} $color={queryFg}>
             {queryNuc}


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/745

There was a redundant null check in the NucleotideMutationBadge component that was causing position of a mutation at first nuc to be ignored (the number 0 is considered nullish in js). This check is redundant anyway, because the position is never null, so I removed it. AminoacidMutationBadge component does not have this check, so it should behave correctly.

