### PR TITLE
feat(web): limit number of markers that can be displayed in seq views

### DIFF
--- a/packages_rs/nextclade-web/src/components/Common/NumericField.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/NumericField.tsx
@@ -15,7 +15,6 @@ export const Label = styled(ReactstrapLabel)<{ disabled?: boolean }>`
   color: ${(props) => (props.disabled ? props.theme.gray500 : undefined)};
   padding: 2px 5px;
   width: 100%;
-  display: flex;
 `
 
 export const LabelText = styled.div<{ disabled?: boolean }>`
@@ -44,6 +43,7 @@ export const FormGroup = styled(ReactstrapFormGroup)`
 export interface NumericFieldProps extends InputProps {
   identifier: string
   label: string
+  title?: string
   value: number | typeof Number.POSITIVE_INFINITY
   min: number
   max: number
@@ -59,6 +59,7 @@ export function NumericField({
   min,
   max,
   disabled,
+  title,
   ...props
 }: NumericFieldProps) {
   const { t } = useTranslation()
@@ -95,12 +96,13 @@ export function NumericField({
   )
 
   return (
-    <FormGroup row className="d-flex w-100">
-      <Label className="col-sm-9 ml-auto" htmlFor={identifier} disabled={disabled}>
+    <FormGroup>
+      <Label htmlFor={identifier} disabled={disabled} title={title}>
         <LabelText disabled={disabled}>{label}</LabelText>
         <ErrorText disabled={disabled}>{error}</ErrorText>
       </Label>
       <Input
+        title={title}
         className={classNames(error && !disabled && 'border-danger', 'col-sm-3')}
         type="number"
         id={identifier}

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { ReactResizeDetectorDimensions, withResizeDetector } from 'react-resize-detector'
 import { useRecoilValue } from 'recoil'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { maxNucMarkersAtom } from 'src/state/seqViewSettings.state'
 import styled from 'styled-components'
 
 import type { AnalysisResult } from 'src/algorithms/types'
@@ -27,12 +29,19 @@ export const SequenceViewSVG = styled.svg`
   height: 100%;
 `
 
+export const SequenceViewText = styled.p`
+  margin: auto;
+`
+
 export interface SequenceViewProps extends ReactResizeDetectorDimensions {
   sequence: AnalysisResult
 }
 
 export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
   const { seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd, frameShifts } = sequence
+
+  const { t } = useTranslationSafe()
+  const maxNucMarkers = useRecoilValue(maxNucMarkersAtom)
 
   const genomeSize = useRecoilValue(genomeSizeAtom)
 
@@ -82,6 +91,21 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
       pixelsPerBase={pixelsPerBase}
     />
   ))
+
+  const totalMarkers = mutationViews.length + deletionViews.length + missingViews.length + frameShiftMarkers.length
+  if (totalMarkers > maxNucMarkers) {
+    return (
+      <SequenceViewWrapper>
+        <SequenceViewText
+          title={t(
+            "Markers are the colored rectangles which represent mutations, deletions etc. There is a technical limit of how many of those can be displayed at a time, depending on how fast your computer is. You can tune the threshold in the 'Settings' dialog, accessible with the button on the top panel.",
+          )}
+        >
+          {t('Too many markers to display. The threshold can be increased in "Settings" dialog')}
+        </SequenceViewText>
+      </SequenceViewWrapper>
+    )
+  }
 
   return (
     <SequenceViewWrapper>

--- a/packages_rs/nextclade-web/src/components/Settings/SeqViewSettings.tsx
+++ b/packages_rs/nextclade-web/src/components/Settings/SeqViewSettings.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useMemo } from 'react'
 import { Col, Container, Form, FormGroup, Label, Row } from 'reactstrap'
 import { RecoilState, useRecoilState } from 'recoil'
 import { Multitoggle } from 'src/components/Common/Multitoggle'
+import { NumericField } from 'src/components/Common/NumericField'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { useRecoilStateDeferred } from 'src/hooks/useRecoilStateDeferred'
 import {
   SEQ_MARKER_HEIGHT_STATES,
   SeqMarkerHeightState,
@@ -12,6 +14,7 @@ import {
   seqMarkerGapHeightStateAtom,
   seqMarkerMutationHeightStateAtom,
   seqMarkerUnsequencedHeightStateAtom,
+  maxNucMarkersAtom,
 } from 'src/state/seqViewSettings.state'
 
 /** Adapts Recoil state  `enum` to `string` */
@@ -44,6 +47,8 @@ export function useSeqMarkerState(state: RecoilState<SeqMarkerHeightState>) {
 export function SeqViewSettings() {
   const { t } = useTranslationSafe()
 
+  const [maxNucMarkers, setMaxNucMarkers] = useRecoilStateDeferred(maxNucMarkersAtom)
+
   const [seqMarkerMissingHeightState, setSeqMarkerMissingHeightState] = useSeqMarkerState(
     seqMarkerMissingHeightStateAtom,
   )
@@ -63,6 +68,18 @@ export function SeqViewSettings() {
       <Row noGutters>
         <Col>
           <Form>
+            <NumericField
+              identifier="max-nuc-markers"
+              label={t('Maximum number of nucleotide sequence view markers')}
+              title={t(
+                'Sets threshold on maximum number of markers (mutations, deletions etc.) to display in nucleotide views. Reducing this number increases performance. If the threshold is reached, then the nucleotide sequence view will be disabled.',
+              )}
+              min={0}
+              max={1_000_000}
+              value={maxNucMarkers}
+              onValueChanged={setMaxNucMarkers}
+            />
+
             <FormGroup>
               {t('Missing')}
               <Multitoggle

--- a/packages_rs/nextclade-web/src/state/seqViewSettings.state.ts
+++ b/packages_rs/nextclade-web/src/state/seqViewSettings.state.ts
@@ -75,3 +75,9 @@ export const seqMarkerFrameShiftStateAtom = atom<SeqMarkerFrameShiftState>({
   default: SeqMarkerFrameShiftState.On,
   effects: [persistAtom],
 })
+
+export const maxNucMarkersAtom = atom<number>({
+  key: 'maxNucMarkers',
+  default: 300,
+  effects: [persistAtom],
+})


### PR DESCRIPTION
This add a setting that defined maximum number of markers (mutations, deletions, missing, frame shifts) that can be displayed in nucleotide sequence views.

If this number is exceeded, a message is displayed instead.

The value is 300 by default and can be changed in settings. Value is persisted in local storage.

