### PR TITLE
fix(web): ensure dataset is read from URL

### DIFF
--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -104,7 +104,7 @@ export function RecoilStateInitializer() {
           defaultDatasetName,
           defaultDatasetNameFriendly,
         })
-        set(datasetCurrentNameAtom, (previous) => previous ?? currentDatasetName)
+        set(datasetCurrentNameAtom, (previous) => currentDatasetName ?? previous)
 
         return undefined
       })


### PR DESCRIPTION
This ensures that the dataset is properly changed if the launch happens from URL.

With this, the previous dataset, persisted in local storage is used, which causes analysis errors if the requested dataset is not the same as the previously used dataset.

