### PR TITLE
fix: strip gap characters from qry seq when reading in

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -3,6 +3,7 @@ use crate::cli::nextclade_ordered_writer::NextcladeOrderedWriter;
 use crossbeam::thread;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
+use log::info;
 use nextclade::align::gap_open::{get_gap_open_close_scores_codon_aware, get_gap_open_close_scores_flat};
 use nextclade::analyze::pcr_primers::PcrPrimer;
 use nextclade::analyze::virus_properties::VirusProperties;
@@ -10,7 +11,7 @@ use nextclade::gene::gene_map::GeneMap;
 use nextclade::io::fasta::{read_one_fasta, FastaReader, FastaRecord};
 use nextclade::io::gff3::read_gff3_file;
 use nextclade::io::json::json_write;
-use nextclade::io::nuc::{from_nuc_seq, to_nuc_seq, Nuc};
+use nextclade::io::nuc::{from_nuc_seq, to_nuc_seq, to_ungapped_nuc_seq, Nuc};
 use nextclade::option_get_some;
 use nextclade::qc::qc_config::QcConfig;
 use nextclade::run::nextclade_run_one::nextclade_run_one;
@@ -20,7 +21,6 @@ use nextclade::tree::tree::AuspiceTree;
 use nextclade::tree::tree_attach_new_nodes::tree_attach_new_nodes_in_place;
 use nextclade::tree::tree_preprocess::tree_preprocess_in_place;
 use nextclade::types::outputs::NextcladeOutputs;
-use log::info;
 use serde::{Deserialize, Serialize};
 
 pub struct NextcladeRecord {
@@ -146,7 +146,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
 
         for FastaRecord { seq_name, seq, index } in &fasta_receiver {
           info!("Processing sequence '{seq_name}'");
-          let qry_seq = to_nuc_seq(&seq)
+          let qry_seq = to_ungapped_nuc_seq(&seq)
             .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
             .unwrap();
 

--- a/packages_rs/nextclade/src/io/nuc.rs
+++ b/packages_rs/nextclade/src/io/nuc.rs
@@ -146,6 +146,14 @@ pub fn to_nuc_seq(str: &str) -> Result<Vec<Nuc>, Report> {
   str.chars().map(to_nuc).collect()
 }
 
+pub fn to_ungapped_nuc_seq(str: &str) -> Result<Vec<Nuc>, Report> {
+  str
+    .chars()
+    .filter(|&x| x != char::from_u32('-' as u32).unwrap())
+    .map(to_nuc)
+    .collect()
+}
+
 pub fn from_nuc_seq(seq: &[Nuc]) -> String {
   seq.iter().map(|nuc| from_nuc(*nuc)).collect()
 }


### PR DESCRIPTION
We need to strip `-` characters from the query sequence as some of our algorithms assume the query sequence doesn't contain these.

I created a new function to ungap straight when reading in, maybe there's a better way to do this. We may also ungap the reference sequence, just in case. Or at least warn if it contains gaps, since that would be a problem for our algorithms, too.