### PR TITLE
fix: make GapAlignmentSide values in JSON to resemble the ones in CLI

### DIFF
--- a/packages_rs/nextclade/src/align/params.rs
+++ b/packages_rs/nextclade/src/align/params.rs
@@ -3,6 +3,7 @@ use optfield::optfield;
 use serde::{Deserialize, Serialize};
 
 #[derive(ArgEnum, Copy, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum GapAlignmentSide {
   Left,
   Right,


### PR DESCRIPTION
Uses [serde's `rename_all` container attribute](https://serde.rs/container-attrs.html#rename_all) to convert variants of `enum GapAlignmentSide` to kebab case during (de)serialization, e.g. in `virus_proprieties.json`.

The enum variants in Rust are by convention in PascalCase, and serde uses them as is. But we want to make the values in `virus_proerties.json` to resemble the values in CLI arguments, and clap seems to be converting enums to kebab case.

If merged, this change requires simultaneous adjustment of datasets using the `gap_alignment_side` param.

