### PR TITLE
fix: prepend new node in Auspice tree

### DIFF
--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -76,35 +76,38 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
     )
   };
 
-  node.children.push(AuspiceTreeNode {
-    name: format!("{}_new", result.seq_name),
-    branch_attrs: TreeBranchAttrs {
-      mutations,
-      other: serde_json::Value::default(),
-    },
-    node_attrs: TreeNodeAttrs {
-      div: Some(result.divergence),
-      clade_membership: TreeNodeAttr::new(&result.clade),
-      node_type: Some(TreeNodeAttr::new("New")),
-      region: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
-      country: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
-      division: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
-      alignment: Some(TreeNodeAttr::new(&alignment)),
-      missing: Some(TreeNodeAttr::new(&format_missings(&result.missing, ", "))),
-      gaps: Some(TreeNodeAttr::new(&format_nuc_deletions(&result.deletions, ", "))),
-      non_acgtns: Some(TreeNodeAttr::new(&format_non_acgtns(&result.non_acgtns, ", "))),
-      has_pcr_primer_changes,
-      pcr_primer_changes,
-      missing_genes: Some(TreeNodeAttr::new(&format_failed_genes(&result.missing_genes, ", "))),
-      other: serde_json::Value::default(),
+  node.children.insert(
+    0,
+    AuspiceTreeNode {
+      name: format!("{}_new", result.seq_name),
+      branch_attrs: TreeBranchAttrs {
+        mutations,
+        other: serde_json::Value::default(),
+      },
+      node_attrs: TreeNodeAttrs {
+        div: Some(result.divergence),
+        clade_membership: TreeNodeAttr::new(&result.clade),
+        node_type: Some(TreeNodeAttr::new("New")),
+        region: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
+        country: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
+        division: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
+        alignment: Some(TreeNodeAttr::new(&alignment)),
+        missing: Some(TreeNodeAttr::new(&format_missings(&result.missing, ", "))),
+        gaps: Some(TreeNodeAttr::new(&format_nuc_deletions(&result.deletions, ", "))),
+        non_acgtns: Some(TreeNodeAttr::new(&format_non_acgtns(&result.non_acgtns, ", "))),
+        has_pcr_primer_changes,
+        pcr_primer_changes,
+        missing_genes: Some(TreeNodeAttr::new(&format_failed_genes(&result.missing_genes, ", "))),
+        other: serde_json::Value::default(),
 
-      // TODO
-      qc_status: None,
+        // TODO
+        qc_status: None,
+      },
+      children: vec![],
+      tmp: TreeNodeTempData::default(),
+      other: serde_json::Value::default(),
     },
-    children: vec![],
-    tmp: TreeNodeTempData::default(),
-    other: serde_json::Value::default(),
-  });
+  );
 }
 
 fn convert_mutations_to_node_branch_attrs(nuc_muts: &PrivateNucMutations) -> BTreeMap<String, Vec<String>> {


### PR DESCRIPTION
New node is attached at bottom rather than top in line with Auspice/Augur convention. Inserting at front of vec is not great for performance, but this is probably not limiting anyways. Otherwise, maybe we can put children from back to front in array rather than front to back.

<img width="1669" alt="Screenshot 2022-05-17 at 15 28 45" src="https://user-images.githubusercontent.com/25161793/168826304-f2fac514-c513-43b4-a9bc-7f27b63128bb.png">
