### PR TITLE
fix: ref leaf was missing in tree, fixes label duplication during node attachement

### DIFF
--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -49,7 +49,6 @@ fn attach_new_node(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
 
 fn add_aux_node(node: &mut AuspiceTreeNode) {
   debug_assert!(node.is_ref_node());
-  println!("Adding aux node to {}", node.tmp.id);
 
   let mut aux_node = node.clone();
   aux_node.branch_attrs.mutations.clear();


### PR DESCRIPTION
fixes https://github.com/nextstrain/nextclade/issues/653
1. Reference leaf was missing when new node was attached to leaf.
2. Fixes label duplication when new node is attached (old known problem)

Tested locally, seems to work.

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/25161793/168839007-3446d66a-55f3-4259-930d-9f98e3120daf.png">
