### PR TITLE
feat(web): display total number of markers and limit in the message

### DIFF
--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
@@ -101,7 +101,10 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
             "Markers are the colored rectangles which represent mutations, deletions etc. There is a technical limit of how many of those can be displayed at a time, depending on how fast your computer is. You can tune the threshold in the 'Settings' dialog, accessible with the button on the top panel.",
           )}
         >
-          {t('Too many markers to display. The threshold can be increased in "Settings" dialog')}
+          {t(
+            'Too many markers to display ({{totalMarkers}}). The threshold ({{maxNucMarkers}}) can be increased in "Settings" dialog',
+            { totalMarkers, maxNucMarkers },
+          )}
         </SequenceViewText>
       </SequenceViewWrapper>
     )

--- a/packages_rs/nextclade-web/src/state/seqViewSettings.state.ts
+++ b/packages_rs/nextclade-web/src/state/seqViewSettings.state.ts
@@ -78,6 +78,6 @@ export const seqMarkerFrameShiftStateAtom = atom<SeqMarkerFrameShiftState>({
 
 export const maxNucMarkersAtom = atom<number>({
   key: 'maxNucMarkers',
-  default: 300,
+  default: 3000,
   effects: [persistAtom],
 })


### PR DESCRIPTION
This adds some more information to the message appearing instead of sequence view when the limit of markers is exceeded. Now the message shows how many markers it is in total to draw and what is the current limit.

This gives users some more actionable data on how to adjust the limit.

![01](https://user-images.githubusercontent.com/9403403/170984749-feb1d40d-dacd-43a3-80e8-1ad43c990ef1.png)

