### PR TITLE
CLI redesign for v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "rstest_reuse",
  "serde",
  "serde_json",
+ "tinytemplate",
  "traversal",
  "validator",
 ]
@@ -1401,6 +1402,8 @@ dependencies = [
  "rstest_reuse",
  "semver 1.0.9",
  "serde",
+ "strum 0.24.0",
+ "strum_macros 0.24.0",
  "url",
 ]
 

--- a/packages_rs/nextclade-cli/Cargo.toml
+++ b/packages_rs/nextclade-cli/Cargo.toml
@@ -33,9 +33,11 @@ owo-colors = "3.3.0"
 pretty_assertions = "1.2.1"
 rayon = "1.5.2"
 regex = "1.5.5"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "deflate", "gzip", "brotli", "socks", "rustls-tls"]}
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "deflate", "gzip", "brotli", "socks", "rustls-tls"] }
 semver = "1.0.9"
 serde = { version = "1.0.136", features = ["derive"] }
+strum = "0.24.0"
+strum_macros = "0.24"
 url = { version = "2.2.2", features = ["serde"] }
 
 [target.'cfg(all(target_os="linux", target_arch="x86_64"))'.dependencies]

--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -126,9 +126,13 @@ pub struct NextalignRunArgs {
   #[clap(value_hint = ValueHint::FilePath)]
   pub genes: Option<Vec<String>>,
 
-  /// Write all output files to this directory. Convenient when you want to receive all or most output files.
+  /// Produce all of the output files into this directory, using default basename and predefined suffixes and extensions. This is equivalent to specifying each of the individual `--output-*` flags. Convenient when you want to receive all or most of output files into the same directory and don't care about their filenames.
   ///
-  /// The list of output files can be optionally restricted using `--output-selection` flag. The base filename can be set using `--output-basename` flag. The paths can be overridden on a per-file basis using `--output-*` flags.
+  /// Output files can be optionally included or excluded using `--output-selection` flag.
+  /// The base filename can be set using `--output-basename` flag.
+  ///
+  /// If both the `--output-all` and individual `--output-*` flags are provided, each
+  //  individual flag overrides the corresponding default output path.
   ///
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'O')]
@@ -138,16 +142,20 @@ pub struct NextalignRunArgs {
 
   /// Set the base filename to use for output files.
   ///
-  /// To be used together with `--output-all` flag. By default uses the filename of the sequences file (provided with `--input-fasta`). The paths can be overridden on a per-file basis using `--output-*` flags.
+  /// By default the base filename is extracted from the input sequences file (provided with `--input-fasta`).
+  ///
+  /// Only valid together with `--output-all` flag.
   #[clap(long, short = 'n')]
   #[clap(requires = "output-all")]
   pub output_basename: Option<String>,
 
-  /// Restricts outputs for `--output-all` flag
+  /// Restricts outputs for `--output-all` flag.
   ///
-  /// Should contain one or multiple of List of comma-separated strings which
+  /// Should contain a comma-separated list of names of output files to produce.
   ///
-  /// To be used together with `--output-all` flag.
+  /// If 'all' is present in the list, then all other entries are ignored and all outputs are produced.
+  ///
+  /// Only valid together with `--output-all` flag.
   #[clap(
     long,
     short = 's',

--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, CommandFactory, Parser, Subcommand, ValueHint};
+use clap::{AppSettings, ArgGroup, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use clap_complete_fig::Fig;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
@@ -73,6 +73,7 @@ pub enum NextalignCommands {
 }
 
 #[derive(Parser, Debug)]
+#[clap(group(ArgGroup::new("output").required(true)))]
 pub struct NextalignRunArgs {
   /// Path to a FASTA file with input sequences
   #[clap(long, short = 'i', visible_alias("sequences"))]
@@ -122,6 +123,7 @@ pub struct NextalignRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'd')]
   #[clap(value_hint = ValueHint::DirPath)]
+  #[clap(group = "output")]
   pub output_dir: Option<PathBuf>,
 
   /// Set the base filename to use for output files.
@@ -141,6 +143,7 @@ pub struct NextalignRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'o')]
   #[clap(value_hint = ValueHint::AnyPath)]
+  #[clap(group = "output")]
   pub output_fasta: Option<PathBuf>,
 
   /// Path to output CSV file that contain insertions stripped from the reference alignment.
