### PR TITLE
feat: add gap alignment side enum param

### DIFF
--- a/packages_rs/nextclade/src/align/params.rs
+++ b/packages_rs/nextclade/src/align/params.rs
@@ -92,19 +92,8 @@ pub struct AlignPairwiseParams {
   #[clap(default_value_t = AlignPairwiseParams::default().terminal_bandwidth)]
   pub terminal_bandwidth: i32,
 
-  /// TODO: refactor with below into one parameter (two flags into one variable, like action in Python argparse)
-  /// Left align gaps (convention) instead of right align (Nextclade historical practice)
-  /// Make mutually exclusive with `--right-align-gaps`
-  #[clap(long)]
-  pub left_align_gaps: bool,
-
-  /// TODO: refactor with above into one parameter (two flags into one variable, like action in Python argparse)
-  /// Right align gaps (historical Nextclade practice)
-  /// Make mutually exclusive with `--right-align-gaps`
-  #[clap(long)]
-  pub right_align_gaps: bool,
-
-  /// TODO: Write description
+  /// Whether to align gaps on the left or right side if equally parsimonious.
+  /// Left aligning gaps is the convention, right align is Nextclade's historic default
   #[clap(long, arg_enum)]
   #[clap(default_value_t = AlignPairwiseParams::default().gap_alignment_side)]
   pub gap_alignment_side: GapAlignmentSide,
@@ -130,8 +119,6 @@ impl Default for AlignPairwiseParams {
       right_terminal_gaps_free: true,
       excess_bandwidth: 9,
       terminal_bandwidth: 50,
-      left_align_gaps: false,
-      right_align_gaps: true,
       gap_alignment_side: GapAlignmentSide::Right,
     }
   }

--- a/packages_rs/nextclade/src/align/params.rs
+++ b/packages_rs/nextclade/src/align/params.rs
@@ -1,4 +1,10 @@
-use clap::{Parser, ValueHint};
+use clap::{ArgEnum, Parser, ValueHint};
+
+#[derive(ArgEnum, Copy, Clone, Debug)]
+pub enum GapAlignmentSide {
+  Left,
+  Right,
+}
 
 #[derive(Parser, Debug)]
 pub struct AlignPairwiseParams {
@@ -97,6 +103,11 @@ pub struct AlignPairwiseParams {
   /// Make mutually exclusive with `--right-align-gaps`
   #[clap(long)]
   pub right_align_gaps: bool,
+
+  /// TODO: Write description
+  #[clap(long, arg_enum)]
+  #[clap(default_value_t = AlignPairwiseParams::default().gap_alignment_side)]
+  pub gap_alignment_side: GapAlignmentSide,
 }
 
 impl Default for AlignPairwiseParams {
@@ -121,6 +132,7 @@ impl Default for AlignPairwiseParams {
       terminal_bandwidth: 50,
       left_align_gaps: false,
       right_align_gaps: true,
+      gap_alignment_side: GapAlignmentSide::Right,
     }
   }
 }

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -1,5 +1,5 @@
 use crate::align::band_2d::{Band2d, Stripe};
-use crate::align::params::AlignPairwiseParams;
+use crate::align::params::{AlignPairwiseParams, GapAlignmentSide};
 use crate::io::letter::Letter;
 use log::trace;
 
@@ -40,7 +40,10 @@ pub fn score_matrix<T: Letter<T>>(
   // Whether alignment is left or right aligned
   // If default changes, need to change logic here
   // Right align is default so ignored at the moment
-  let left_align = if params.left_align_gaps { 1 } else { 0 };
+  let left_align = match params.gap_alignment_side {
+    GapAlignmentSide::Left => 1,
+    GapAlignmentSide::Right => 0,
+  };
 
   // fill scores with alignment scores
   // if the colon marks the position in the sequence before rPos,qPos

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -37,9 +37,6 @@ pub fn score_matrix<T: Letter<T>>(
 
   trace!("Score matrix: allocated alignment band of size={band_size}");
 
-  // Whether alignment is left or right aligned
-  // If default changes, need to change logic here
-  // Right align is default so ignored at the moment
   let left_align = match params.gap_alignment_side {
     GapAlignmentSide::Left => 1,
     GapAlignmentSide::Right => 0,


### PR DESCRIPTION
For mutually exclusive options.

The CLI args are:

```
--gap-alignment-side=left
--gap-alignment-side=right
```

Perhaps better to call is "gap placement side" or something like this?
