### PR TITLE
feat: discard bad seed positions as soon as possible

### DIFF
--- a/packages_rs/nextclade/src/align/seed_match.rs
+++ b/packages_rs/nextclade/src/align/seed_match.rs
@@ -22,8 +22,8 @@ pub fn seed_match(kmer: &[Nuc], ref_seq: &[Nuc], start_pos: usize, mismatches_al
         tmp_score += 1;
       }
 
-      // TODO: this speeds up seed-matching by disregarding bad seeds.
-      if tmp_score + mismatches_allowed < pos {
+      // this speeds up seed-matching by disregarding bad seeds.
+      if tmp_score + mismatches_allowed <= pos {
         break;
       }
     }

--- a/packages_rs/nextclade/src/align/seed_match.rs
+++ b/packages_rs/nextclade/src/align/seed_match.rs
@@ -1,10 +1,14 @@
 use crate::io::nuc::Nuc;
 
+#[derive(Debug)]
 pub struct SeedMatchResult {
   pub ref_pos: usize,
   pub score: usize,
 }
 
+/// Find best match in reference sequence, with at most `mismatches_allowed` mismatches.
+/// Ambiguous nucleotides in kmer will never match.
+/// Kmers never match outside reference terminals.
 pub fn seed_match(kmer: &[Nuc], ref_seq: &[Nuc], start_pos: usize, mismatches_allowed: usize) -> SeedMatchResult {
   let ref_len = ref_seq.len();
   let kmer_len = kmer.len();
@@ -22,7 +26,7 @@ pub fn seed_match(kmer: &[Nuc], ref_seq: &[Nuc], start_pos: usize, mismatches_al
         tmp_score += 1;
       }
 
-      // this speeds up seed-matching by disregarding bad seeds.
+      // abort as soon as there are more mismatches than allowed
       if tmp_score + mismatches_allowed <= pos {
         break;
       }
@@ -31,7 +35,7 @@ pub fn seed_match(kmer: &[Nuc], ref_seq: &[Nuc], start_pos: usize, mismatches_al
       max_score = tmp_score;
       max_ref_pos = ref_pos;
 
-      // if maximal score is reached
+      // finish asap if perfect match found
       if tmp_score == kmer_len {
         break;
       }
@@ -41,5 +45,96 @@ pub fn seed_match(kmer: &[Nuc], ref_seq: &[Nuc], start_pos: usize, mismatches_al
   SeedMatchResult {
     ref_pos: max_ref_pos,
     score: max_score,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::io::nuc::to_nuc_seq;
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  #[rstest]
+  fn seed_match_abort_asap() {
+    let ref_seq = to_nuc_seq("AAACCCAAATGAA").unwrap();
+    let kmer = to_nuc_seq("ACGA").unwrap();
+    let mismatch_allowed = 0;
+
+    let result = seed_match(&kmer, &ref_seq, 0, mismatch_allowed);
+
+    assert_eq!(result.score, 2);
+    assert_eq!(result.ref_pos, 2);
+  }
+
+  #[rstest]
+  fn seed_match_mismatch_tolerated() {
+    let ref_seq = to_nuc_seq("ACGCCGACCTCAGTT").unwrap();
+    let kmer = to_nuc_seq("CGGT").unwrap();
+    let mismatch_allowed = 1;
+
+    let result = seed_match(&kmer, &ref_seq, 0, mismatch_allowed);
+
+    assert_eq!(result.ref_pos, 10);
+    assert_eq!(result.score, 3);
+  }
+
+  #[rstest]
+  fn seed_match_pick_first_perfect_match() {
+    let ref_seq = to_nuc_seq("AAACCCAAACCCAAA").unwrap();
+    let kmer = to_nuc_seq("CCC").unwrap();
+    let mismatch_allowed = 1;
+
+    let result = seed_match(&kmer, &ref_seq, 0, mismatch_allowed);
+
+    assert_eq!(result.score, 3);
+    assert_eq!(result.ref_pos, 3);
+  }
+
+  #[rstest]
+  fn seed_match_find_perfect_match_after_imperfect() {
+    let ref_seq = to_nuc_seq("AAAACCAAACCCAAA").unwrap();
+    let kmer = to_nuc_seq("CCC").unwrap();
+    let mismatch_allowed = 1;
+
+    let result = seed_match(&kmer, &ref_seq, 0, mismatch_allowed);
+
+    assert_eq!(result.score, 3);
+    assert_eq!(result.ref_pos, 9);
+  }
+
+  #[rstest]
+  fn seed_match_accept_amb_and_gaps() {
+    let ref_seq = to_nuc_seq("ACGCCGACCTCGGTTAAA").unwrap();
+    let kmer = to_nuc_seq("CG-TYW").unwrap();
+    let mismatch_allowed = 3;
+
+    let result = seed_match(&kmer, &ref_seq, 0, mismatch_allowed);
+
+    assert_eq!(result.ref_pos, 10);
+    assert_eq!(result.score, 3);
+  }
+
+  #[rstest]
+  fn seed_match_does_not_match_across_terminals() {
+    let ref_seq = to_nuc_seq("ACGCCGACCTCGGT").unwrap();
+    let kmer = to_nuc_seq("CGTTYW").unwrap();
+    let mismatch_allowed = 3;
+
+    let result = seed_match(&kmer, &ref_seq, 0, mismatch_allowed);
+
+    assert_eq!(result.ref_pos, 1);
+    assert_eq!(result.score, 2);
+  }
+
+  #[rstest]
+  fn seed_match_general_case() {
+    let ref_seq = to_nuc_seq("ACGCCGACCTCGGTT").unwrap();
+    let kmer = to_nuc_seq("CGGT").unwrap();
+
+    let result = seed_match(&kmer, &ref_seq, 0, 1);
+
+    assert_eq!(result.ref_pos, 10);
+    assert_eq!(result.score, 4);
   }
 }


### PR DESCRIPTION
If my reasoning is correct, there's an off-by-one error in the original code. We could abort already one mismatch earlier. Hence I replaced `<` with `<=`.

Would be good if @rneher could check the logic. I'm pretty sure this is correct.

I've added unit tests, it all works as expected.

This should speed up seed matching by around 20%, as with 3 mismatches allowed, the expected number of checks before aborting was up to now 5, and now it's 4.