### PR TITLE
fix(web): treat dataset default gene field as optional

### DIFF
--- a/packages_rs/nextclade-web/src/algorithms/types.ts
+++ b/packages_rs/nextclade-web/src/algorithms/types.ts
@@ -511,7 +511,7 @@ export interface Dataset {
   nameFriendly: string
   datasetRefs: DatasetRef[]
   defaultRef: string
-  defaultGene: string
+  defaultGene?: string
   geneOrderPreference: string[]
 }
 

--- a/packages_rs/nextclade-web/src/state/dataset.state.ts
+++ b/packages_rs/nextclade-web/src/state/dataset.state.ts
@@ -2,6 +2,7 @@ import { isNil } from 'lodash'
 import { atom, DefaultValue, selector } from 'recoil'
 
 import type { DatasetFlat } from 'src/algorithms/types'
+import { GENE_OPTION_NUC_SEQUENCE } from 'src/constants'
 import { inputResetAtom } from 'src/state/inputs.state'
 import { persistAtom } from 'src/state/persist/localStorage'
 import { viewedGeneAtom } from 'src/state/settings.state'
@@ -37,7 +38,7 @@ export const datasetCurrentNameAtom = selector<string | undefined>({
       const dataset = datasets.find((dataset) => dataset.name === newDatasetCurrentName)
       if (dataset) {
         set(datasetCurrentNameStorageAtom, dataset.name)
-        set(viewedGeneAtom, dataset.defaultGene)
+        set(viewedGeneAtom, dataset.defaultGene ?? GENE_OPTION_NUC_SEQUENCE)
         reset(inputResetAtom)
       }
     }


### PR DESCRIPTION
When `defaultGene` was not set in the dataset, causing "Gene is missing in gene map" text appearing in the sequence view, due to gene view being switched to peptide view for `undefined` gene.

Let's treat the `defaultGene` field as optional and, if it's undefined, default to nuc view.

