### PR TITLE
feat(web): configure sequence markers height

### DIFF
--- a/packages_rs/nextclade-web/src/components/Common/Multitoggle.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/Multitoggle.tsx
@@ -1,0 +1,95 @@
+import { noop } from 'lodash'
+import React, { useCallback, useMemo } from 'react'
+import styled from 'styled-components'
+
+export const Switch = styled.div<{ $width: number }>`
+  position: relative;
+  height: 26px;
+  width: ${(props) => props.$width}px;
+  background-color: ${(props) => props.theme.gray300};
+  border-radius: 3px;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px rgba(255, 255, 255, 0.1);
+`
+
+export const SwitchRadio = styled.input`
+  display: none;
+`
+
+export const SwitchSelection = styled.span<{ $widthPx: number; $leftPercent: number }>`
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: ${(props) => props.$leftPercent}%;
+  width: ${(props) => props.$widthPx}px;
+  height: 26px;
+  background-color: ${(props) => props.theme.primary};
+  border-radius: 3px;
+  transition: left 0.25s ease-out;
+  box-shadow: ${(props) => props.theme.shadows.slight};
+`
+
+export const SwitchLabel = styled.label<{ $widthPx: number }>`
+  position: relative;
+  z-index: 2;
+  float: left;
+  width: ${(props) => props.$widthPx}px;
+  line-height: 26px;
+  font-size: 12px;
+  color: ${(props) => props.theme.bodyColor};
+  text-align: center;
+  cursor: pointer;
+
+  ${SwitchRadio}:checked + & {
+    transition: 0.15s ease-out;
+    color: ${(props) => props.theme.white};
+  }
+`
+
+export interface ClickableLabelProps {
+  value: string
+  onChange(value: string): void
+  itemWidth: number
+}
+
+export function ClickableLabel({ value, onChange, itemWidth, ...restProps }: ClickableLabelProps) {
+  const onClick = useCallback(() => onChange(value), [onChange, value])
+  return (
+    <SwitchLabel onClick={onClick} $widthPx={itemWidth} {...restProps}>
+      {value}
+    </SwitchLabel>
+  )
+}
+
+export interface MultitoggleProps {
+  values: string[]
+  value: string
+  onChange(value: string): void
+  itemWidth?: number
+}
+
+export function Multitoggle({ values, value, onChange, itemWidth = 45, ...restProps }: MultitoggleProps) {
+  const { selectionLeftPercent, selectionWidthPx, totalWidth } = useMemo(() => {
+    return {
+      selectionLeftPercent: (values.indexOf(value) / values.length) * 100,
+      selectionWidthPx: itemWidth,
+      totalWidth: itemWidth * values.length,
+    }
+  }, [itemWidth, value, values])
+
+  return (
+    <Switch $width={totalWidth} {...restProps}>
+      {values.map((val) => {
+        return (
+          <span key={val}>
+            <SwitchRadio type="radio" name="switch" checked={val === value} onChange={noop} />
+            <ClickableLabel value={val} onChange={onChange} itemWidth={itemWidth} />
+          </span>
+        )
+      })}
+      <SwitchSelection $leftPercent={selectionLeftPercent} $widthPx={selectionWidthPx} />
+    </Switch>
+  )
+}
+
+//

--- a/packages_rs/nextclade-web/src/components/Common/NumericInput.ts
+++ b/packages_rs/nextclade-web/src/components/Common/NumericInput.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+import { Input } from 'src/components/Common/NumericField'
+
+export const NumericInput = styled(Input)`
+  display: inline;
+  max-width: 5rem;
+`

--- a/packages_rs/nextclade-web/src/components/Layout/SettingsButton.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/SettingsButton.tsx
@@ -1,37 +1,28 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { debounce } from 'lodash'
-
 import {
-  Alert,
   Button,
   ButtonProps,
   Col,
   Container,
   FormGroup,
-  Label,
   Modal as ReactstrapModal,
   ModalBody as ReactstrapModalBody,
   ModalFooter as ReactstrapModalFooter,
   ModalHeader as ReactstrapModalHeader,
   Row,
 } from 'reactstrap'
-import classNames from 'classnames'
-import { useRecoilState, useResetRecoilState } from 'recoil'
-import { changelogShouldShowOnUpdatesAtom, isSettingsDialogOpenAtom, numThreadsAtom } from 'src/state/settings.state'
+import { useRecoilState } from 'recoil'
 import styled from 'styled-components'
 import { IoMdSettings } from 'react-icons/io'
