### PR TITLE
feat(web): display nuc and aa insertions in sequence views

### DIFF
--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerInsertion.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerInsertion.tsx
@@ -1,0 +1,44 @@
+import React, { SVGProps, useCallback, useMemo, useState } from 'react'
+
+import type { AminoacidInsertion } from 'src/algorithms/types'
+import { AA_MIN_WIDTH_PX } from 'src/constants'
+import { Tooltip } from 'src/components/Results/Tooltip'
+import { getSafeId } from 'src/helpers/getSafeId'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { ListOfInsertionsAa } from 'src/components/Results/ListOfInsertions'
+
+export interface MissingViewProps extends SVGProps<SVGPolygonElement> {
+  seqName: string
+  insertion: AminoacidInsertion
+  pixelsPerAa: number
+}
+
+function PeptideMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerAa, ...rest }: MissingViewProps) {
+  const { t } = useTranslationSafe()
+  const [showTooltip, setShowTooltip] = useState(false)
+  const onMouseLeave = useCallback(() => setShowTooltip(false), [])
+  const onMouseEnter = useCallback(() => setShowTooltip(true), [])
+
+  const id = getSafeId('insertion-marker', { seqName, ...insertion })
+
+  const { pos } = insertion
+  const halfNuc = Math.max(pixelsPerAa, AA_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = pos * pixelsPerAa - halfNuc
+
+  const insertions = useMemo(() => [insertion], [insertion])
+  const pointsMain = useMemo(() => `${x} 10, ${x + 5} 19, ${x - 5} 19`, [x])
+  const pointsOutline = useMemo(() => `${x} 7, ${x + 7} 22, ${x - 7} 22`, [x])
+
+  return (
+    <g id={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <polygon points={pointsOutline} fill={'#ffff00'} {...rest} />
+      <polygon points={pointsMain} fill={'#ff0000'} {...rest} />
+      <Tooltip target={id} isOpen={showTooltip} fullWidth>
+        <h6>{t('Amino acid insertion')}</h6>
+        <ListOfInsertionsAa insertions={insertions} totalInsertions={1} />
+      </Tooltip>
+    </g>
+  )
+}
+
+export const PeptideMarkerInsertion = React.memo(PeptideMarkerInsertionUnmemoed)

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerInsertion.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerInsertion.tsx
@@ -1,4 +1,5 @@
 import React, { SVGProps, useCallback, useMemo, useState } from 'react'
+import { useTheme } from 'styled-components'
 
 import type { AminoacidInsertion } from 'src/algorithms/types'
 import { AA_MIN_WIDTH_PX } from 'src/constants'
@@ -14,6 +15,14 @@ export interface MissingViewProps extends SVGProps<SVGPolygonElement> {
 }
 
 function PeptideMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerAa, ...rest }: MissingViewProps) {
+  const {
+    seqView: {
+      markers: {
+        insertions: { background, outline },
+      },
+    },
+  } = useTheme()
+
   const { t } = useTranslationSafe()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
@@ -31,8 +40,8 @@ function PeptideMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerAa, ...re
 
   return (
     <g id={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      <polygon points={pointsOutline} fill={'#ffff00'} {...rest} />
-      <polygon points={pointsMain} fill={'#ff0000'} {...rest} />
+      <polygon points={pointsOutline} fill={outline} {...rest} />
+      <polygon points={pointsMain} fill={background} {...rest} />
       <Tooltip target={id} isOpen={showTooltip} fullWidth>
         <h6>{t('Amino acid insertion')}</h6>
         <ListOfInsertionsAa insertions={insertions} totalInsertions={1} />

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useState } from 'react'
 import { ReactResizeDetectorDimensions, withResizeDetector } from 'react-resize-detector'
 import { Alert as ReactstrapAlert } from 'reactstrap'
 import { useRecoilValue } from 'recoil'
-import { geneMapAtom } from 'src/state/results.state'
 import styled from 'styled-components'
 
+import { geneMapAtom } from 'src/state/results.state'
 import type { AnalysisResult, Gene, PeptideWarning } from 'src/algorithms/types'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { getSafeId } from 'src/helpers/getSafeId'
@@ -15,6 +15,7 @@ import { SequenceViewWrapper, SequenceViewSVG } from './SequenceView'
 import { groupAdjacentAminoacidChanges } from './groupAdjacentAminoacidChanges'
 import { PeptideMarkerUnknown } from './PeptideMarkerUnknown'
 import { PeptideMarkerFrameShift } from './PeptideMarkerFrameShift'
+import { PeptideMarkerInsertion } from './PeptideMarkerInsertion'
 
 const MissingRow = styled.div`
   background-color: ${(props) => props.theme.gray650};
@@ -96,7 +97,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
     )
   }
 
-  const { seqName, unknownAaRanges, frameShifts } = sequence
+  const { seqName, unknownAaRanges, frameShifts, aaInsertions } = sequence
   const geneLength = gene.end - gene.start
   const pixelsPerAa = width / Math.round(geneLength / 3)
   const aaSubstitutions = sequence.aaSubstitutions.filter((aaSub) => aaSub.gene === viewedGene)
@@ -115,6 +116,14 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
         pixelsPerAa={pixelsPerAa}
       />
     ))
+
+  const insertionMarkers = aaInsertions
+    .filter((ins) => ins.gene === viewedGene)
+    .map((insertion) => {
+      return (
+        <PeptideMarkerInsertion key={insertion.pos} seqName={seqName} insertion={insertion} pixelsPerAa={pixelsPerAa} />
+      )
+    })
 
   return (
     <SequenceViewWrapper>
@@ -137,6 +146,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
           )
         })}
         {frameShiftMarkers}
+        {insertionMarkers}
       </SequenceViewSVG>
     </SequenceViewWrapper>
   )

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerInsertion.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerInsertion.tsx
@@ -1,4 +1,5 @@
 import React, { SVGProps, useCallback, useMemo, useState } from 'react'
+import { useTheme } from 'styled-components'
 
 import { BASE_MIN_WIDTH_PX } from 'src/constants'
 import type { NucleotideInsertion } from 'src/algorithms/types'
@@ -14,6 +15,14 @@ export interface MissingViewProps extends SVGProps<SVGPolygonElement> {
 }
 
 function SequenceMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerBase, ...rest }: MissingViewProps) {
+  const {
+    seqView: {
+      markers: {
+        insertions: { background, outline },
+      },
+    },
+  } = useTheme()
+
   const { t } = useTranslationSafe()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
@@ -31,8 +40,8 @@ function SequenceMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerBase, ..
 
   return (
     <g id={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      <polygon points={pointsOutline} fill={'#ffff00'} {...rest} />
-      <polygon points={pointsMain} fill={'#ff0000'} {...rest} />
+      <polygon points={pointsOutline} fill={outline} {...rest} />
+      <polygon points={pointsMain} fill={background} {...rest} />
       <Tooltip target={id} isOpen={showTooltip} fullWidth>
         <h6>{t('Nucleotide insertion')}</h6>
         <ListOfInsertionsNuc insertions={insertions} totalInsertions={1} />

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerInsertion.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerInsertion.tsx
@@ -1,0 +1,44 @@
+import React, { SVGProps, useCallback, useMemo, useState } from 'react'
+
+import { BASE_MIN_WIDTH_PX } from 'src/constants'
+import type { NucleotideInsertion } from 'src/algorithms/types'
+import { Tooltip } from 'src/components/Results/Tooltip'
+import { getSafeId } from 'src/helpers/getSafeId'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { ListOfInsertionsNuc } from 'src/components/Results/ListOfInsertions'
+
+export interface MissingViewProps extends SVGProps<SVGPolygonElement> {
+  seqName: string
+  insertion: NucleotideInsertion
+  pixelsPerBase: number
+}
+
+function SequenceMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerBase, ...rest }: MissingViewProps) {
+  const { t } = useTranslationSafe()
+  const [showTooltip, setShowTooltip] = useState(false)
+  const onMouseLeave = useCallback(() => setShowTooltip(false), [])
+  const onMouseEnter = useCallback(() => setShowTooltip(true), [])
+
+  const id = getSafeId('insertion-marker', { seqName, ...insertion })
+
+  const { pos } = insertion
+  const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc
+  const x = pos * pixelsPerBase - halfNuc
+
+  const insertions = useMemo(() => [insertion], [insertion])
+  const pointsMain = useMemo(() => `${x} 10, ${x + 5} 19, ${x - 5} 19`, [x])
+  const pointsOutline = useMemo(() => `${x} 7, ${x + 7} 22, ${x - 7} 22`, [x])
+
+  return (
+    <g id={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <polygon points={pointsOutline} fill={'#ffff00'} {...rest} />
+      <polygon points={pointsMain} fill={'#ff0000'} {...rest} />
+      <Tooltip target={id} isOpen={showTooltip} fullWidth>
+        <h6>{t('Nucleotide insertion')}</h6>
+        <ListOfInsertionsNuc insertions={insertions} totalInsertions={1} />
+      </Tooltip>
+    </g>
+  )
+}
+
+export const SequenceMarkerInsertion = React.memo(SequenceMarkerInsertionUnmemoed)

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
@@ -104,7 +104,8 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     />
   ))
 
-  const totalMarkers = mutationViews.length + deletionViews.length + missingViews.length + frameShiftMarkers.length
+  const totalMarkers =
+    mutationViews.length + deletionViews.length + missingViews.length + frameShiftMarkers.length + insertionViews.length
   if (totalMarkers > maxNucMarkers) {
     return (
       <SequenceViewWrapper>

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
@@ -12,6 +12,7 @@ import { SequenceMarkerMissing } from './SequenceMarkerMissing'
 import { SequenceMarkerMutation } from './SequenceMarkerMutation'
 import { SequenceMarkerUnsequencedEnd, SequenceMarkerUnsequencedStart } from './SequenceMarkerUnsequenced'
 import { SequenceMarkerFrameShift } from './SequenceMarkerFrameShift'
+import { SequenceMarkerInsertion } from './SequenceMarkerInsertion'
 
 export const SequenceViewWrapper = styled.div`
   display: flex;
@@ -38,7 +39,7 @@ export interface SequenceViewProps extends ReactResizeDetectorDimensions {
 }
 
 export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
-  const { seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd, frameShifts } = sequence
+  const { seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd, frameShifts, insertions } = sequence
 
   const { t } = useTranslationSafe()
   const maxNucMarkers = useRecoilValue(maxNucMarkersAtom)
@@ -83,6 +84,17 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     )
   })
 
