### PR TITLE
fix(web): ensure seq name column and tooltip are shown for failed seq

### DIFF
--- a/packages_rs/nextclade-web/src/components/Results/ColumnName.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnName.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { analysisResultAtom } from 'src/state/results.state'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { ColumnNameTooltip } from 'src/components/Results/ColumnNameTooltip'
+import { ColumnNameErrorTooltip, ColumnNameTooltip } from 'src/components/Results/ColumnNameTooltip'
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { getStatusIconAndText } from 'src/components/Results/getStatusIconAndText'
 
@@ -37,19 +37,27 @@ export function ColumnName({ seqName }: ColumnNameProps) {
     [error, result?.analysisResult.warnings, t],
   )
 
-  if (!result?.analysisResult) {
-    return null
-  }
+  const tooltip = useMemo(() => {
+    if (error) {
+      return (
+        <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
+          <ColumnNameErrorTooltip seqName={seqName} error={error} />
+        </Tooltip>
+      )
+    }
+
+    return (
+      <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
+        <ColumnNameTooltip seqName={seqName} />
+      </Tooltip>
+    )
+  }, [error, id, seqName, showTooltip])
 
   return (
     <SequenceName id={id} className="w-100" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       <StatusIcon />
       {seqName}
-      {
-        <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
-          <ColumnNameTooltip seqName={seqName} />
-        </Tooltip>
-      }
+      {tooltip}
     </SequenceName>
   )
 }

--- a/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
@@ -38,19 +38,6 @@ export function ColumnNameTooltip({ seqName }: ColumnNameTooltipProps) {
     [error, result?.analysisResult.warnings, t],
   )
 
-  const errorComponent = useMemo(() => {
-    if (!error) {
-      return null
-    }
-
-    return (
-      <Alert key={error} color="danger" fade={false} className="px-2 py-1 my-1">
-        <ErrorIcon />
-        {error}
-      </Alert>
-    )
-  }, [error])
-
   const warningComponents = useMemo(() => {
     return (result?.analysisResult?.warnings ?? []).map((warning) => (
       <Alert key={`${warning.geneName}: ${warning.warning}`} color="warning" fade={false} className="px-2 py-1 my-1">
@@ -111,9 +98,45 @@ export function ColumnNameTooltip({ seqName }: ColumnNameTooltipProps) {
         )}
 
         <tr>
+          <td colSpan={2}>{warningComponents}</td>
+        </tr>
+      </tbody>
+    </TableSlim>
+  )
+}
+
+export interface ColumnNameErrorTooltipProps {
+  seqName: string
+  error: string
+}
+
+export function ColumnNameErrorTooltip({ seqName, error }: ColumnNameErrorTooltipProps) {
+  const { t } = useTranslationSafe()
+
+  return (
+    <TableSlim borderless className="mb-1">
+      <thead />
+      <tbody>
+        <tr>
           <td colSpan={2}>
-            {errorComponent}
-            {warningComponents}
+            <h5 className="mb-2">{seqName}</h5>
+          </td>
+        </tr>
+
+        <tr>
+          <td>{t('Analysis status')}</td>
+          <td>
+            <ErrorIcon size={18} />
+            {t('Failed')}
+          </td>
+        </tr>
+
+        <tr>
+          <td colSpan={2}>
+            <Alert key={error} color="danger" fade={false} className="px-2 py-1 my-1">
+              <ErrorIcon />
+              {error}
+            </Alert>
           </td>
         </tr>
       </tbody>

--- a/packages_rs/nextclade-web/src/components/Results/getStatusIconAndText.ts
+++ b/packages_rs/nextclade-web/src/components/Results/getStatusIconAndText.ts
@@ -37,6 +37,7 @@ export const ErrorIcon = styled(BsFillXOctagonFill)`
   width: 1rem;
   height: 1rem;
   color: ${(props) => props.theme.danger};
+  padding-right: 2px;
   filter: drop-shadow(2px 1px 2px rgba(0, 0, 0, 0.2));
 `
 


### PR DESCRIPTION
For sequences that fail alignment the name column was blank and no tooltip was shown. This was due to incorrect conditional logic in the component.

Now the name column and its tooltip are displayed correctly.