-import { MdRefresh } from 'react-icons/md'
-import { useFormikContext, Formik, Form, FormikHelpers, FormikErrors } from 'formik'
 
-import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
+import { CardL2, CardL2Body, CardL2Header } from 'src/components/Common/Card'
 import { Toggle } from 'src/components/Common/Toggle'
+import { SeqViewSettings } from 'src/components/Settings/SeqViewSettings'
+import { SystemSettings } from 'src/components/Settings/SystemSettings'
+import { changelogShouldShowOnUpdatesAtom, isSettingsDialogOpenAtom } from 'src/state/settings.state'
+import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { Input } from 'src/components/Common/NumericField'
-import { MEMORY_BYTES_PER_THREAD_MINIMUM, useGuessNumThreads } from 'src/helpers/getNumThreads'
-import { PROJECT_NAME } from 'src/constants'
-import { prettyBytes } from 'src/i18n/i18n'
-import { TableSlim } from 'src/components/Common/TableSlim'
 
 export const ButtonSettingsBase = styled(ButtonTransparent)<ButtonProps>`
   margin: 2px 2px;
@@ -85,65 +76,19 @@ export const ModalFooter = styled(ReactstrapModalFooter)`
   padding: 0;
 `
 
-export const NumericInput = styled(Input)`
-  display: inline;
-  max-width: 5rem;
-`
-
-export interface SettingsFormValues {
-  numThreads: number
-}
-
 export function SettingsButton() {
   const { t } = useTranslationSafe()
 
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useRecoilState(isSettingsDialogOpenAtom)
   const [showWhatsnewOnUpdate, setShowWhatsnewOnUpdate] = useRecoilState(changelogShouldShowOnUpdatesAtom)
-  const [numThreads, setNumThreads] = useRecoilState(numThreadsAtom)
-  const resetNumThreads = useResetRecoilState(numThreadsAtom)
-
-  const guess = useGuessNumThreads(numThreads)
 
   const toggleOpen = useCallback(
     () => setIsSettingsDialogOpen(!isSettingsDialogOpen),
     [setIsSettingsDialogOpen, isSettingsDialogOpen],
   )
 
-  const handleValidate = useCallback((values: SettingsFormValues): FormikErrors<SettingsFormValues> => {
-    const errors: FormikErrors<SettingsFormValues> = {}
-    const { numThreads } = values
-    if (!Number.isInteger(numThreads) || numThreads < 0 || numThreads > 1000) {
-      errors.numThreads = 'Should be a positive integer from 1 to 1000'
-    }
-    return errors
-  }, [])
-
-  const setNumThreadsDebounced = useMemo(
-    () => debounce(setNumThreads, 500, { leading: false, trailing: true }), // prettier-ignore
-    [setNumThreads],
-  )
-
-  const handleSubmit = useCallback(
-    (values: SettingsFormValues, { setSubmitting }: FormikHelpers<SettingsFormValues>) => {
-      setNumThreadsDebounced(values.numThreads)
-      setSubmitting(false)
-    },
-    [setNumThreadsDebounced],
-  )
-
   const text = useMemo(() => t('Settings'), [t])
   const closeText = useMemo(() => t('Close this window'), [t])
-
-  const initialValues = useMemo(() => ({ numThreads }), [numThreads])
-  const onReset = useCallback(() => ({ numThreads }), [numThreads])
-
-  const memoryAvailable = useMemo(() => {
-    return guess.memoryAvailable ? prettyBytes.format(guess.memoryAvailable) : t('unsupported')
-  }, [guess.memoryAvailable, t])
-
-  const memoryAvailablePerThread = useMemo(() => {
-    return guess.memoryAvailable ? prettyBytes.format(guess.memoryAvailable / numThreads) : t('unsupported')
-  }, [guess.memoryAvailable, numThreads, t])
 
   return (
     <>
@@ -161,101 +106,40 @@ export function SettingsButton() {
           <Container>
             <Row>
               <Col>
-                <Formik
-                  initialValues={initialValues}
-                  validate={handleValidate}
-                  onSubmit={handleSubmit}
-                  onReset={onReset}
-                >
-                  {({ values, errors, touched, handleChange, handleBlur, resetForm }) => (
-                    <Form>
-                      <FormikAutoSubmit />
-
-                      <FormGroup>
-                        <Label className="d-block w-100">
-                          <NumericInput
-                            id="numThreads"
-                            min={1}
-                            max={1000}
-                            className={classNames('d-inline', errors?.numThreads && 'border-danger')}
-                            type="number"
-                            identifier="settings-num-threads-input"
-                            value={values.numThreads}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                          />
-                          <span className="d-inline">
-                            <span className="mx-3">{t('Number of CPU threads')}</span>
-                            <span className="mx-auto">
-                              <ButtonTransparent
-                                className="my-0"
-                                type="button"
-                                title={t('Reset to default')}
-                                // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
-                                onClick={() => {
-                                  resetNumThreads()
-                                  resetForm()
-                                }}
-                              >
-                                <MdRefresh /> {t('Reset')}
-                              </ButtonTransparent>
-                            </span>
-                          </span>
-                          {touched.numThreads && errors?.numThreads && (
-                            <p className="text-danger">{errors.numThreads}</p>
-                          )}
-                          {guess.numThreads && guess.memoryAvailable && (
-                            <Alert className="mt-2 p-1" color="primary" isOpen fade={false}>
-                              <TableSlim borderless className="small mb-1">
-                                <tbody>
-                                  <tr>
-                                    <td>{t('Memory available*')}</td>
-                                    <td>{memoryAvailable}</td>
-                                  </tr>
-
-                                  <tr>
-                                    <td>{t('Memory per CPU thread')}</td>
-                                    <td>{memoryAvailablePerThread}</td>
-                                  </tr>
-
-                                  <tr>
-                                    <td>{t('Recommended number of CPU threads**')}</td>
-                                    <td>{guess.numThreads ?? t('unsupported')}</td>
-                                  </tr>
-
-                                  <tr>
-                                    <td colSpan={2} className="small">
-                                      {t('* Current value. This amount can change depending on load')}
-                                    </td>
-                                  </tr>
-
-                                  <tr>
-                                    <td colSpan={2} className="small">
-                                      {t('** {{appName}} requires at least {{memoryRequired}} of memory per thread', {
-                                        appName: PROJECT_NAME,
-                                        memoryRequired: prettyBytes.format(MEMORY_BYTES_PER_THREAD_MINIMUM),
-                                      })}
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </TableSlim>
-                            </Alert>
-                          )}
-                        </Label>
-                      </FormGroup>
-
-                      <FormGroup>
-                        <Toggle
-                          identifier={'settings-show-whatsnew-toggle'}
-                          checked={showWhatsnewOnUpdate}
-                          onCheckedChanged={setShowWhatsnewOnUpdate}
-                        >
-                          {t(`Show "What's new" dialog after each update`)}
-                        </Toggle>
-                      </FormGroup>
-                    </Form>
-                  )}
-                </Formik>
+                <CardL2>
+                  <CardL2Header>{t('System')}</CardL2Header>
+                  <CardL2Body>
+                    <SystemSettings />
+                  </CardL2Body>
+                </CardL2>
+              </Col>
+            </Row>
+            <Row noGutters>
+              <Col>
+                <CardL2>
+                  <CardL2Header>{t('Sequence view markers')}</CardL2Header>
+                  <CardL2Body>
+                    <SeqViewSettings />
+                  </CardL2Body>
+                </CardL2>
+              </Col>
+            </Row>
+            <Row noGutters>
+              <Col>
+                <CardL2>
+                  <CardL2Header>{t('Other settings')}</CardL2Header>
+                  <CardL2Body>
+                    <FormGroup>
+                      <Toggle
+                        identifier={'settings-show-whatsnew-toggle'}
+                        checked={showWhatsnewOnUpdate}
+                        onCheckedChanged={setShowWhatsnewOnUpdate}
+                      >
+                        {t(`Show "What's new" dialog after each update`)}
+                      </Toggle>
+                    </FormGroup>
+                  </CardL2Body>
+                </CardL2>
               </Col>
             </Row>
           </Container>
@@ -275,14 +159,4 @@ export function SettingsButton() {
       </Modal>
     </>
   )
-}
-
-export function FormikAutoSubmit() {
-  const { values, submitForm, isValid } = useFormikContext()
-  React.useEffect(() => {
-    if (isValid) {
-      void submitForm() // eslint-disable-line no-void
-    }
-  }, [values, submitForm, isValid])
-  return null
 }

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -3,12 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
 import type { FrameShift } from 'src/algorithms/types'
-import { BASE_MIN_WIDTH_PX } from 'src/constants'
-import { Tooltip } from 'src/components/Results/Tooltip'
 import { TableRowSpacer, TableSlim } from 'src/components/Common/TableSlim'
+import { Tooltip } from 'src/components/Results/Tooltip'
+import { BASE_MIN_WIDTH_PX } from 'src/constants'
 import { formatRange, formatRangeMaybeEmpty } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { geneMapAtom } from 'src/state/results.state'
+import { SeqMarkerFrameShiftState, seqMarkerFrameShiftStateAtom } from 'src/state/seqViewSettings.state'
 
 const frameShiftColor = '#eb0d2a'
 const frameShiftBorderColor = '#ffff00'
@@ -26,6 +27,12 @@ function SequenceMarkerFrameShiftUnmemoed({ seqName, frameShift, pixelsPerBase, 
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
   const geneMap = useRecoilValue(geneMapAtom)
+
+  const seqMarkerFrameShiftState = useRecoilValue(seqMarkerFrameShiftStateAtom)
+
+  if (seqMarkerFrameShiftState === SeqMarkerFrameShiftState.Off) {
+    return null
+  }
 
   const { geneName, nucAbs, codon, gapsTrailing, gapsLeading } = frameShift
   const id = getSafeId('frame-shift-nuc-marker', { seqName, ...frameShift })

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerGap.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerGap.tsx
@@ -1,4 +1,5 @@
-import React, { SVGProps, useCallback, useState } from 'react'
+import React, { SVGProps, useCallback, useMemo, useState } from 'react'
+import { useRecoilValue } from 'recoil'
 
 import { BASE_MIN_WIDTH_PX, GAP } from 'src/constants'
 import type { NucleotideDeletion } from 'src/algorithms/types'
@@ -9,6 +10,7 @@ import { formatRange } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { getSeqMarkerDims, seqMarkerGapHeightStateAtom, SeqMarkerHeightState } from 'src/state/seqViewSettings.state'
 
 const gapColor = getNucleotideColor(GAP)
 
@@ -23,6 +25,13 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
+
+  const seqMarkerGapHeightState = useRecoilValue(seqMarkerGapHeightStateAtom)
+  const { y, height } = useMemo(() => getSeqMarkerDims(seqMarkerGapHeightState), [seqMarkerGapHeightState])
+
+  if (seqMarkerGapHeightState === SeqMarkerHeightState.Off) {
+    return null
+  }
 
   const { start: begin, length, aaSubstitutions, aaDeletions } = deletion
   const end = begin + length
@@ -43,9 +52,9 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
       id={id}
       fill={gapColor}
       x={x}
-      y={-10}
+      y={y}
       width={width}
-      height="30"
+      height={height}
       {...rest}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMissing.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMissing.tsx
@@ -1,13 +1,19 @@
-import React, { SVGProps, useCallback, useState } from 'react'
+import React, { SVGProps, useCallback, useMemo, useState } from 'react'
 
 import { useTranslation } from 'react-i18next'
-import { BASE_MIN_WIDTH_PX, N } from 'src/constants'
+import { useRecoilValue } from 'recoil'
 
 import type { NucleotideMissing } from 'src/algorithms/types'
-import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
 import { Tooltip } from 'src/components/Results/Tooltip'
+import { BASE_MIN_WIDTH_PX, N } from 'src/constants'
 import { formatRange } from 'src/helpers/formatRange'
+import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
 import { getSafeId } from 'src/helpers/getSafeId'
+import {
+  getSeqMarkerDims,
+  SeqMarkerHeightState,
+  seqMarkerMissingHeightStateAtom,
+} from 'src/state/seqViewSettings.state'
 
 const missingColor = getNucleotideColor(N)
 
@@ -22,6 +28,13 @@ export function SequenceMarkerMissingUnmemoed({ seqName, missing, pixelsPerBase,
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
+
+  const seqMarkerMissingHeightState = useRecoilValue(seqMarkerMissingHeightStateAtom)
+  const { y, height } = useMemo(() => getSeqMarkerDims(seqMarkerMissingHeightState), [seqMarkerMissingHeightState])
+
+  if (seqMarkerMissingHeightState === SeqMarkerHeightState.Off) {
+    return null
+  }
 
   const { begin, end } = missing // prettier-ignore
 
@@ -38,9 +51,9 @@ export function SequenceMarkerMissingUnmemoed({ seqName, missing, pixelsPerBase,
       id={id}
       fill={missingColor}
       x={x}
-      y={-10}
+      y={y}
       width={width}
-      height="30"
+      height={height}
       {...rest}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMutation.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMutation.tsx
@@ -1,13 +1,19 @@
-import React, { SVGProps, useCallback, useState } from 'react'
+import React, { SVGProps, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-
-import { BASE_MIN_WIDTH_PX } from 'src/constants'
+import { useRecoilValue } from 'recoil'
 import type { NucleotideSubstitution } from 'src/algorithms/types'
-import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
-import { Tooltip } from 'src/components/Results/Tooltip'
-import { getSafeId } from 'src/helpers/getSafeId'
 import { AminoacidMutationBadge, NucleotideMutationBadge } from 'src/components/Common/MutationBadge'
 import { TableSlim } from 'src/components/Common/TableSlim'
+import { Tooltip } from 'src/components/Results/Tooltip'
+
+import { BASE_MIN_WIDTH_PX } from 'src/constants'
+import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
+import { getSafeId } from 'src/helpers/getSafeId'
+import {
+  getSeqMarkerDims,
+  SeqMarkerHeightState,
+  seqMarkerMutationHeightStateAtom,
+} from 'src/state/seqViewSettings.state'
 
 export interface SequenceMarkerMutationProps extends SVGProps<SVGRectElement> {
   seqName: string
@@ -26,6 +32,13 @@ function SequenceMarkerMutationUnmemoed({
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
+  const seqMarkerMutationHeightState = useRecoilValue(seqMarkerMutationHeightStateAtom)
+  const { y, height } = useMemo(() => getSeqMarkerDims(seqMarkerMutationHeightState), [seqMarkerMutationHeightState])
+
+  if (seqMarkerMutationHeightState === SeqMarkerHeightState.Off) {
+    return null
+  }
+
   const { pos, queryNuc, aaSubstitutions, aaDeletions } = substitution
   const id = getSafeId('mutation-marker', { seqName, ...substitution })
 
@@ -41,9 +54,9 @@ function SequenceMarkerMutationUnmemoed({
       id={id}
       fill={fill}
       x={x}
-      y={-10}
+      y={y}
       width={width}
-      height="30"
+      height={height}
       {...rest}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerUnsequenced.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerUnsequenced.tsx
@@ -1,13 +1,19 @@
-import React, { memo, PropsWithChildren, SVGProps, useCallback, useState } from 'react'
+import React, { memo, PropsWithChildren, SVGProps, useCallback, useMemo, useState } from 'react'
 
 import { useTranslation } from 'react-i18next'
+import { useRecoilValue } from 'recoil'
 
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { BASE_MIN_WIDTH_PX } from 'src/constants'
 import { formatRange } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
+import {
+  getSeqMarkerDims,
+  SeqMarkerHeightState,
+  seqMarkerUnsequencedHeightStateAtom,
+} from 'src/state/seqViewSettings.state'
 
-const colorUnsequenced = '#BBBBBB'
+const colorUnsequenced = '#bbbbbb'
 
 export interface SequenceMarkerProps extends SVGProps<SVGRectElement> {
   id: string
@@ -28,6 +34,16 @@ export const SequenceMarker = memo(function SequenceMarkerImpl({
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
+  const seqMarkerUnsequencedHeightState = useRecoilValue(seqMarkerUnsequencedHeightStateAtom)
+  const { y, height } = useMemo(
+    () => getSeqMarkerDims(seqMarkerUnsequencedHeightState),
+    [seqMarkerUnsequencedHeightState],
+  )
+
+  if (seqMarkerUnsequencedHeightState === SeqMarkerHeightState.Off) {
+    return null
+  }
+
   let width = (end - begin) * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
   const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
@@ -45,9 +61,9 @@ export const SequenceMarker = memo(function SequenceMarkerImpl({
       id={id}
       fill={colorUnsequenced}
       x={x}
-      y={-10}
+      y={y}
       width={width}
-      height="30"
+      height={height}
       {...restProps}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/packages_rs/nextclade-web/src/components/Settings/SeqViewSettings.tsx
+++ b/packages_rs/nextclade-web/src/components/Settings/SeqViewSettings.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback, useMemo } from 'react'
+import { Col, Container, Form, FormGroup, Label, Row } from 'reactstrap'
+import { RecoilState, useRecoilState } from 'recoil'
+import { Multitoggle } from 'src/components/Common/Multitoggle'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import {
+  SEQ_MARKER_HEIGHT_STATES,
+  SeqMarkerHeightState,
+  seqMarkerHeightStateFromString,
+  seqMarkerMissingHeightStateAtom,
+  seqMarkerHeightStateToString,
+  seqMarkerGapHeightStateAtom,
+  seqMarkerMutationHeightStateAtom,
+  seqMarkerUnsequencedHeightStateAtom,
+} from 'src/state/seqViewSettings.state'
+
+/** Adapts Recoil state  `enum` to `string` */
+export function useEnumRecoilState<T>(
+  state: RecoilState<T>,
+  serialize: (x: T) => string,
+  deserialize: (k: string) => T,
+): [string, (k: string) => void] {
+  const [enumValue, setEnumValue] = useRecoilState(state)
+
+  const stringValue = useMemo(() => {
+    return serialize(enumValue)
+  }, [enumValue, serialize])
+
+  const setStringValue = useCallback(
+    (key: string) => {
+      const e = deserialize(key)
+      setEnumValue(e)
+    },
+    [deserialize, setEnumValue],
+  )
+
+  return [stringValue, setStringValue]
+}
+
+export function useSeqMarkerState(state: RecoilState<SeqMarkerHeightState>) {
+  return useEnumRecoilState(state, seqMarkerHeightStateToString, seqMarkerHeightStateFromString)
+}
+
+export function SeqViewSettings() {
+  const { t } = useTranslationSafe()
+
+  const [seqMarkerMissingHeightState, setSeqMarkerMissingHeightState] = useSeqMarkerState(
+    seqMarkerMissingHeightStateAtom,
+  )
+
+  const [seqMarkerGapHeightState, setSeqMarkerGapHeightState] = useSeqMarkerState(seqMarkerGapHeightStateAtom)
+
+  const [seqMarkerMutationHeightState, setSeqMarkerMutationHeightState] = useSeqMarkerState(
+    seqMarkerMutationHeightStateAtom,
+  )
+
+  const [seqMarkerUnsequencedHeightState, setSeqMarkerUnsequencedHeightState] = useSeqMarkerState(
+    seqMarkerUnsequencedHeightStateAtom,
+  )
+
+  return (
+    <Container fluid>
+      <Row noGutters>
+        <Col>
+          <Form>
+            <FormGroup>
+              {t('Missing')}
+              <Multitoggle
+                values={SEQ_MARKER_HEIGHT_STATES}
+                value={seqMarkerMissingHeightState}
+                onChange={setSeqMarkerMissingHeightState}
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <Label>
+                {t('Gaps')}
+                <Multitoggle
+                  values={SEQ_MARKER_HEIGHT_STATES}
+                  value={seqMarkerGapHeightState}
+                  onChange={setSeqMarkerGapHeightState}
+                />
+              </Label>
+            </FormGroup>
+
+            <FormGroup>
+              <Label>
+                {t('Mutations')}
+                <Multitoggle
+                  values={SEQ_MARKER_HEIGHT_STATES}
+                  value={seqMarkerMutationHeightState}
+                  onChange={setSeqMarkerMutationHeightState}
+                />
+              </Label>
+            </FormGroup>
+
+            <FormGroup>
+              <Label>
+                {t('Unsequenced')}
+                <Multitoggle
+                  values={SEQ_MARKER_HEIGHT_STATES}
+                  value={seqMarkerUnsequencedHeightState}
+                  onChange={setSeqMarkerUnsequencedHeightState}
+                />
+              </Label>
+            </FormGroup>
+          </Form>
+        </Col>
+      </Row>
+    </Container>
+  )
+}

--- a/packages_rs/nextclade-web/src/components/Settings/SystemSettings.tsx
+++ b/packages_rs/nextclade-web/src/components/Settings/SystemSettings.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useMemo } from 'react'
+import { useRecoilState, useResetRecoilState } from 'recoil'
+import classNames from 'classnames'
+import { Form, Formik, FormikErrors, FormikHelpers, useFormikContext } from 'formik'
+import { debounce } from 'lodash'
+import { MdRefresh } from 'react-icons/md'
+import { Alert, FormGroup, Label } from 'reactstrap'
+
+import { PROJECT_NAME } from 'src/constants'
+import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
+import { TableSlim } from 'src/components/Common/TableSlim'
+import { MEMORY_BYTES_PER_THREAD_MINIMUM, useGuessNumThreads } from 'src/helpers/getNumThreads'
+import { prettyBytes } from 'src/i18n/i18n'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { NumericInput } from 'src/components/Common/NumericInput'
+import { numThreadsAtom } from 'src/state/settings.state'
+
+export interface SettingsFormValues {
+  numThreads: number
+}
+
+export function SystemSettings() {
+  const { t } = useTranslationSafe()
+
+  const [numThreads, setNumThreads] = useRecoilState(numThreadsAtom)
+  const resetNumThreads = useResetRecoilState(numThreadsAtom)
+  const guess = useGuessNumThreads(numThreads)
+  const handleValidate = useCallback((values: SettingsFormValues): FormikErrors<SettingsFormValues> => {
+    const errors: FormikErrors<SettingsFormValues> = {}
+    const { numThreads } = values
+    if (!Number.isInteger(numThreads) || numThreads < 0 || numThreads > 1000) {
+      errors.numThreads = 'Should be a positive integer from 1 to 1000'
+    }
+    return errors
+  }, [])
+
+  const setNumThreadsDebounced = useMemo(
+    () => debounce(setNumThreads, 500, { leading: false, trailing: true }), // prettier-ignore
+    [setNumThreads],
+  )
+
+  const handleSubmit = useCallback(
+    (values: SettingsFormValues, { setSubmitting }: FormikHelpers<SettingsFormValues>) => {
+      setNumThreadsDebounced(values.numThreads)
+      setSubmitting(false)
+    },
+    [setNumThreadsDebounced],
+  )
+
+  const initialValues = useMemo(() => ({ numThreads }), [numThreads])
+  const onReset = useCallback(() => ({ numThreads }), [numThreads])
+
+  const memoryAvailable = useMemo(() => {
+    return guess.memoryAvailable ? prettyBytes.format(guess.memoryAvailable) : t('unsupported')
+  }, [guess.memoryAvailable, t])
+
+  const memoryAvailablePerThread = useMemo(() => {
+    return guess.memoryAvailable ? prettyBytes.format(guess.memoryAvailable / numThreads) : t('unsupported')
+  }, [guess.memoryAvailable, numThreads, t])
+
+  return (
+    <Formik initialValues={initialValues} validate={handleValidate} onSubmit={handleSubmit} onReset={onReset}>
+      {({ values, errors, touched, handleChange, handleBlur, resetForm }) => (
+        <Form>
+          <FormikAutoSubmit />
+
+          <FormGroup>
+            <Label className="d-block w-100">
+              <NumericInput
+                id="numThreads"
+                min={1}
+                max={1000}
+                className={classNames('d-inline', errors?.numThreads && 'border-danger')}
+                type="number"
+                identifier="settings-num-threads-input"
+                value={values.numThreads}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              />
+              <span className="d-inline">
+                <span className="mx-3">{t('Number of CPU threads')}</span>
+                <span className="mx-auto">
+                  <ButtonTransparent
+                    className="my-0"
+                    type="button"
+                    title={t('Reset to default')}
+                    // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
+                    onClick={() => {
+                      resetNumThreads()
+                      resetForm()
+                    }}
+                  >
+                    <MdRefresh /> {t('Reset')}
+                  </ButtonTransparent>
+                </span>
+              </span>
+              {touched.numThreads && errors?.numThreads && <p className="text-danger">{errors.numThreads}</p>}
+              {guess.numThreads && guess.memoryAvailable && (
+                <Alert className="mt-2 p-1" color="primary" isOpen fade={false}>
+                  <TableSlim borderless className="small mb-1">
+                    <tbody>
+                      <tr>
+                        <td>{t('Memory available*')}</td>
+                        <td>{memoryAvailable}</td>
+                      </tr>
+
+                      <tr>
+                        <td>{t('Memory per CPU thread')}</td>
+                        <td>{memoryAvailablePerThread}</td>
+                      </tr>
+
+                      <tr>
+                        <td>{t('Recommended number of CPU threads**')}</td>
+                        <td>{guess.numThreads ?? t('unsupported')}</td>
+                      </tr>
+
+                      <tr>
+                        <td colSpan={2} className="small">
+                          {t('* Current value. This amount can change depending on load')}
+                        </td>
+                      </tr>
+
+                      <tr>
+                        <td colSpan={2} className="small">
+                          {t('** {{appName}} requires at least {{memoryRequired}} of memory per thread', {
+                            appName: PROJECT_NAME,
+                            memoryRequired: prettyBytes.format(MEMORY_BYTES_PER_THREAD_MINIMUM),
+                          })}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </TableSlim>
+                </Alert>
+              )}
+            </Label>
+          </FormGroup>
+        </Form>
+      )}
+    </Formik>
+  )
+}
+
+export function FormikAutoSubmit() {
+  const { values, submitForm, isValid } = useFormikContext()
+  React.useEffect(() => {
+    if (isValid) {
+      void submitForm() // eslint-disable-line no-void
+    }
+  }, [values, submitForm, isValid])
+  return null
+}

--- a/packages_rs/nextclade-web/src/state/seqViewSettings.state.ts
+++ b/packages_rs/nextclade-web/src/state/seqViewSettings.state.ts
@@ -1,0 +1,77 @@
+import { atom } from 'recoil'
+import { ErrorInternal } from 'src/helpers/ErrorInternal'
+
+import { persistAtom } from 'src/state/persist/localStorage'
+
+export enum SeqMarkerHeightState {
+  Off = 'Off',
+  Top = 'Top',
+  Bottom = 'Bottom',
+  Full = 'Full',
+}
+
+export const SEQ_MARKER_HEIGHT_STATES = Object.keys(SeqMarkerHeightState)
+
+export function seqMarkerHeightStateToString(val: SeqMarkerHeightState) {
+  return val.toString()
+}
+
+export function seqMarkerHeightStateFromString(key: string) {
+  // prettier-ignore
+  switch (key) {
+    case 'Top': return SeqMarkerHeightState.Top
+    case 'Bottom': return SeqMarkerHeightState.Bottom
+    case 'Full': return SeqMarkerHeightState.Full
+    case 'Off': return SeqMarkerHeightState.Off
+  }
+  throw new ErrorInternal(`When converting string to 'SeqMarkerHeightState': Unknown variant'${key}'`)
+}
+
+export function getSeqMarkerDims(state: SeqMarkerHeightState) {
+  switch (state) {
+    case SeqMarkerHeightState.Top:
+      return { y: -10, height: 10 }
+    case SeqMarkerHeightState.Bottom:
+      return { y: 10, height: 10 }
+    case SeqMarkerHeightState.Full:
+      return { y: -10, height: 30 }
+    case SeqMarkerHeightState.Off:
+      return { y: 0, height: 0 }
+  }
+  throw new ErrorInternal(`getSeqMarkerDims: Unknown 'SeqMarkerHeightState' variant: '${state}'`) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+}
+
+export const seqMarkerMissingHeightStateAtom = atom<SeqMarkerHeightState>({
+  key: 'seqMarkerMissingHeight',
+  default: SeqMarkerHeightState.Top,
+  effects: [persistAtom],
+})
+
+export const seqMarkerGapHeightStateAtom = atom<SeqMarkerHeightState>({
+  key: 'seqMarkerGapHeight',
+  default: SeqMarkerHeightState.Full,
+  effects: [persistAtom],
+})
+
+export const seqMarkerMutationHeightStateAtom = atom<SeqMarkerHeightState>({
+  key: 'seqMarkerMutationHeight',
+  default: SeqMarkerHeightState.Full,
+  effects: [persistAtom],
+})
+
+export const seqMarkerUnsequencedHeightStateAtom = atom<SeqMarkerHeightState>({
+  key: 'seqMarkerUnsequencedHeight',
+  default: SeqMarkerHeightState.Full,
+  effects: [persistAtom],
+})
+
+export enum SeqMarkerFrameShiftState {
+  Off = 'Off',
+  On = 'On',
+}
+
+export const seqMarkerFrameShiftStateAtom = atom<SeqMarkerFrameShiftState>({
+  key: 'seqMarkerFrameShiftState',
+  default: SeqMarkerFrameShiftState.On,
+  effects: [persistAtom],
+})


### PR DESCRIPTION
This adds toggles to the "Settings" dialog, which allow to toggle markers in sequence views between full-height, half-height at the bottom, half-height at the top and turned off entirely. The toggles are separate for missing, gaps, mutations and unsequenced markers.

The values are remembered in local storage and persist across app launches.


Right now only the nuc view is configurable and only for 4 of hese categories of vertical markers (and not frame shifts for example), but we can add similar toggles to peptide view and other markers later.


Known issues:
 - [ ] only the last blue toggle is highlighted with white text. Something weird there.
 - [ ] could not figure out how to make a horizontal form (labels on same line). Reactstrap makes this surprisingly difficult.


![01](https://user-images.githubusercontent.com/9403403/169816411-9533a565-34f6-4b69-afec-219aeb4337da.png)