@@ -150,6 +153,7 @@ pub struct NextalignRunArgs {
   /// If the required directory tree does not exist, it will be created.",
   #[clap(long, short = 'I')]
   #[clap(value_hint = ValueHint::AnyPath)]
+  #[clap(group = "output")]
   pub output_insertions: Option<PathBuf>,
 
   /// Path to output CSV file containing errors and warnings occurred during processing
@@ -159,6 +163,7 @@ pub struct NextalignRunArgs {
   /// If the required directory tree does not exist, it will be created
   #[clap(long, short = 'e')]
   #[clap(value_hint = ValueHint::AnyPath)]
+  #[clap(group = "output")]
   pub output_errors: Option<PathBuf>,
 
   /// Number of processing jobs. If not specified, all available CPU threads will be used.

--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -1,21 +1,19 @@
-use clap::{AppSettings, ArgGroup, CommandFactory, Parser, Subcommand, ValueHint};
+use clap::{AppSettings, ArgEnum, ArgGroup, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use clap_complete_fig::Fig;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
-use eyre::{eyre, Report, WrapErr};
+use eyre::{eyre, ContextCompat, Report, WrapErr};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::LevelFilter;
 use nextclade::align::params::AlignPairwiseParamsOptional;
 use nextclade::io::fs::basename;
-use nextclade::make_internal_error;
-use nextclade::make_error;
 use nextclade::utils::global_init::setup_logger;
-use std::env::current_dir;
 use std::fmt::Debug;
 use std::io;
 use std::path::PathBuf;
-use std::str::FromStr;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 lazy_static! {
   static ref SHELLS: &'static [&'static str] = &["bash", "elvish", "fish", "fig", "powershell", "zsh"];
@@ -38,17 +36,17 @@ pub struct NextalignArgs {
   #[clap(subcommand)]
   pub command: NextalignCommands,
 
-  /// Make output more quiet or more verbose
-  #[clap(flatten)]
-  pub verbose: Verbosity<WarnLevel>,
-
   /// Set verbosity level [default: warn]
   #[clap(long, global = true, conflicts_with = "verbose", conflicts_with = "silent", possible_values(VERBOSITIES.iter()))]
-  pub verbosity: Option<log::LevelFilter>,
+  pub verbosity: Option<LevelFilter>,
 
   /// Disable all console output. Same as --verbosity=off
   #[clap(long, global = true, conflicts_with = "verbose", conflicts_with = "verbosity")]
   pub silent: bool,
+
+  /// Make output more quiet or more verbose
+  #[clap(flatten)]
+  pub verbose: Verbosity<WarnLevel>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -72,6 +70,15 @@ pub enum NextalignCommands {
   Run(Box<NextalignRunArgs>),
 }
 
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum, EnumIter)]
+pub enum NextalignOutputSelection {
+  All,
+  Fasta,
+  Translations,
+  Insertions,
+  Errors,
+}
+
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("output").required(true)))]
 pub struct NextalignRunArgs {
@@ -82,16 +89,32 @@ pub struct NextalignRunArgs {
 
   /// Path to a FASTA file containing reference sequence.
   ///
-  /// This file is expected to contain exactly 1 sequence.
+  /// This file should contain exactly 1 sequence.
   #[clap(long, short = 'r', visible_alias("reference"))]
   #[clap(value_hint = ValueHint::FilePath)]
   pub input_ref: PathBuf,
 
+  /// Path to a .gff file containing the gene map (genome annotation).
+  ///
+  /// Gene map (sometimes also called 'genome annotation') is used to find coding regions. If not supplied, coding regions will
+  /// not be translated, amino acid sequences will not be output, and nucleotide sequence
+  /// alignment will not be informed by codon boundaries
+  ///
+  /// List of genes can be restricted using `--genes` flag. Otherwise all genes found in the gene map will be used.
+  ///
+  /// Learn more about Generic Feature Format Version 3 (GFF3):
+  /// https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md",
+  #[clap(long, short = 'm', alias = "genemap")]
+  #[clap(value_hint = ValueHint::FilePath)]
+  pub input_gene_map: Option<PathBuf>,
+
   /// Comma-separated list of names of genes to use.
   ///
-  /// If not supplied or empty, sequence will not be translated. If non-empty, should contain a coma-separated list of gene names.
+  /// This defines which peptides will be written into outputs, and which genes will be taken into account during
+  /// codon-aware alignment. Must only contain gene names present in the gene map. If
+  /// this flag is not supplied or its value is an empty string, then all genes found in the gene map will be used.
   ///
-  /// Parameters `--genes` and `--genemap` should be either both specified or both omitted.
+  /// Requires `--input-gene-map` to be specified.
   #[clap(
     long,
     short = 'g',
@@ -102,43 +125,41 @@ pub struct NextalignRunArgs {
   #[clap(value_hint = ValueHint::FilePath)]
   pub genes: Option<Vec<String>>,
 
-  /// Path to a .gff file containing the gene map (genome annotation).
+  /// Write all output files to this directory. Convenient when you want to receive all or most output files.
   ///
-  /// Gene map (sometimes also called 'genome annotation') is used to find coding regions. If not supplied, coding regions will
-  /// not be translated, amino acid sequences will not be output, amino acid mutations will not be detected and nucleotide sequence
-  /// alignment will not be informed by codon boundaries
-  ///
-  /// Unless `--genes` are specified, all genes will be translated.
-  ///
-  /// Learn more about Generic Feature Format Version 3 (GFF3):
-  /// https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md",
-  #[clap(long, short = 'm', alias = "genemap")]
-  #[clap(value_hint = ValueHint::FilePath)]
-  pub input_gene_map: Option<PathBuf>,
-
-  /// Write output files to this directory.
-  ///
-  /// The base filename can be set using `--output-basename` flag. The paths can be overridden on a per-file basis using `--output-*` flags.
+  /// The list of output files can be optionally restricted using `--output-selection` flag. The base filename can be set using `--output-basename` flag. The paths can be overridden on a per-file basis using `--output-*` flags.
   ///
   /// If the required directory tree does not exist, it will be created.
-  #[clap(long, short = 'd')]
+  #[clap(long, short = 'O')]
   #[clap(value_hint = ValueHint::DirPath)]
   #[clap(group = "output")]
-  pub output_dir: Option<PathBuf>,
+  pub output_all: Option<PathBuf>,
 
   /// Set the base filename to use for output files.
   ///
-  /// To be used together with `--output-dir` flag. By default uses the filename of the sequences file (provided with `--input-fasta`). The paths can be overridden on a per-file basis using `--output-*` flags.
+  /// To be used together with `--output-all` flag. By default uses the filename of the sequences file (provided with `--input-fasta`). The paths can be overridden on a per-file basis using `--output-*` flags.
   #[clap(long, short = 'n')]
   pub output_basename: Option<String>,
 
-  /// Whether to include aligned reference nucleotide sequence into output nucleotide sequence FASTA file and reference peptides into output peptide FASTA files.
-  #[clap(long)]
-  pub include_reference: bool,
+  /// Restricts outputs for `--output-all` flag
+  ///
+  /// Should contain one or multiple of List of comma-separated strings which
+  ///
+  /// To be used together with `--output-all` flag.
+  #[clap(
+    long,
+    short = 's',
+    takes_value = true,
+    multiple_values = true,
+    use_value_delimiter = true
+  )]
+  #[clap(requires = "output-all")]
+  #[clap(arg_enum)]
+  pub output_selection: Vec<NextalignOutputSelection>,
 
   /// Path to output FASTA file with aligned sequences.
   ///
-  /// Overrides paths given with `--output-dir` and `--output-basename`.
+  /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
   ///
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'o')]
@@ -146,11 +167,25 @@ pub struct NextalignRunArgs {
   #[clap(group = "output")]
   pub output_fasta: Option<PathBuf>,
 
+  /// Template string for path to output fasta files containing translated and aligned peptides. A separate file will be generated for every gene.
+  /// The string should contain template variable `{gene}`, where the gene name will be substituted.
+  /// Make sure you properly quote and/or escape the curly braces, so that your shell, programming language or pipeline manager does not attempt to substitute the variables.
+  ///
+  /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
+  ///
+  /// Example: `--output-translations='output_dir/{gene}.translation.fasta'`
+  ///
+  /// If the required directory tree does not exist, it will be created.
+  #[clap(long, short = 'P')]
+  #[clap(value_hint = ValueHint::AnyPath)]
+  #[clap(group = "output")]
+  pub output_translations: Option<String>,
+
   /// Path to output CSV file that contain insertions stripped from the reference alignment.
   ///
-  /// Overrides paths given with `--output-dir` and `--output-basename`.
+  /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
   ///
-  /// If the required directory tree does not exist, it will be created.",
+  /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'I')]
   #[clap(value_hint = ValueHint::AnyPath)]
   #[clap(group = "output")]
