### PR TITLE
chore(ci): fix vercel build

### DIFF
--- a/scripts/build_locally.sh
+++ b/scripts/build_locally.sh
@@ -626,7 +626,7 @@ echo "-------------------------------------------------------------------------"
 if [ "${NEXTCLADE_BUILD_WASM}" == "true" ] || [ "${NEXTCLADE_BUILD_WASM}" == "1" ]; then
   print 92 "Install Emscripten SDK";
 
-  if [ ! -d "${NEXTCLADE_EMSDK_DIR}" ]; then
+  if [ ! -f "${NEXTCLADE_EMSDK_DIR}/emsdk_env.sh" ]; then
     ./scripts/install_emscripten.sh "${NEXTCLADE_EMSDK_DIR}" "${NEXTCLADE_EMSDK_VERSION}"
   else
     echo "Emscripten SDK already found in '${NEXTCLADE_EMSDK_DIR}'. Skipping install."


### PR DESCRIPTION
By checking for a specific file existence, not directory existence, when deciding on whether to install emsdk

