### PR TITLE
fix: ensure aa muts are attached to the tree

### DIFF
--- a/packages_rs/nextclade/src/analyze/aa_sub.rs
+++ b/packages_rs/nextclade/src/analyze/aa_sub.rs
@@ -1,4 +1,4 @@
-use crate::io::aa::Aa;
+use crate::io::aa::{from_aa, Aa};
 use crate::io::letter::Letter;
 use crate::io::nuc::Nuc;
 use crate::io::parse_pos::parse_pos;
@@ -30,6 +30,11 @@ impl AaSubMinimal {
   /// Checks whether this substitution is a deletion (substitution of letter `Gap`)
   pub fn is_del(&self) -> bool {
     self.qry.is_gap()
+  }
+
+  pub fn to_string_without_gene(&self) -> String {
+    // NOTE: by convention, in bioinformatics, nucleotides are numbered starting from 1, however our arrays are 0-based
+    return format!("{}{}{}", from_aa(self.reff), self.pos + 1, from_aa(self.qry));
   }
 }
 

--- a/packages_rs/nextclade/src/analyze/find_private_aa_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_aa_mutations.rs
@@ -4,9 +4,9 @@ use crate::analyze::aa_sub::AaSubMinimal;
 use crate::analyze::is_sequenced::is_aa_sequenced;
 use crate::analyze::letter_ranges::{AaRange, GeneAaRange};
 use crate::analyze::virus_properties::{LabelMap, MutationLabelMaps, VirusProperties};
-use crate::io::gene_map::GeneMap;
 use crate::gene::genotype::{Genotype, GenotypeLabeled};
 use crate::io::aa::Aa;
+use crate::io::gene_map::GeneMap;
 use crate::io::letter::Letter;
 use crate::make_internal_report;
 use crate::translate::translate_genes::{Translation, TranslationMap};
@@ -43,6 +43,7 @@ pub fn find_private_aa_mutations(
   gene_map
     .iter()
     .filter_map(|(gene, _)| match node.tmp.aa_mutations.get(gene) {
+      //node.tmp contains mutations accumulated from root
       None => None,
       Some(node_mut_map) => {
         let ref_peptide = ref_peptides
@@ -122,8 +123,6 @@ pub fn find_private_aa_mutations_for_one_gene(
 }
 
 /// Iterates over sequence substitutions, compares sequence and node substitutions and finds the private ones.
-///
-/// This function is generic and is suitable for both nucleotide and aminoacid substitutions.
 fn process_seq_substitutions(
   node_mut_map: &BTreeMap<usize, Aa>,
   substitutions: &[&AaSub],

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -71,7 +71,7 @@ pub struct TreeNodeAttrs {
   pub missing: Option<TreeNodeAttr>,
 
   #[serde(skip_serializing_if = "Option::is_none")]
-  #[serde(rename = "Missing")]
+  #[serde(rename = "Gaps")]
   pub gaps: Option<TreeNodeAttr>,
 
   #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This fixes an omission: only nuc mutations were attached to the tree JSON object, and aa mutations were missing.

