### PR TITLE
refactor: replace gene.strand strings with enum variants

### DIFF
--- a/packages_rs/nextclade/src/gene/gene.rs
+++ b/packages_rs/nextclade/src/gene/gene.rs
@@ -1,4 +1,25 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum GeneStrand {
+  #[serde(rename = "+")]
+  Forward,
+  #[serde(rename = "-")]
+  Reverse,
+  #[serde(rename = ".")]
+  Unknown,
+}
+
+impl From<bio_types::strand::Strand> for GeneStrand {
+  fn from(s: bio_types::strand::Strand) -> Self {
+    match s {
+      bio_types::strand::Strand::Forward => Self::Forward,
+      bio_types::strand::Strand::Reverse => Self::Reverse,
+      bio_types::strand::Strand::Unknown => Self::Unknown,
+    }
+  }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -6,7 +27,7 @@ pub struct Gene {
   pub gene_name: String,
   pub start: usize,
   pub end: usize,
-  pub strand: String,
+  pub strand: GeneStrand,
   pub frame: i32,
 }
 

--- a/packages_rs/nextclade/src/io/gff3.rs
+++ b/packages_rs/nextclade/src/io/gff3.rs
@@ -1,4 +1,4 @@
-use crate::gene::gene::Gene;
+use crate::gene::gene::{Gene, GeneStrand};
 use crate::io::gene_map::GeneMap;
 use crate::utils::error::to_eyre_error;
 use bio::io::gff::{GffType, Reader as GffReader, Record as GffRecord};
@@ -22,9 +22,9 @@ pub fn convert_gff_record_to_gene(gene_name: &str, record: &GffRecord) -> Result
   let start = (*record.start() - 1) as usize; // Convert to 0-based indices
   Ok(Gene {
     gene_name: gene_name.to_owned(),
-    start, // Convert to 0-based indices
+    start,
     end: *record.end() as usize,
-    strand: record.strand().unwrap_or(Strand::from_char(&'+')?).to_string(), // '+' strand by default
+    strand: record.strand().map(|s| s.into()).unwrap_or(GeneStrand::Unknown),
     frame: parse_gff3_frame(record.frame(), start),
   })
 }

--- a/packages_rs/nextclade/src/io/gff3.rs
+++ b/packages_rs/nextclade/src/io/gff3.rs
@@ -24,7 +24,7 @@ pub fn convert_gff_record_to_gene(gene_name: &str, record: &GffRecord) -> Result
     gene_name: gene_name.to_owned(),
     start,
     end: *record.end() as usize,
-    strand: record.strand().map(|s| s.into()).unwrap_or(GeneStrand::Unknown),
+    strand: record.strand().map_or(GeneStrand::Unknown, |s| s.into()),
     frame: parse_gff3_frame(record.frame(), start),
   })
 }

--- a/packages_rs/nextclade/src/translate/translate_genes.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes.rs
@@ -3,7 +3,7 @@ use crate::align::insertions_strip::{insertions_strip, Insertion};
 use crate::align::params::AlignPairwiseParams;
 use crate::align::remove_gaps::remove_gaps_in_place;
 use crate::analyze::count_gaps::GapCounts;
-use crate::gene::gene::Gene;
+use crate::gene::gene::{Gene, GeneStrand};
 use crate::io::aa::Aa;
 use crate::io::gene_map::GeneMap;
 use crate::io::letter::{serde_deserialize_seq, serde_serialize_seq, Letter};
@@ -144,7 +144,7 @@ pub fn translate_gene(
   let mut qry_gene_seq = extract_gene(qry_seq, gene, coord_map);
 
   // Reverse strands should be reverse-complemented first
-  if gene.strand.contains("-") {
+  if gene.strand == GeneStrand::Reverse {
     reverse_complement_in_place(&mut ref_gene_seq);
     reverse_complement_in_place(&mut qry_gene_seq);
   }

--- a/packages_rs/nextclade/src/translate/translate_genes_ref.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes_ref.rs
@@ -1,4 +1,5 @@
 use crate::align::params::AlignPairwiseParams;
+use crate::gene::gene::GeneStrand;
 use crate::io::gene_map::GeneMap;
 use crate::io::nuc::Nuc;
 use crate::translate::complement::reverse_complement_in_place;
@@ -16,7 +17,7 @@ pub fn translate_genes_ref(
     .iter()
     .map(|(gene_name, gene)| -> Result<(String, Translation), Report> {
       let mut gene_nuc_seq = ref_seq[gene.start..gene.end].to_vec();
-      if gene.strand == "-" {
+      if gene.strand == GeneStrand::Reverse {
         reverse_complement_in_place(&mut gene_nuc_seq);
       }
       let peptide = translate(&gene_nuc_seq, gene, params)?;


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/809

Enum should be less prone to errors, more idiomatic, and perhaps even a tiny bit faster that strings.

Additionally, if strand is missing from GFF file, I set it to `Unknown` (`.`) variant now, instead of to `Forward` (`+`). I think this is more correct. The enum variant `Unknown` can be handled separately if needed, in the code that uses `gene.strand`.