@@ -158,17 +193,17 @@ pub struct NextalignRunArgs {
 
   /// Path to output CSV file containing errors and warnings occurred during processing
   ///
-  /// Overrides paths given with `--output-dir` and `--output-basename`).
+  /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
   ///
-  /// If the required directory tree does not exist, it will be created
+  /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'e')]
   #[clap(value_hint = ValueHint::AnyPath)]
   #[clap(group = "output")]
   pub output_errors: Option<PathBuf>,
 
-  /// Number of processing jobs. If not specified, all available CPU threads will be used.
-  #[clap(long, short, default_value_t = num_cpus::get() )]
-  pub jobs: usize,
+  /// Whether to include aligned reference nucleotide sequence into output nucleotide sequence FASTA file and reference peptides into output peptide FASTA files.
+  #[clap(long)]
+  pub include_reference: bool,
 
   /// Emit output sequences in-order.
   ///
@@ -180,6 +215,10 @@ pub struct NextalignRunArgs {
   /// Note: the sequences which trigger errors during processing will be omitted from outputs, regardless of this flag.
   #[clap(long)]
   pub in_order: bool,
+
+  /// Number of processing jobs. If not specified, all available CPU threads will be used.
+  #[clap(global = false, long, short = 'j', default_value_t = num_cpus::get() )]
+  pub jobs: usize,
 
   #[clap(flatten)]
   pub alignment_params: AlignPairwiseParamsOptional,
@@ -193,8 +232,8 @@ fn generate_completions(shell: &str) -> Result<(), Report> {
     return Ok(());
   }
 
-  let generator =
-    Shell::from_str(&shell.to_lowercase()).map_err(|err| eyre!("{}: Possible values: {}", err, SHELLS.join(", ")))?;
+  let generator = Shell::from_str(&shell.to_lowercase(), true)
+    .map_err(|err| eyre!("{}: Possible values: {}", err, SHELLS.join(", ")))?;
 
   let bin_name = command.get_name().to_owned();
 
@@ -205,25 +244,61 @@ fn generate_completions(shell: &str) -> Result<(), Report> {
 
 /// Get output filenames provided by user or, if not provided, create filenames based on input fasta
 pub fn nextalign_get_output_filenames(run_args: &mut NextalignRunArgs) -> Result<(), Report> {
-  let NextalignRunArgs { input_fasta, .. } = run_args;
+  let NextalignRunArgs {
+    input_fasta,
+    output_all,
+    ref mut output_basename,
+    ref mut output_errors,
+    ref mut output_fasta,
+    ref mut output_insertions,
+    ref mut output_translations,
+    ref mut output_selection,
+    ..
+  } = run_args;
 
-  let basename = run_args.output_basename.get_or_insert(basename(&input_fasta)?);
+  // If `--output-all` is provided, then we need to deduce default output filenames,
+  // while taking care to preserve values of any individual `--output-*` flags,
+  // as well as to honor restrictions put by the `--output-selection` flag, if provided.
+  if let Some(output_all) = output_all {
+    let output_basename = output_basename.get_or_insert(basename(&input_fasta)?);
+    let default_output_file_path = output_all.join(&output_basename);
 
-  let output_dir = run_args
-    .output_dir
-    .get_or_insert(current_dir().wrap_err("When getting current working directory")?);
+    // If `--output-selection` is empty or contains `all`, then fill it with all possible variants
+    if output_selection.is_empty() || output_selection.contains(&NextalignOutputSelection::All) {
+      *output_selection = NextalignOutputSelection::iter().collect_vec();
+    }
 
-  run_args
-    .output_fasta
-    .get_or_insert(output_dir.join(&basename).with_extension("aligned.fasta"));
+    // We use `Option::get_or_insert()` mutable method here in order
+    // to set default output filenames only if they are not provided.
 
-  run_args
-    .output_insertions
-    .get_or_insert(output_dir.join(&basename).with_extension("insertions.csv"));
+    if output_selection.contains(&NextalignOutputSelection::Fasta) {
+      output_fasta.get_or_insert(default_output_file_path.with_extension("aligned.fasta"));
+    }
 
-  run_args
-    .output_errors
-    .get_or_insert(output_dir.join(&basename).with_extension("errors.csv"));
+    if output_selection.contains(&NextalignOutputSelection::Insertions) {
+      let output_insertions =
+        output_insertions.get_or_insert(default_output_file_path.with_extension("insertions.csv"));
+    }
+
+    if output_selection.contains(&NextalignOutputSelection::Errors) {
+      let output_errors = output_errors.get_or_insert(default_output_file_path.with_extension("errors.csv"));
+    }
+
+    if output_selection.contains(&NextalignOutputSelection::Translations) {
+      let output_translations = {
+        let output_translations_path = default_output_file_path
+          .with_file_name(format!("{output_basename}_gene_{{gene}}"))
+          .with_extension("translation.fasta");
+
+        let output_translations_template = output_translations_path
+          .to_str()
+          .wrap_err_with(|| format!("When converting path to string: '{output_translations_path:?}'"))?
+          .to_owned();
+
+        output_translations.get_or_insert(output_translations_template)
+      };
+    }
+  }
 
   Ok(())
 }

--- a/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
@@ -2,24 +2,15 @@ use crate::cli::nextalign_cli::NextalignRunArgs;
 use crate::cli::nextalign_ordered_writer::NextalignOrderedWriter;
 use crossbeam::thread;
 use eyre::{Report, WrapErr};
-use itertools::{Either, Itertools};
 use log::info;
-use nextclade::align::align::align_nuc;
 use nextclade::align::gap_open::{get_gap_open_close_scores_codon_aware, get_gap_open_close_scores_flat};
-use nextclade::align::insertions_strip::insertions_strip;
 use nextclade::align::params::AlignPairwiseParams;
 use nextclade::io::fasta::{read_one_fasta, FastaReader, FastaRecord};
-use nextclade::io::gene_map::{read_gene_map, GeneMap};
-use nextclade::io::gff3::read_gff3_file;
-use nextclade::io::nuc::{to_nuc_seq, Nuc};
+use nextclade::io::gene_map::read_gene_map;
+use nextclade::io::nuc::to_nuc_seq;
 use nextclade::run::nextalign_run_one::nextalign_run_one;
-use nextclade::translate::translate_genes::{translate_genes, Translation, TranslationMap};
 use nextclade::translate::translate_genes_ref::translate_genes_ref;
 use nextclade::types::outputs::NextalignOutputs;
-use nextclade::utils::error::report_to_string;
-use nextclade::{make_error, option_get_some};
-use std::collections::HashSet;
-use std::path::PathBuf;
 
 pub struct NextalignRecord {
   pub index: usize,
@@ -35,10 +26,12 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
     input_ref,
     genes,
     input_gene_map,
-    output_dir,
+    output_all,
     output_basename,
+    output_selection,
     include_reference,
     output_fasta,
+    output_translations,
     output_insertions,
     output_errors,
     jobs,
@@ -46,11 +39,11 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
     alignment_params: alignment_params_from_cli,
   } = args;
 
-  let output_fasta = option_get_some!(output_fasta)?;
-  let output_basename = option_get_some!(output_basename)?;
-  let output_dir = option_get_some!(output_dir)?;
-  let output_insertions = option_get_some!(output_insertions)?;
-  let output_errors = option_get_some!(output_errors)?;
+  // let output_fasta = option_get_some!(output_fasta)?;
+  // let output_basename = option_get_some!(output_basename)?;
+  // let output_dir = option_get_some!(output_dir)?;
+  // let output_insertions = option_get_some!(output_insertions)?;
+  // let output_errors = option_get_some!(output_errors)?;
 
   let mut alignment_params = AlignPairwiseParams::default();
 
@@ -136,12 +129,11 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
 
     s.spawn(move |_| {
       let mut output_writer = NextalignOrderedWriter::new(
-        gene_map,
+        &gene_map,
         &output_fasta,
+        &output_translations,
         &output_insertions,
         &output_errors,
-        &output_dir,
-        &output_basename,
         in_order,
       )
       .wrap_err("When creating output writer")

--- a/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
@@ -39,16 +39,10 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
     alignment_params: alignment_params_from_cli,
   } = args;
 
-  // let output_fasta = option_get_some!(output_fasta)?;
-  // let output_basename = option_get_some!(output_basename)?;
-  // let output_dir = option_get_some!(output_dir)?;
-  // let output_insertions = option_get_some!(output_insertions)?;
-  // let output_errors = option_get_some!(output_errors)?;
-
   let mut alignment_params = AlignPairwiseParams::default();
 
   // Merge alignment params coming from CLI arguments
-  alignment_params.merge_opt(alignment_params_from_cli.clone());
+  alignment_params.merge_opt(alignment_params_from_cli);
 
   let ref_record = &read_one_fasta(input_ref)?;
   let ref_seq = &to_nuc_seq(&ref_record.seq)?;
@@ -129,7 +123,7 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
 
     s.spawn(move |_| {
       let mut output_writer = NextalignOrderedWriter::new(
-        &gene_map,
+        gene_map,
         &output_fasta,
         &output_translations,
         &output_insertions,

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -301,9 +301,13 @@ pub struct NextcladeRunArgs {
   #[clap(value_hint = ValueHint::FilePath)]
   pub genes: Option<Vec<String>>,
 
-  /// Write all output files to this directory. Convenient when you want to receive all or most output files.
+  /// Produce all of the output files into this directory, using default basename and predefined suffixes and extensions. This is equivalent to specifying each of the individual `--output-*` flags. Convenient when you want to receive all or most of output files into the same directory and don't care about their filenames.
   ///
-  /// The list of output files can be optionally restricted using `--output-selection` flag. The base filename can be set using `--output-basename` flag. The paths can be overridden on a per-file basis using `--output-*` flags.
+  /// Output files can be optionally included or excluded using `--output-selection` flag.
+  /// The base filename can be set using `--output-basename` flag.
+  ///
+  /// If both the `--output-all` and individual `--output-*` flags are provided, each
+  //  individual flag overrides the corresponding default output path.
   ///
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'O')]
@@ -313,16 +317,20 @@ pub struct NextcladeRunArgs {
 
   /// Set the base filename to use for output files.
   ///
-  /// To be used together with `--output-all` flag. By default uses the filename of the sequences file (provided with `--input-fasta`). The paths can be overridden on a per-file basis using `--output-*` flags.
+  /// By default the base filename is extracted from the input sequences file (provided with `--input-fasta`).
+  ///
+  /// Only valid together with `--output-all` flag.
   #[clap(long, short = 'n')]
   #[clap(requires = "output-all")]
   pub output_basename: Option<String>,
 
-  /// Restricts outputs for `--output-all` flag
+  /// Restricts outputs for `--output-all` flag.
   ///
-  /// Should contain one or multiple of List of comma-separated strings which
+  /// Should contain a comma-separated list of names of output files to produce.
   ///
-  /// To be used together with `--output-all` flag.
+  /// If 'all' is present in the list, then all other entries are ignored and all outputs are produced.
+  ///
+  /// Only valid together with `--output-all` flag.
   #[clap(
     long,
     short = 's',
@@ -362,7 +370,7 @@ pub struct NextcladeRunArgs {
 
   /// Path to output Newline-delimited JSON (NDJSON) results file.
   ///
-  /// This file format is most suitable for further machine processing of the results.
+  /// This file format is most suitable for further machine processing of the results. By contrast to plain json, it can be streamed line-by line, so much bigger outputs are feasible.
   ///
   /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
   ///

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -208,7 +208,6 @@ pub enum NextcladeOutputSelection {
 }
 
 #[derive(Parser, Debug)]
-#[clap(group(ArgGroup::new("output").required(true).multiple(true)))]
 pub struct NextcladeRunArgs {
   /// Path to a FASTA file with input sequences
   #[clap(long, short = 'i', visible_alias("sequences"))]
@@ -309,10 +308,11 @@ pub struct NextcladeRunArgs {
   /// If both the `--output-all` and individual `--output-*` flags are provided, each
   //  individual flag overrides the corresponding default output path.
   ///
+  /// At least one of the output flags is required: `--output-all`, `--output-fasta`, `--output-ndjson`, `--output-json`, `--output-csv`, `--output-tsv`, `--output-tree`, `--output-translations`, `--output-insertions`, `--output-errors`
+  ///
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'O')]
   #[clap(value_hint = ValueHint::DirPath)]
-  #[clap(group = "output")]
   pub output_all: Option<PathBuf>,
 
   /// Set the base filename to use for output files.
@@ -349,7 +349,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'o')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_fasta: Option<PathBuf>,
 
   /// Template string for path to output fasta files containing translated and aligned peptides. A separate file will be generated for every gene.
@@ -365,7 +364,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'P')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_translations: Option<String>,
 
   /// Path to output Newline-delimited JSON (NDJSON) results file.
@@ -377,7 +375,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'N')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_ndjson: Option<PathBuf>,
 
   /// Path to output JSON results file.
@@ -389,7 +386,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'J')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_json: Option<PathBuf>,
 
   /// Path to output CSV results file.
@@ -403,7 +399,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'c')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_csv: Option<PathBuf>,
 
   /// Path to output TSV results file.
@@ -417,7 +412,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 't')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_tsv: Option<PathBuf>,
 
   /// Path to output phylogenetic tree with input sequences placed onto it, in Auspice JSON V2 format.
@@ -432,7 +426,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'T')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_tree: Option<PathBuf>,
 
   /// Path to output CSV file that contain insertions stripped from the reference alignment.
