### PR TITLE
feat: add preview version warning

### DIFF
--- a/packages_rs/nextclade-web/src/components/Common/PreviewWarning.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/PreviewWarning.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { UncontrolledAlert } from 'reactstrap'
+
+import { RELEASE_URL } from 'src/constants'
+import { LinkExternal } from 'src/components/Link/LinkExternal'
+
+export function shouldRenderPreviewWarning(): boolean {
+  return process.env.NODE_ENV !== 'development' && (process.env.BRANCH_NAME ?? '') !== 'release'
+}
+
+export function PreviewWarning() {
+  const { t } = useTranslation()
+
+  const warningText = useMemo(() => t('This is a preview version. For official website please visit '), [t])
+
+  if (!shouldRenderPreviewWarning()) {
+    return null
+  }
+
+  return (
+    <UncontrolledAlert color="warning" className="text-center">
+      <span>{warningText}</span>
+      <span>
+        <LinkExternal href={RELEASE_URL}>{RELEASE_URL}</LinkExternal>
+      </span>
+    </UncontrolledAlert>
+  )
+}

--- a/packages_rs/nextclade-web/src/constants.ts
+++ b/packages_rs/nextclade-web/src/constants.ts
@@ -5,6 +5,7 @@ export const PROJECT_NAME = 'Nextclade' as const
 export const PROJECT_DESCRIPTION = 'Clade assignment, mutation calling, and sequence quality checks' as const
 export const COPYRIGHT_YEAR_START = 2020 as const
 export const COMPANY_NAME = 'Nextstrain developers' as const
+export const RELEASE_URL = 'https://clades.nextstrain.org' as const
 
 export const DOMAIN = process.env.DOMAIN ?? ''
 export const DOMAIN_STRIPPED = process.env.DOMAIN_STRIPPED ?? ''

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -48,6 +48,7 @@ import i18n from 'src/i18n/i18n'
 import { theme } from 'src/theme'
 import { datasetCurrentNameAtom, datasetsAtom } from 'src/state/dataset.state'
 import { ErrorBoundary } from 'src/components/Error/ErrorBoundary'
+import { PreviewWarning } from 'src/components/Common/PreviewWarning'
 
 import 'src/styles/global.scss'
 
@@ -187,6 +188,7 @@ export function MyApp({ Component, pageProps, router }: AppProps) {
                     </Suspense>
                     <Suspense fallback={fallback}>
                       <SEO />
+                      <PreviewWarning />
                       <Component {...pageProps} />
                       <ErrorPopup />
                       <ReactQueryDevtools initialIsOpen={false} />


### PR DESCRIPTION
This adds an alert at the top of the page, when:
 - the app is build from a git branch that is not `release` branch
 - and it's not a dev build (`NODE_ENV != 'development'`)

Alert can be dismissed with a button, but reappears on page refresh (or next visit).

This tries to be minimalistic and to not introduce too many differences between prod and non-prod builds.

![01](https://user-images.githubusercontent.com/9403403/172522099-ec06aa8a-f831-4b17-a1b7-fd2f5416d54e.png)

