### PR TITLE
feat(web): limit number of aa mut badges in nuc gap tooltips

### DIFF
--- a/packages_rs/nextclade-web/src/components/SequenceView/ListOfAaChangesFlatTruncated.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/ListOfAaChangesFlatTruncated.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+
+import { AminoacidDeletion, AminoacidSubstitution } from 'src/algorithms/types'
+import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
+import { TableSlim } from 'src/components/Common/TableSlim'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+
+export interface ListOfMutationsTruncatedProps {
+  aaSubstitutions: AminoacidSubstitution[]
+  aaDeletions: AminoacidDeletion[]
+  maxRows?: number
+}
+
+export function ListOfAaChangesFlatTruncated({
+  aaSubstitutions,
+  aaDeletions,
+  maxRows = 6,
+}: ListOfMutationsTruncatedProps) {
+  const { t } = useTranslationSafe()
+
+  const subs = aaSubstitutions.map((sub) => ({ ...sub, type: 'substitution' }))
+  const dels = aaDeletions.map((del) => ({ ...del, type: 'deletion' }))
+  const changes = [...subs, ...dels]
+
+  let changesHead = changes
+  let changesTail: typeof changes = []
+  if (changes.length > maxRows) {
+    changesHead = changes.slice(0, (maxRows + 1) / 2)
+    changesTail = changes.slice(-maxRows / 2)
+  }
+
+  return (
+    <TableSlim borderless className="mb-1">
+      <thead />
+      <tbody>
+        <tr className="mb-2">
+          <td colSpan={2}>
+            <h6>{t('Aminoacid changes ({{count}})', { count: changes.length })}</h6>
+          </td>
+        </tr>
+
+        {changesHead.map((change) => (
+          <tr key={change.codon}>
+            <td>{change.type === 'substitution' ? t('Substitution') : t('Deletion')}</td>
+            <td>
+              <AminoacidMutationBadge mutation={change} />
+            </td>
+          </tr>
+        ))}
+
+        {changesTail.length > 0 && (
+          <tr>
+            <td>{'...'}</td>
+            <td>{'...'}</td>
+          </tr>
+        )}
+
+        {changesTail.length > 0 &&
+          changesTail.map((change) => (
+            <tr key={change.codon}>
+              <td>{change.type === 'substitution' ? t('Substitution') : t('Deletion')}</td>
+              <td>
+                <AminoacidMutationBadge mutation={change} />
+              </td>
+            </tr>
+          ))}
+      </tbody>
+    </TableSlim>
+  )
+}

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerGap.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerGap.tsx
@@ -1,16 +1,16 @@
 import React, { SVGProps, useCallback, useMemo, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
-import { BASE_MIN_WIDTH_PX, GAP } from 'src/constants'
 import type { NucleotideDeletion } from 'src/algorithms/types'
-import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
-import { Tooltip } from 'src/components/Results/Tooltip'
 import { TableSlim } from 'src/components/Common/TableSlim'
+import { Tooltip } from 'src/components/Results/Tooltip'
+import { BASE_MIN_WIDTH_PX, GAP } from 'src/constants'
 import { formatRange } from 'src/helpers/formatRange'
+import { getNucleotideColor } from 'src/helpers/getNucleotideColor'
 import { getSafeId } from 'src/helpers/getSafeId'
-import { AminoacidMutationBadge } from 'src/components/Common/MutationBadge'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { getSeqMarkerDims, seqMarkerGapHeightStateAtom, SeqMarkerHeightState } from 'src/state/seqViewSettings.state'
+import { ListOfAaChangesFlatTruncated } from 'src/components/SequenceView/ListOfAaChangesFlatTruncated'
 
 const gapColor = getNucleotideColor(GAP)
 
@@ -29,10 +29,6 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
   const seqMarkerGapHeightState = useRecoilValue(seqMarkerGapHeightStateAtom)
   const { y, height } = useMemo(() => getSeqMarkerDims(seqMarkerGapHeightState), [seqMarkerGapHeightState])
 
-  if (seqMarkerGapHeightState === SeqMarkerHeightState.Off) {
-    return null
-  }
-
   const { start: begin, length, aaSubstitutions, aaDeletions } = deletion
   const end = begin + length
 
@@ -46,6 +42,10 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
   const rangeStr = formatRange(begin, end)
 
   const totalAaChanges = aaSubstitutions.length + aaDeletions.length
+
+  if (seqMarkerGapHeightState === SeqMarkerHeightState.Off) {
+    return null
+  }
 
   return (
     <rect
@@ -77,23 +77,7 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
               </tr>
             )}
 
-            {aaSubstitutions.map((mut) => (
-              <tr key={mut.codon}>
-                <td>{t('Aminoacid substitution')}</td>
-                <td>
-                  <AminoacidMutationBadge mutation={mut} />
-                </td>
-              </tr>
-            ))}
-
-            {aaDeletions.map((del) => (
-              <tr key={del.queryContext}>
-                <td>{t('Aminoacid deletion')}</td>
-                <td>
-                  <AminoacidMutationBadge mutation={del} />
-                </td>
-              </tr>
-            ))}
+            <ListOfAaChangesFlatTruncated aaSubstitutions={aaSubstitutions} aaDeletions={aaDeletions} maxRows={10} />
           </tbody>
         </TableSlim>
       </Tooltip>


### PR DESCRIPTION
This limits number of aminoacid mutation badges in the tooltip of the nucleotide gap marker in sequence view.

This avoid screen overflow when there's too many mutations.

This happens with aa deletions mostly, so ideally we need to group aa deletions into ranges. But it have negative impact to other places which need access to individual deletions and is more work overall. Maybe later.

