### PR TITLE
fix: typos/wording in cli help texts

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -141,7 +141,7 @@ pub struct NextalignRunArgs {
   #[clap(value_hint = ValueHint::AnyPath)]
   pub output_fasta: Option<PathBuf>,
 
-  /// Path to output CSV file with stripped insertions data.
+  /// Path to output CSV file that contain insertions stripped from the reference alignment.
   ///
   /// Overrides paths given with `--output-dir` and `--output-basename`.
   ///

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -231,7 +231,7 @@ pub struct NextcladeRunArgs {
 
   /// Path to a FASTA file containing reference sequence. This file is expected to contain exactly 1 sequence.
   ///
-  /// Overrides path to `tree.json` in the dataset (`--input-dataset`).
+  /// Overrides path to `reference.fasta` in the dataset (`--input-dataset`).
   #[clap(long, short = 'r', alias("reference"), alias("input-root-seq"))]
   #[clap(value_hint = ValueHint::FilePath)]
   pub input_ref: Option<PathBuf>,
@@ -367,7 +367,7 @@ pub struct NextcladeRunArgs {
   #[clap(value_hint = ValueHint::AnyPath)]
   pub output_tree: Option<PathBuf>,
 
-  /// Path to output CSV file with stripped insertions data.
+  /// Path to output CSV file that contain insertions stripped from the reference alignment.
   ///
   /// Overrides paths given with `--output-dir` and `--output-basename`.
   ///

--- a/packages_rs/nextclade/src/align/params.rs
+++ b/packages_rs/nextclade/src/align/params.rs
@@ -9,12 +9,12 @@ pub struct AlignPairwiseParams {
   #[clap(default_value_t = AlignPairwiseParams::default().min_length)]
   pub min_length: usize,
 
-  /// Penalty for extending a gap. If zero, all gaps regardless of length incur the same penalty.
+  /// Penalty for extending a gap in alignment. If zero, all gaps regardless of length incur the same penalty.
   #[clap(long)]
   #[clap(default_value_t = AlignPairwiseParams::default().penalty_gap_extend)]
   pub penalty_gap_extend: i32,
 
-  /// Penalty for opening of a gap. A higher penalty results in fewer gaps and more mismatches. Should be less than `--penalty-gap-open-in-frame` to avoid gaps in genes.
+  /// Penalty for opening of a gap in alignment. A higher penalty results in fewer gaps and more mismatches. Should be less than `--penalty-gap-open-in-frame` to avoid gaps in genes.
   #[clap(long)]
   #[clap(default_value_t = AlignPairwiseParams::default().penalty_gap_open)]
   pub penalty_gap_open: i32,
@@ -34,7 +34,7 @@ pub struct AlignPairwiseParams {
   #[clap(default_value_t = AlignPairwiseParams::default().penalty_mismatch)]
   pub penalty_mismatch: i32,
 
-  /// Score for encouraging aligned nucleotides or amino acids with matching state.
+  /// Score for matching states in nucleotide or amino acid alignments.
   #[clap(long)]
   #[clap(default_value_t = AlignPairwiseParams::default().score_match)]
   pub score_match: i32,
@@ -54,7 +54,7 @@ pub struct AlignPairwiseParams {
   #[clap(default_value_t = AlignPairwiseParams::default().mismatches_allowed)]
   pub mismatches_allowed: usize,
 
-  /// Minimum number of seeds to search for during nucleotide alignment. Relevant for short sequences. In long sequences, the number of seeds is determined by `--nuc-seed-spacing`.
+  /// Minimum number of seeds to search for during nucleotide alignment. Relevant for short sequences. In long sequences, the number of seeds is determined by `--seed-spacing`.
   #[clap(long)]
   #[clap(default_value_t = AlignPairwiseParams::default().min_seeds)]
   pub min_seeds: i32,


### PR DESCRIPTION
should be mergable immediately