+  const insertionViews = insertions.map((insertion) => {
+    return (
+      <SequenceMarkerInsertion
+        key={insertion.pos}
+        seqName={seqName}
+        insertion={insertion}
+        pixelsPerBase={pixelsPerBase}
+      />
+    )
+  })
+
   const frameShiftMarkers = frameShifts.map((frameShift) => (
     <SequenceMarkerFrameShift
       key={`${frameShift.geneName}_${frameShift.nucAbs.begin}`}
@@ -119,6 +131,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
         {mutationViews}
         {missingViews}
         {deletionViews}
+        {insertionViews}
         <SequenceMarkerUnsequencedEnd
           seqName={seqName}
           genomeSize={genomeSize}

--- a/packages_rs/nextclade-web/src/theme.ts
+++ b/packages_rs/nextclade-web/src/theme.ts
@@ -162,6 +162,15 @@ export const theme = {
   shadows,
   filePicker,
   uploadZone,
+
+  seqView: {
+    markers: {
+      insertions: {
+        background: '#ff0000',
+        outline: '#ffff00',
+      },
+    },
+  },
 }
 
 export type Theme = typeof theme

--- a/packages_rs/nextclade-web/src/theme.ts
+++ b/packages_rs/nextclade-web/src/theme.ts
@@ -166,8 +166,8 @@ export const theme = {
   seqView: {
     markers: {
       insertions: {
-        background: '#ff0000',
-        outline: '#ffff00',
+        background: '#000000',
+        outline: '#ff0000',
       },
     },
   },

--- a/packages_rs/nextclade-web/src/theme.ts
+++ b/packages_rs/nextclade-web/src/theme.ts
@@ -166,8 +166,8 @@ export const theme = {
   seqView: {
     markers: {
       insertions: {
-        background: '#000000',
-        outline: '#ff0000',
+        background: '#7123de',
+        outline: '#f7f416',
       },
     },
   },


### PR DESCRIPTION
This adds display of insertions in nucleotide and aminoacid sequence views

Resolves #769 

![01](https://user-images.githubusercontent.com/9403403/170981831-ce5a5d37-5612-42d9-b64d-ea8f54116f8d.png)
![02](https://user-images.githubusercontent.com/9403403/170981840-3df3048d-960b-452f-85eb-17404a159170.png)
![03](https://user-images.githubusercontent.com/9403403/170981846-58d0260a-3952-45b4-b212-83d005b8aa98.png)