@@ -442,7 +435,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'I')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_insertions: Option<PathBuf>,
 
   /// Path to output CSV file containing errors and warnings occurred during processing
@@ -452,7 +444,6 @@ pub struct NextcladeRunArgs {
   /// If the required directory tree does not exist, it will be created.
   #[clap(long, short = 'e')]
   #[clap(value_hint = ValueHint::AnyPath)]
-  #[clap(group = "output")]
   pub output_errors: Option<PathBuf>,
 
   /// Whether to include aligned reference nucleotide sequence into output nucleotide sequence FASTA file and reference peptides into output peptide FASTA files.
@@ -592,6 +583,39 @@ Example for bash shell:
       "#
       );
     }
+  }
+
+  let all_outputs_are_missing = [
+    output_all,
+    output_fasta,
+    output_ndjson,
+    output_json,
+    output_csv,
+    output_tsv,
+    output_tree,
+    output_insertions,
+    output_errors,
+  ]
+  .iter()
+  .all(|o| o.is_none())
+    && output_translations.is_none();
+
+  if all_outputs_are_missing {
+    return make_error!(
+      r#"No output flags provided.
+
+At least one of the following flags is required:
+  --output-all
+  --output-fasta
+  --output-ndjson
+  --output-json
+  --output-csv
+  --output-tsv
+  --output-tree
+  --output-translations
+  --output-insertions
+  --output-errors"#
+    );
   }
 
   Ok(())

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -9,8 +9,7 @@ use nextclade::align::params::AlignPairwiseParams;
 use nextclade::analyze::pcr_primers::PcrPrimer;
 use nextclade::analyze::virus_properties::VirusProperties;
 use nextclade::io::fasta::{read_one_fasta, FastaReader, FastaRecord};
