### PR TITLE
fix(web): display codon 0 correctly in the peptide context

### DIFF
--- a/packages/web/src/components/SequenceView/PeptideContext.tsx
+++ b/packages/web/src/components/SequenceView/PeptideContext.tsx
@@ -158,13 +158,20 @@ export function PeptideContextCodon({ refCodon, queryCodon, change, codon, nucBe
 
   const highlight: boolean[] = safeZip(refCodon.split(''), queryCodon.split('')).map(([ref, query]) => ref !== query)
 
+  const posOneBased = useMemo(() => {
+    if (codon === undefined) {
+      return undefined
+    }
+    return codon + 1
+  }, [codon])
+
   return (
     <td>
       <TableNuc>
         <TableBodyNuc>
           <TrNuc>
             <TdNuc colSpan={3}>
-              <AminoacidPositionText>{codon && codon + 1}</AminoacidPositionText>
+              <AminoacidPositionText>{posOneBased}</AminoacidPositionText>
             </TdNuc>
           </TrNuc>
 


### PR DESCRIPTION
Codon 0 (1 in one-based indexing) was not displayed correctly in the peptide context due to `0` treated as `false` in the conditional statement.

<img width="496" alt="01" src="https://user-images.githubusercontent.com/9403403/167037145-8ee19b82-a5c7-4df5-8ef8-70fb064bee8c.png">

