### PR TITLE
fix(web): display codon 0 correctly in peptide context

### DIFF
--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideContext.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideContext.tsx
@@ -6,7 +6,7 @@ import { Table as ReactstrapTable } from 'reactstrap'
 import { safeZip, safeZip3 } from 'src/helpers/safeZip'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { AminoacidChange, AminoacidChangesGroup } from 'src/components/SequenceView/groupAdjacentAminoacidChanges'
-import { first, last } from 'lodash'
+import { first, isNil, last } from 'lodash'
 import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
 import { Aminoacid, Nucleotide } from 'src/algorithms/types'
 
@@ -157,13 +157,27 @@ export function PeptideContextCodon({ refCodon, queryCodon, change, codon, nucBe
 
   const highlight: boolean[] = safeZip(refCodon.split(''), queryCodon.split('')).map(([ref, query]) => ref !== query)
 
+  const codonOneBased = useMemo(() => {
+    if (isNil(codon)) {
+      return 0
+    }
+    return codon + 1
+  }, [codon])
+
+  const nucBeginNeBased = useMemo(() => {
+    if (isNil(nucBegin)) {
+      return 0
+    }
+    return nucBegin + 1
+  }, [nucBegin])
+
   return (
     <td>
       <TableNuc>
         <TableBodyNuc>
           <TrNuc>
             <TdNuc colSpan={3}>
-              <AminoacidPositionText>{codon && codon + 1}</AminoacidPositionText>
+              <AminoacidPositionText>{codonOneBased}</AminoacidPositionText>
             </TdNuc>
           </TrNuc>
 
@@ -191,7 +205,7 @@ export function PeptideContextCodon({ refCodon, queryCodon, change, codon, nucBe
 
           <TrNuc>
             <TdAxis colSpan={3}>
-              <NucleotidePositionText>{nucBegin && nucBegin + 1}</NucleotidePositionText>
+              <NucleotidePositionText>{nucBeginNeBased}</NucleotidePositionText>
             </TdAxis>
           </TrNuc>
         </TableBodyNuc>


### PR DESCRIPTION
This is an extended repeat of https://github.com/nextstrain/nextclade/pull/777, which was accidentally wiped out sometimes during merges.

