### PR TITLE
feat: make aa substitution tooltips in gene views sticky when clicked

### DIFF
--- a/packages/web/src/components/Common/useClickOutside.ts
+++ b/packages/web/src/components/Common/useClickOutside.ts
@@ -1,0 +1,25 @@
+import { MutableRefObject, useEffect } from 'react'
+
+/**
+ * Hook that alerts clicks outside of the passed ref
+ * Author: Ben Bud
+ * Source: https://stackoverflow.com/a/42234988
+ */
+export function useClickOutside<T extends HTMLElement | SVGElement>(
+  ref: MutableRefObject<T | null>,
+  onClickOutside: () => void,
+) {
+  useEffect(() => {
+    function handleClickOutside(event: Event) {
+      if (event.target instanceof Node && ref.current && !ref.current.contains(event.target)) {
+        onClickOutside()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [onClickOutside, ref])
+}


### PR DESCRIPTION
A prototype which aims to improve user experience around tooltips.

When clicked, on the aa mutation, these tooltips:

![01](https://user-images.githubusercontent.com/9403403/157650546-0fe07df0-eeca-4596-90fc-2eed1c94c7a3.png)

will now stick, so that information can be copied.

