### PR TITLE
fix(web): use default gene in sequence views on startup

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { Button, Col, Collapse, Row } from 'reactstrap'
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
+import { useRecoilValue, useResetRecoilState } from 'recoil'
 import { datasetCurrentAtom, datasetCurrentNameAtom } from 'src/state/dataset.state'
 import styled from 'styled-components'
 

--- a/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { Button, Col, Collapse, Row } from 'reactstrap'
-import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
 import { datasetCurrentAtom, datasetCurrentNameAtom } from 'src/state/dataset.state'
 import styled from 'styled-components'
 
@@ -71,11 +71,11 @@ export function DatasetCurrent() {
   const { t } = useTranslationSafe()
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const datasetCurrent = useRecoilValue(datasetCurrentAtom)
-  const setDatasetCurrent = useSetRecoilState(datasetCurrentNameAtom)
+  const resetDatasetCurrent = useResetRecoilState(datasetCurrentNameAtom)
 
   const onChangeClicked = useCallback(() => {
-    setDatasetCurrent(undefined)
-  }, [setDatasetCurrent])
+    resetDatasetCurrent()
+  }, [resetDatasetCurrent])
 
   const onCustomizeClicked = useCallback(() => setAdvancedOpen((advancedOpen) => !advancedOpen), [])
 

--- a/packages_rs/nextclade-web/src/state/dataset.state.ts
+++ b/packages_rs/nextclade-web/src/state/dataset.state.ts
@@ -2,6 +2,7 @@ import { isNil } from 'lodash'
 import { atom, DefaultValue, selector } from 'recoil'
 
 import type { DatasetFlat } from 'src/algorithms/types'
+import { inputResetAtom } from 'src/state/inputs.state'
 import { persistAtom } from 'src/state/persist/localStorage'
 import { viewedGeneAtom } from 'src/state/settings.state'
 import { isDefaultValue } from './results.state'
@@ -27,15 +28,17 @@ export const datasetCurrentNameAtom = selector<string | undefined>({
   get({ get }) {
     return get(datasetCurrentNameStorageAtom)
   },
-  set({ get, set, reset }, datasetCurrentName: string | undefined | DefaultValue) {
-    if (isDefaultValue(datasetCurrentName) || isNil(datasetCurrentName)) {
+  set({ get, set, reset }, newDatasetCurrentName: string | undefined | DefaultValue) {
+    const datasetCurrentName = get(datasetCurrentNameStorageAtom)
+    if (isDefaultValue(newDatasetCurrentName) || isNil(newDatasetCurrentName)) {
       reset(datasetCurrentNameStorageAtom)
-    } else {
+    } else if (datasetCurrentName !== newDatasetCurrentName) {
       const { datasets } = get(datasetsAtom)
-      const dataset = datasets.find((dataset) => dataset.name === datasetCurrentName)
+      const dataset = datasets.find((dataset) => dataset.name === newDatasetCurrentName)
       if (dataset) {
         set(datasetCurrentNameStorageAtom, dataset.name)
         set(viewedGeneAtom, dataset.defaultGene)
+        reset(inputResetAtom)
       }
     }
   },

--- a/packages_rs/nextclade-web/src/state/dataset.state.ts
+++ b/packages_rs/nextclade-web/src/state/dataset.state.ts
@@ -1,3 +1,4 @@
+import { isNil } from 'lodash'
 import { atom, DefaultValue, selector } from 'recoil'
 
 import type { DatasetFlat } from 'src/algorithms/types'
@@ -27,7 +28,7 @@ export const datasetCurrentNameAtom = selector<string | undefined>({
     return get(datasetCurrentNameStorageAtom)
   },
   set({ get, set, reset }, datasetCurrentName: string | undefined | DefaultValue) {
-    if (isDefaultValue(datasetCurrentName)) {
+    if (isDefaultValue(datasetCurrentName) || isNil(datasetCurrentName)) {
       reset(datasetCurrentNameStorageAtom)
     } else {
       const { datasets } = get(datasetsAtom)

--- a/packages_rs/nextclade-web/src/state/inputs.state.ts
+++ b/packages_rs/nextclade-web/src/state/inputs.state.ts
@@ -43,3 +43,18 @@ export const hasRequiredInputsAtom = selector({
     return !isNil(get(qrySeqInputAtom))
   },
 })
+
+/** Resets all inputs (e.g. when switching datasets) */
+export const inputResetAtom = selector<undefined>({
+  key: 'inputReset',
+  get: () => undefined,
+  set({ reset }) {
+    reset(qrySeqInputAtom)
+    reset(refSeqInputAtom)
+    reset(geneMapInputAtom)
+    reset(refTreeInputAtom)
+    reset(qcConfigInputAtom)
+    reset(virusPropertiesInputAtom)
+    reset(primersCsvInputAtom)
+  },
+})


### PR DESCRIPTION
This ensures that sequence view are switched to default gene after navigation to results page. The gene is changed every time the dataset is changed. Otherwise it remembers selected gene (even across runs).

Additionally, it also removes all input files when dataset is changed. Seemingly unrelated, but it was close by in the code and easy to fix.
