### PR TITLE
chore(build): speedup debug binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,10 +2,23 @@
 frequency = 'always'
 
 [profile.dev]
-codegen-units = 32
+codegen-units = 4096
 incremental = true
 lto = "off"
-opt-level = 1
+
+# Optimize dependencies even in debug mode
+[profile.dev.package."*"]
+opt-level = 2
+[profile.dev.package.backtrace]
+opt-level = 3
+[profile.dev.package.color-spantrace]
+opt-level = 3
+[profile.dev.package.tracing]
+opt-level = 3
+[profile.dev.package.tracing-error]
+opt-level = 3
+[profile.dev.package.tracing-subscriber]
+opt-level = 3
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
In order to improve deb experience, this configures build to optimize dependency packages even in dev mode. Nextclade packages themselves stay unoptimized, so that full debug information is available.

Also increases number of codegen units to speedup incremental build process.