-use nextclade::io::gene_map::{read_gene_map, GeneMap};
-use nextclade::io::gff3::read_gff3_file;
+use nextclade::io::gene_map::read_gene_map;
 use nextclade::io::json::json_write;
 use nextclade::io::nuc::{from_nuc_seq, to_nuc_seq, Nuc};
 use nextclade::option_get_some;
@@ -22,7 +21,6 @@ use nextclade::tree::tree::AuspiceTree;
 use nextclade::tree::tree_attach_new_nodes::tree_attach_new_nodes_in_place;
 use nextclade::tree::tree_preprocess::tree_preprocess_in_place;
 use nextclade::types::outputs::NextcladeOutputs;
-use serde::{Deserialize, Serialize};
 
 pub struct NextcladeRecord {
   pub index: usize,
@@ -35,6 +33,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
 
   let NextcladeRunArgs {
     input_fasta,
+    input_dataset,
     input_ref,
     input_tree,
     input_qc_config,
@@ -42,8 +41,10 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
     input_pcr_primers,
     input_gene_map,
     genes,
-    output_dir,
+    output_all,
     output_basename,
+    output_selection,
+    output_translations,
     include_reference,
     output_fasta,
     output_ndjson,
@@ -56,7 +57,6 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
     jobs,
     in_order,
     alignment_params: alignment_params_from_cli,
-    ..
   } = args;
 
   let input_ref = option_get_some!(input_ref)?;
@@ -64,16 +64,6 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
   let input_qc_config = option_get_some!(input_qc_config)?;
   let input_virus_properties = option_get_some!(input_virus_properties)?;
   let input_pcr_primers = option_get_some!(input_pcr_primers)?;
-
-  let output_fasta = option_get_some!(output_fasta)?;
-  let output_basename = option_get_some!(output_basename)?;
-  let output_dir = option_get_some!(output_dir)?;
-  let output_insertions = option_get_some!(output_insertions)?;
-  let output_errors = option_get_some!(output_errors)?;
-  let output_json = option_get_some!(output_json)?;
-  let output_ndjson = option_get_some!(output_ndjson)?;
-  let output_csv = option_get_some!(output_csv)?;
-  let output_tsv = option_get_some!(output_tsv)?;
 
   let ref_record = &read_one_fasta(input_ref)?;
   let ref_seq = &to_nuc_seq(&ref_record.seq)?;
@@ -189,7 +179,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
 
     let writer = s.spawn(move |_| {
       let mut output_writer = NextcladeOrderedWriter::new(
-        gene_map,
+        &gene_map,
         clade_node_attrs,
         &output_fasta,
         &output_json,
@@ -198,8 +188,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
         &output_tsv,
         &output_insertions,
         &output_errors,
-        &output_dir,
-        &output_basename,
+        &output_translations,
         in_order,
       )
       .wrap_err("When creating output writer")

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -80,7 +80,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
   }
 
   // Merge alignment params coming from CLI arguments
-  alignment_params.merge_opt(alignment_params_from_cli.clone());
+  alignment_params.merge_opt(alignment_params_from_cli);
 
   info!("Alignment parameters (final):\n{alignment_params:#?}");
 
@@ -179,7 +179,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
 
     let writer = s.spawn(move |_| {
       let mut output_writer = NextcladeOrderedWriter::new(
-        &gene_map,
+        gene_map,
         clade_node_attrs,
         &output_fasta,
         &output_json,

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -2,10 +2,9 @@ use crate::cli::nextclade_loop::NextcladeRecord;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::warn;
-use nextclade::io::gene_map::GeneMap;
-use nextclade::io::csv::CsvVecFileWriter;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
+use nextclade::io::gene_map::GeneMap;
 use nextclade::io::insertions_csv::InsertionsCsvWriter;
 use nextclade::io::ndjson::NdjsonFileWriter;
 use nextclade::io::nextclade_csv::NextcladeResultsCsvFileWriter;
@@ -13,20 +12,23 @@ use nextclade::io::nuc::from_nuc_seq;
 use nextclade::io::results_json::ResultsJsonWriter;
 use nextclade::translate::translate_genes::TranslationMap;
 use nextclade::tree::tree::CladeNodeAttrKeyDesc;
+use nextclade::types::outputs::NextcladeOutputs;
 use nextclade::utils::error::report_to_string;
+use nextclade::utils::option::OptionMapRefFallible;
 use std::collections::HashMap;
-use std::path::Path;
+use std::hash::Hasher;
+use std::path::PathBuf;
 
 /// Writes output files, potentially preserving the initial order of records (same as in the inputs)
 pub struct NextcladeOrderedWriter<'a> {
-  fasta_writer: FastaWriter,
-  fasta_peptide_writer: FastaPeptideWriter,
-  output_json_writer: ResultsJsonWriter,
-  output_ndjson_writer: NdjsonFileWriter,
-  output_csv_writer: NextcladeResultsCsvFileWriter,
-  output_tsv_writer: NextcladeResultsCsvFileWriter,
-  insertions_csv_writer: InsertionsCsvWriter,
-  errors_csv_writer: ErrorsCsvWriter<'a>,
+  fasta_writer: Option<FastaWriter>,
+  fasta_peptide_writer: Option<FastaPeptideWriter>,
+  output_json_writer: Option<ResultsJsonWriter>,
+  output_ndjson_writer: Option<NdjsonFileWriter>,
+  output_csv_writer: Option<NextcladeResultsCsvFileWriter>,
+  output_tsv_writer: Option<NextcladeResultsCsvFileWriter>,
+  insertions_csv_writer: Option<InsertionsCsvWriter>,
+  errors_csv_writer: Option<ErrorsCsvWriter<'a>>,
   expected_index: usize,
   queue: HashMap<usize, NextcladeRecord>,
   in_order: bool,
@@ -36,32 +38,40 @@ impl<'a> NextcladeOrderedWriter<'a> {
   pub fn new(
     gene_map: &'a GeneMap,
     clade_node_attr_key_descs: &[CladeNodeAttrKeyDesc],
-    output_fasta: &Path,
-    output_json: &Path,
-    output_ndjson: &Path,
-    output_csv: &Path,
-    output_tsv: &Path,
-    output_insertions: &Path,
-    output_errors: &Path,
-    output_dir: &Path,
-    output_basename: &str,
+    output_fasta: &Option<PathBuf>,
+    output_json: &Option<PathBuf>,
+    output_ndjson: &Option<PathBuf>,
+    output_csv: &Option<PathBuf>,
+    output_tsv: &Option<PathBuf>,
+    output_insertions: &Option<PathBuf>,
+    output_errors: &Option<PathBuf>,
+    output_translations: &Option<String>,
     in_order: bool,
   ) -> Result<Self, Report> {
-    let fasta_writer = FastaWriter::from_path(&output_fasta)?;
-    let fasta_peptide_writer = FastaPeptideWriter::new(gene_map, &output_dir, &output_basename)?;
-    let output_json_writer = ResultsJsonWriter::new(&output_json, clade_node_attr_key_descs)?;
-    let output_ndjson_writer = NdjsonFileWriter::new(&output_ndjson)?;
+    let fasta_writer = output_fasta.map_ref_fallible(FastaWriter::from_path)?;
+
+    let fasta_peptide_writer = output_translations
+      .map_ref_fallible(|output_translations| FastaPeptideWriter::new(gene_map, &output_translations))?;
+
+    let insertions_csv_writer = output_insertions.map_ref_fallible(InsertionsCsvWriter::new)?;
+
+    let errors_csv_writer =
+      output_errors.map_ref_fallible(|output_errors| ErrorsCsvWriter::new(gene_map, &output_errors))?;
+
+    let output_json_writer =
+      output_json.map_ref_fallible(|output_json| ResultsJsonWriter::new(&output_json, clade_node_attr_key_descs))?;
+
+    let output_ndjson_writer = output_ndjson.map_ref_fallible(NdjsonFileWriter::new)?;
 
     let clade_node_attr_keys = clade_node_attr_key_descs
       .iter()
       .map(|desc| desc.name.clone())
       .collect_vec();
+    let output_csv_writer = output_csv
+      .map_ref_fallible(|output_csv| NextcladeResultsCsvFileWriter::new(&output_csv, b';', &clade_node_attr_keys))?;
+    let output_tsv_writer = output_tsv
+      .map_ref_fallible(|output_tsv| NextcladeResultsCsvFileWriter::new(&output_tsv, b'\t', &clade_node_attr_keys))?;
 
-    let output_csv_writer = NextcladeResultsCsvFileWriter::new(&output_csv, b';', &clade_node_attr_keys)?;
-    let output_tsv_writer = NextcladeResultsCsvFileWriter::new(&output_tsv, b'\t', &clade_node_attr_keys)?;
-
-    let insertions_csv_writer = InsertionsCsvWriter::new(&output_insertions)?;
-    let errors_csv_writer = ErrorsCsvWriter::new(gene_map, &output_errors)?;
     Ok(Self {
       fasta_writer,
       fasta_peptide_writer,
@@ -80,11 +90,18 @@ impl<'a> NextcladeOrderedWriter<'a> {
   pub fn write_ref(&mut self, ref_record: &FastaRecord, ref_peptides: &TranslationMap) -> Result<(), Report> {
     let FastaRecord { seq_name, seq, .. } = &ref_record;
 
-    self.fasta_writer.write(seq_name, seq)?;
+    if let Some(fasta_writer) = &mut self.fasta_writer {
+      fasta_writer.write(seq_name, seq)?;
+    }
 
-    ref_peptides
-      .iter()
-      .try_for_each(|(_, peptide)| self.fasta_peptide_writer.write(seq_name, peptide))
+    ref_peptides.iter().try_for_each(|(_, peptide)| {
+      if let Some(fasta_peptide_writer) = &mut self.fasta_peptide_writer {
+        fasta_peptide_writer.write(seq_name, peptide)?;
+      }
+      Result::<(), Report>::Ok(())
+    })?;
+
+    Ok(())
   }
 
   /// Writes output record into output files
@@ -97,29 +114,46 @@ impl<'a> NextcladeOrderedWriter<'a> {
 
     match outputs_or_err {
       Ok((qry_seq_stripped, translations, nextclade_outputs)) => {
-        self.fasta_writer.write(&seq_name, &from_nuc_seq(&qry_seq_stripped))?;
+        let NextcladeOutputs {
+          warnings,
+          insertions,
+          missing_genes,
+          ..
+        } = &nextclade_outputs;
 
-        self.output_csv_writer.write(&nextclade_outputs)?;
-
-        self.output_tsv_writer.write(&nextclade_outputs)?;
-
-        self.output_ndjson_writer.write(&nextclade_outputs)?;
-
-        for translation in &translations {
-          self.fasta_peptide_writer.write(&seq_name, translation)?;
+        if let Some(fasta_writer) = &mut self.fasta_writer {
+          fasta_writer.write(&seq_name, &from_nuc_seq(&qry_seq_stripped))?;
         }
 
-        self
-          .insertions_csv_writer
-          .write(&seq_name, &nextclade_outputs.insertions, &translations)?;
+        if let Some(fasta_peptide_writer) = &mut self.fasta_peptide_writer {
+          for translation in &translations {
+            fasta_peptide_writer.write(&seq_name, translation)?;
+          }
+        }
 
-        self.errors_csv_writer.write_aa_errors(
-          &seq_name,
-          &nextclade_outputs.warnings,
-          &nextclade_outputs.missing_genes,
-        )?;
+        if let Some(insertions_csv_writer) = &mut self.insertions_csv_writer {
+          insertions_csv_writer.write(&seq_name, insertions, &translations)?;
+        }
 
-        self.output_json_writer.write(nextclade_outputs);
+        if let Some(errors_csv_writer) = &mut self.errors_csv_writer {
+          errors_csv_writer.write_aa_errors(&seq_name, warnings, missing_genes)?;
+        }
+
+        if let Some(output_csv_writer) = &mut self.output_csv_writer {
+          output_csv_writer.write(&nextclade_outputs)?;
+        }
+
+        if let Some(output_tsv_writer) = &mut self.output_tsv_writer {
+          output_tsv_writer.write(&nextclade_outputs)?;
+        }
+
+        if let Some(output_ndjson_writer) = &mut self.output_ndjson_writer {
+          output_ndjson_writer.write(&nextclade_outputs)?;
+        }
+
+        if let Some(output_json_writer) = &mut self.output_json_writer {
+          output_json_writer.write(nextclade_outputs);
+        }
       }
       Err(report) => {
         let cause = report_to_string(&report);
@@ -127,7 +161,9 @@ impl<'a> NextcladeOrderedWriter<'a> {
           "In sequence #{index} '{seq_name}': {cause}. Note that this sequence will not be included in the results."
         );
         warn!("{message}");
-        self.errors_csv_writer.write_nuc_error(&seq_name, &message)?;
+        if let Some(errors_csv_writer) = &mut self.errors_csv_writer {
+          errors_csv_writer.write_nuc_error(&seq_name, &message)?;
+        }
       }
     }
 
@@ -176,7 +212,10 @@ impl<'a> NextcladeOrderedWriter<'a> {
   /// Finalizes output by writing all queued records
   pub fn finish(&mut self) -> Result<(), Report> {
     self.write_queued_records()?;
-    self.output_json_writer.finish()
+    if let Some(output_json_writer) = &mut self.output_json_writer {
+      output_json_writer.finish()?;
+    }
+    Ok(())
   }
 }
 

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -42,9 +42,9 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order", "indexmap", "unbounded_depth"] }
+tinytemplate = "1.2.1"
 traversal = "0.1.2"
 validator = { version = "0.14.0", features = ["derive"] }
-
 
 [target.'cfg(all(target_family = "linux", target_arch = "x86_64"))'.dependencies]
 mimalloc = { version = "0.1.28", default-features = false, optional = true }

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -1,8 +1,7 @@
-use crate::io::gene_map::GeneMap;
 use crate::io::aa::from_aa_seq;
 use crate::io::fs::ensure_dir;
+use crate::io::gene_map::GeneMap;
 use crate::translate::translate_genes::Translation;
-use crate::utils::error::report_to_string;
 use crate::{make_error, make_internal_error};
 use eyre::{Report, WrapErr};
 use log::{trace, warn};
@@ -10,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use tinytemplate::TinyTemplate;
 
 pub const fn is_char_allowed(c: char) -> bool {
   c.is_ascii_alphabetic() || c == '*'
@@ -153,6 +154,11 @@ impl FastaWriter {
   }
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct OutputTranslationsTemplateContext<'a> {
+  gene: &'a str,
+}
+
 pub type FastaPeptideWritersMap = BTreeMap<String, FastaWriter>;
 
 /// Writes peptides, each into a separate fasta file
@@ -161,18 +167,21 @@ pub struct FastaPeptideWriter {
 }
 
 impl FastaPeptideWriter {
-  pub fn new(
-    gene_map: &GeneMap,
-    output_dir: impl AsRef<Path>,
-    output_basename: impl AsRef<str>,
-  ) -> Result<Self, Report> {
-    let output_dir = output_dir.as_ref();
-    let output_basename = output_basename.as_ref();
+  pub fn new(gene_map: &GeneMap, output_translations: impl AsRef<str>) -> Result<Self, Report> {
+    let output_translations = output_translations.as_ref();
+
+    let mut tt = TinyTemplate::new();
+    tt.add_template("output_translations", output_translations)
+      .wrap_err_with(|| format!("When parsing template: {output_translations}"))?;
 
     let writers = gene_map
       .iter()
       .map(|(gene_name, _)| -> Result<_, Report> {
-        let out_gene_fasta_path = output_dir.join(format!("{output_basename}.gene.{gene_name}.fasta"));
+        let template_context = OutputTranslationsTemplateContext { gene: gene_name };
+        let rendered_path = tt
+          .render("output_translations", &template_context)
+          .wrap_err_with(|| format!("When rendering output translations path template: '{output_translations}', using context: {template_context:?}"))?;
+        let out_gene_fasta_path = PathBuf::from_str(&rendered_path).wrap_err_with(|| format!("Invalid output translations path: '{rendered_path}'"))?;
         trace!("Creating fasta writer to file {out_gene_fasta_path:#?}");
         let writer = FastaWriter::from_path(&out_gene_fasta_path)?;
         Ok((gene_name.clone(), writer))

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -32,11 +32,14 @@ pub fn ensure_dir(filepath: impl AsRef<Path>) -> Result<(), Report> {
 
 pub fn basename(filepath: impl AsRef<Path>) -> Result<String, Report> {
   let filepath = filepath.as_ref();
+
   Ok(
     filepath
       .with_extension("")
+      .file_name()
+      .ok_or_else(|| eyre!("Cannot get filename of path {filepath:#?}"))?
       .to_str()
-      .ok_or_else(|| eyre!("Cannot get base name of path {filepath:#?}"))?
+      .ok_or_else(|| eyre!("Cannot get basename of path {filepath:#?}"))?
       .to_owned(),
   )
 }

--- a/packages_rs/nextclade/src/utils/option.rs
+++ b/packages_rs/nextclade/src/utils/option.rs
@@ -13,3 +13,26 @@ macro_rules! option_get_some {
 }
 
 pub use option_get_some;
+
+pub trait OptionMapRefFallible<'o, T: 'o> {
+  /// Borrows the internal value of an `Option`, maps it using the provided closure
+  /// and transposes `Option` of `Result` to `Result` of `Option`.
+  ///
+  /// Convenient to use with fallible mapping functions (which returns a `Result`)
+  ///
+  /// Inspired by
+  /// https://github.com/ammongit/rust-ref-map/blob/4b1251c6d2fd192d89a114395b36aeeab5c5433c/src/option.rs
+  fn map_ref_fallible<U, F, E>(&'o self, f: F) -> Result<Option<U>, E>
+  where
+    F: FnOnce(&'o T) -> Result<U, E>;
+}
+
+impl<'o, T: 'o> OptionMapRefFallible<'o, T> for Option<T> {
+  #[inline]
+  fn map_ref_fallible<U, F, E>(&'o self, f: F) -> Result<Option<U>, E>
+  where
+    F: FnOnce(&'o T) -> Result<U, E>,
+  {
+    (*self).as_ref().map(f).transpose()
+  }
+}


### PR DESCRIPTION
Novelties:

 - Translations have a dedicated flag, just like any other output. They are not mandatory anymore and are not tied to "all outputs":
	  ```bash
	  --output-translations='output_dir/gene_{{gene}}.translation.fasta'
	  ```

 - "All outputs" flag now means "really all of them". The flag is now named better and not tied to translations:
	  ```
	   --output-all='my_output_dir/' 
	  ```

 - "All outputs" can be filtered by name:

	  ``` 
	  --output-all='my_output_dir/' --output-selection='fasta,tsv,insertions,translations' 
	  ```
 - Nextalign and Nextclade work the same, but Nextclade have more outputs
