### PR TITLE
feat(cli): take all genes if --genes is not provided

### DIFF
--- a/packages_rs/nextclade-cli/examples/simplealign.rs
+++ b/packages_rs/nextclade-cli/examples/simplealign.rs
@@ -2,7 +2,7 @@ use ctor::ctor;
 use eyre::{Report, WrapErr};
 use log::info;
 use nextclade::align::gap_open::{get_gap_open_close_scores_codon_aware, get_gap_open_close_scores_flat};
-use nextclade::gene::gene_map::GeneMap;
+use nextclade::io::gene_map::GeneMap;
 use nextclade::io::fasta::{read_one_fasta, FastaReader, FastaRecord};
 use nextclade::io::gff3::read_gff3_file;
 use nextclade::io::nuc::to_nuc_seq;

--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 use log::LevelFilter;
 use nextclade::align::params::AlignPairwiseParams;
 use nextclade::io::fs::basename;
+use nextclade::make_error;
 use nextclade::utils::global_init::setup_logger;
 use std::env::current_dir;
 use std::fmt::Debug;
@@ -240,7 +241,7 @@ pub fn nextalign_parse_cli_args() -> Result<NextalignArgs, Report> {
     Some(NextalignCommands::Completions { shell }) => {
       generate_completions(shell).wrap_err_with(|| format!("When generating completions for shell '{shell}'"))?;
     }
-    Some(NextalignCommands::Run { 0: ref mut run_args }) => {
+    Some(NextalignCommands::Run(ref mut run_args)) => {
       nextalign_get_output_filenames(run_args).wrap_err("When deducing output filenames")?;
     }
     _ => {}

--- a/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
@@ -1,6 +1,6 @@
 use crate::cli::nextalign_loop::NextalignRecord;
 use eyre::{Report, WrapErr};
-use nextclade::gene::gene_map::GeneMap;
+use nextclade::io::gene_map::GeneMap;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
 use nextclade::io::insertions_csv::InsertionsCsvWriter;

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -3,11 +3,12 @@ use crate::cli::nextclade_ordered_writer::NextcladeOrderedWriter;
 use crossbeam::thread;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
+use log::info;
 use nextclade::align::gap_open::{get_gap_open_close_scores_codon_aware, get_gap_open_close_scores_flat};
 use nextclade::analyze::pcr_primers::PcrPrimer;
 use nextclade::analyze::virus_properties::VirusProperties;
-use nextclade::gene::gene_map::GeneMap;
 use nextclade::io::fasta::{read_one_fasta, FastaReader, FastaRecord};
+use nextclade::io::gene_map::{read_gene_map, GeneMap};
 use nextclade::io::gff3::read_gff3_file;
 use nextclade::io::json::json_write;
 use nextclade::io::nuc::{from_nuc_seq, to_nuc_seq, Nuc};
@@ -20,7 +21,6 @@ use nextclade::tree::tree::AuspiceTree;
 use nextclade::tree::tree_attach_new_nodes::tree_attach_new_nodes_in_place;
 use nextclade::tree::tree_preprocess::tree_preprocess_in_place;
 use nextclade::types::outputs::NextcladeOutputs;
-use log::info;
 use serde::{Deserialize, Serialize};
 
 pub struct NextcladeRecord {
@@ -77,18 +77,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
   let ref_record = &read_one_fasta(input_ref)?;
   let ref_seq = &to_nuc_seq(&ref_record.seq)?;
 
-  let gene_map = &if let Some(input_gene_map) = input_gene_map {
-    let mut gene_map = read_gff3_file(&input_gene_map)?;
-    if let Some(genes) = genes {
-      gene_map = gene_map
-        .into_iter()
-        .filter(|(gene_name, ..)| genes.contains(gene_name))
-        .collect();
-    }
-    gene_map
-  } else {
-    GeneMap::new()
-  };
+  let gene_map = &read_gene_map(&input_gene_map, &genes)?;
 
   let gap_open_close_nuc = &get_gap_open_close_scores_codon_aware(ref_seq, gene_map, &alignment_params);
   let gap_open_close_aa = &get_gap_open_close_scores_flat(ref_seq, &alignment_params);

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -2,7 +2,7 @@ use crate::cli::nextclade_loop::NextcladeRecord;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::warn;
-use nextclade::gene::gene_map::GeneMap;
+use nextclade::io::gene_map::GeneMap;
 use nextclade::io::csv::CsvVecFileWriter;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};

--- a/packages_rs/nextclade-web/src/wasm/analyze.rs
+++ b/packages_rs/nextclade-web/src/wasm/analyze.rs
@@ -5,7 +5,7 @@ use nextclade::align::params::AlignPairwiseParams;
 use nextclade::analyze::pcr_primers::PcrPrimer;
 use nextclade::analyze::virus_properties::VirusProperties;
 use nextclade::gene::gene::Gene;
-use nextclade::gene::gene_map::GeneMap;
+use nextclade::io::gene_map::GeneMap;
 use nextclade::io::fasta::read_one_fasta_str;
 use nextclade::io::gff3::read_gff3_str;
 use nextclade::io::json::json_stringify;

--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -70,7 +70,7 @@ mod tests {
   #![allow(clippy::needless_pass_by_value)] // rstest fixtures are passed by value
   use super::*;
   use crate::align::gap_open::{get_gap_open_close_scores_codon_aware, GapScoreMap};
-  use crate::gene::gene_map::GeneMap;
+  use crate::io::gene_map::GeneMap;
   use crate::io::nuc::{from_nuc_seq, to_nuc_seq};
   use eyre::Report;
   use pretty_assertions::assert_eq;

--- a/packages_rs/nextclade/src/align/gap_open.rs
+++ b/packages_rs/nextclade/src/align/gap_open.rs
@@ -1,5 +1,5 @@
 use crate::align::params::AlignPairwiseParams;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::nuc::Nuc;
 
 pub type GapScoreMap = Vec<i32>;

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -157,7 +157,7 @@ mod tests {
   #![allow(clippy::needless_pass_by_value)] // rstest fixtures are passed by value
   use super::*;
   use crate::align::gap_open::{get_gap_open_close_scores_codon_aware, GapScoreMap};
-  use crate::gene::gene_map::GeneMap;
+  use crate::io::gene_map::GeneMap;
   use crate::io::nuc::{to_nuc_seq, Nuc};
   use eyre::Report;
   use pretty_assertions::assert_eq;

--- a/packages_rs/nextclade/src/analyze/aa_changes.rs
+++ b/packages_rs/nextclade/src/analyze/aa_changes.rs
@@ -1,7 +1,7 @@
 use crate::analyze::aa_del::AaDelMinimal;
 use crate::analyze::aa_sub::AaSubMinimal;
 use crate::gene::gene::Gene;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::aa::{from_aa, Aa};
 use crate::io::letter::Letter;
 use crate::io::nuc::{from_nuc_seq, Nuc};

--- a/packages_rs/nextclade/src/analyze/find_private_aa_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_aa_mutations.rs
@@ -4,7 +4,7 @@ use crate::analyze::aa_sub::AaSubMinimal;
 use crate::analyze::is_sequenced::is_aa_sequenced;
 use crate::analyze::letter_ranges::{AaRange, GeneAaRange};
 use crate::analyze::virus_properties::{LabelMap, MutationLabelMaps, VirusProperties};
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::gene::genotype::{Genotype, GenotypeLabeled};
 use crate::io::aa::Aa;
 use crate::io::letter::Letter;

--- a/packages_rs/nextclade/src/gene/gene_map.rs
+++ b/packages_rs/nextclade/src/gene/gene_map.rs
@@ -1,4 +1,0 @@
-use crate::gene::gene::Gene;
-use std::collections::BTreeMap;
-
-pub type GeneMap = BTreeMap<String, Gene>;

--- a/packages_rs/nextclade/src/gene/mod.rs
+++ b/packages_rs/nextclade/src/gene/mod.rs
@@ -1,3 +1,2 @@
 pub mod gene;
-pub mod gene_map;
 pub mod genotype;

--- a/packages_rs/nextclade/src/io/errors_csv.rs
+++ b/packages_rs/nextclade/src/io/errors_csv.rs
@@ -1,4 +1,4 @@
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::csv::{CsvStructFileWriter, CsvStructWriter};
 use crate::io::nextclade_csv::{format_aa_warnings, format_failed_genes};
 use crate::translate::translate_genes::Translation;

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -1,4 +1,4 @@
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::aa::from_aa_seq;
 use crate::io::fs::ensure_dir;
 use crate::translate::translate_genes::Translation;

--- a/packages_rs/nextclade/src/io/gene_map.rs
+++ b/packages_rs/nextclade/src/io/gene_map.rs
@@ -11,7 +11,7 @@ pub type GeneMap = BTreeMap<String, Gene>;
 /// Reads gene map from file and, optionally, filters it according to the list of requested genes.
 ///
 /// Here are the possible combinations:
-/// 
+///
 /// | --genemap  | --genes |                 behavior                   |
 /// |------------|---------|--------------------------------------------|
 /// |     +      |    +    | Take only specified genes                  |
@@ -33,7 +33,7 @@ pub fn read_gene_map(input_gene_map: &Option<PathBuf>, genes: &Option<Vec<String
     (Some(input_gene_map), None) => read_gff3_file(&input_gene_map),
 
     // Gene list is provided, but no gene map. This is illegal.
-    (None, Some(_)) => make_error!("List of genes is only valid when gene map is provided"),
+    (None, Some(_)) => make_error!("List of genes via '--genes' can only be specified when a gene map (genome annotation) is provided"),
 
     // Nothing is provided. Create an empty gene map.
     // This disables codon-aware alignment, translation, AA mutations, frame shifts, and everything else that relies

--- a/packages_rs/nextclade/src/io/gene_map.rs
+++ b/packages_rs/nextclade/src/io/gene_map.rs
@@ -1,0 +1,43 @@
+use crate::gene::gene::Gene;
+use crate::io::gff3::read_gff3_file;
+use crate::make_error;
+use eyre::Report;
+use itertools::Itertools;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+pub type GeneMap = BTreeMap<String, Gene>;
+
+/// Reads gene map from file and, optionally, filters it according to the list of requested genes.
+///
+/// Here are the possible combinations:
+/// 
+/// | --genemap  | --genes |                 behavior                   |
+/// |------------|---------|--------------------------------------------|
+/// |     +      |    +    | Take only specified genes                  |
+/// |     +      |         | Take all genes                             |
+/// |            |    +    | Error                                      |
+/// |            |         | Skip translation and codon penalties       |
+pub fn read_gene_map(input_gene_map: &Option<PathBuf>, genes: &Option<Vec<String>>) -> Result<GeneMap, Report> {
+  match (input_gene_map, genes) {
+    // Both gene map and list of genes are provided. Read gene map and retain only requested genes.
+    (Some(input_gene_map), Some(genes)) => {
+      let gene_map = read_gff3_file(&input_gene_map)?
+        .into_iter()
+        .filter(|(gene_name, ..)| genes.contains(gene_name))
+        .collect();
+      Ok(gene_map)
+    }
+
+    // Only gene map is provided. Read gene map and take all the genes.
+    (Some(input_gene_map), None) => read_gff3_file(&input_gene_map),
+
+    // Gene list is provided, but no gene map. This is illegal.
+    (None, Some(_)) => make_error!("List of genes is only valid when gene map is provided"),
+
+    // Nothing is provided. Create an empty gene map.
+    // This disables codon-aware alignment, translation, AA mutations, frame shifts, and everything else that relies
+    // on gene information.
+    (None, None) => Ok(GeneMap::new()),
+  }
+}

--- a/packages_rs/nextclade/src/io/gff3.rs
+++ b/packages_rs/nextclade/src/io/gff3.rs
@@ -1,5 +1,5 @@
 use crate::gene::gene::Gene;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::utils::error::to_eyre_error;
 use bio::io::gff::{GffType, Reader as GffReader, Record as GffRecord};
 use bio_types::strand::Strand;

--- a/packages_rs/nextclade/src/io/mod.rs
+++ b/packages_rs/nextclade/src/io/mod.rs
@@ -3,6 +3,7 @@ pub mod csv;
 pub mod errors_csv;
 pub mod fasta;
 pub mod fs;
+pub mod gene_map;
 pub mod gff3;
 pub mod insertions_csv;
 pub mod json;

--- a/packages_rs/nextclade/src/run/nextalign_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextalign_run_one.rs
@@ -1,7 +1,7 @@
 use crate::align::align::align_nuc;
 use crate::align::insertions_strip::insertions_strip;
 use crate::align::params::AlignPairwiseParams;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::nuc::Nuc;
 use crate::translate::translate_genes::{translate_genes, Translation, TranslationMap};
 use crate::types::outputs::{NextalignOutputs, PeptideWarning};

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -11,7 +11,7 @@ use crate::analyze::nuc_changes::{find_nuc_changes, FindNucChangesOutput};
 use crate::analyze::pcr_primer_changes::get_pcr_primer_changes;
 use crate::analyze::pcr_primers::PcrPrimer;
 use crate::analyze::virus_properties::VirusProperties;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::aa::Aa;
 use crate::io::letter::Letter;
 use crate::io::nuc::Nuc;

--- a/packages_rs/nextclade/src/translate/translate_genes.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes.rs
@@ -4,7 +4,7 @@ use crate::align::params::AlignPairwiseParams;
 use crate::align::remove_gaps::remove_gaps_in_place;
 use crate::analyze::count_gaps::GapCounts;
 use crate::gene::gene::Gene;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::aa::Aa;
 use crate::io::letter::{serde_deserialize_seq, serde_serialize_seq, Letter};
 use crate::io::nuc::Nuc;

--- a/packages_rs/nextclade/src/translate/translate_genes_ref.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes_ref.rs
@@ -1,5 +1,5 @@
 use crate::align::params::AlignPairwiseParams;
-use crate::gene::gene_map::GeneMap;
+use crate::io::gene_map::GeneMap;
 use crate::io::nuc::Nuc;
 use crate::translate::complement::reverse_complement_in_place;
 use crate::translate::translate::translate;


### PR DESCRIPTION
This modifies behavior of various combinations of `--genemap` and `--genes` flags and makes it consistent in Nextclade CLI and Nextalign CLI.

The new behavior is as follows:

| --genemap  | --genes |                 behavior                   |
|------------|---------|--------------------------------------------|
|     +      |    +    | Take only specified genes                  |
|     +      |         | Take all genes                             |
|            |    +    | Error                                      |
|            |         | Skip translation and codon penalties       |


Notably, if `--genemap` is provided, but `--genes` is not, then all genes will be taken into consideration.
