### PR TITLE
fix(cli): ensure nextalign cli args for alignment tunning  are optional

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -6,7 +6,7 @@ use eyre::{eyre, Report, WrapErr};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::LevelFilter;
-use nextclade::align::params::AlignPairwiseParams;
+use nextclade::align::params::AlignPairwiseParamsOptional;
 use nextclade::io::fs::basename;
 use nextclade::make_error;
 use nextclade::utils::global_init::setup_logger;
@@ -176,7 +176,7 @@ pub struct NextalignRunArgs {
   pub in_order: bool,
 
   #[clap(flatten)]
-  pub alignment_params: AlignPairwiseParams,
+  pub alignment_params: AlignPairwiseParamsOptional,
 }
 
 fn generate_completions(shell: &str) -> Result<(), Report> {


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/801 where I changed Nextclade CLI args, but forgot to adjust Nextalign CLI args. This PR fixes this omission in Nextalign CLI, by using AlignPairwiseParamsOptional struct, instead of AlignPairwiseParams, and merging incoming CLI params into the defaults, just like it is in Nextclade CLI since #801.

