### PR TITLE
feat(web): upload multiple files

### DIFF
--- a/packages_rs/nextclade-web/src/components/FilePicker/FilePicker.tsx
+++ b/packages_rs/nextclade-web/src/components/FilePicker/FilePicker.tsx
@@ -77,9 +77,9 @@ export function FilePicker({
   const { t } = useTranslationSafe()
   const [activeTab, setActiveTab] = useState<string>('file')
 
-  const onFile = useCallback(
-    (file: File) => {
-      onInput(new AlgorithmInputFile(file))
+  const onFiles = useCallback(
+    (files: File[]) => {
+      onInput(new AlgorithmInputFile(files))
     },
     [onInput],
   )
@@ -111,9 +111,9 @@ export function FilePicker({
         name: 'file',
         title: t('File'),
         body: compact ? (
-          <UploadBoxCompact onUpload={onFile}>{icon}</UploadBoxCompact>
+          <UploadBoxCompact onUpload={onFiles}>{icon}</UploadBoxCompact>
         ) : (
-          <UploadBox onUpload={onFile}>{icon}</UploadBox>
+          <UploadBox onUpload={onFiles}>{icon}</UploadBox>
         ),
       },
       {
@@ -127,7 +127,7 @@ export function FilePicker({
         body: <TabPanelPaste onConfirm={onPaste} instructions={pasteInstructions} inputRef={inputRef} />,
       },
     ],
-    [compact, exampleUrl, icon, inputRef, onFile, onPaste, onUrl, pasteInstructions, t],
+    [compact, exampleUrl, icon, inputRef, onFiles, onPaste, onUrl, pasteInstructions, t],
   )
 
   const FileUploadOrFileInfo = useMemo(() => {

--- a/packages_rs/nextclade-web/src/components/FilePicker/UploadBox.tsx
+++ b/packages_rs/nextclade-web/src/components/FilePicker/UploadBox.tsx
@@ -82,8 +82,8 @@ export function UploadBox({ onUpload, children, ...props }: PropsWithChildren<Up
   const normal = useMemo(
     () => (
       <UploadZoneTextContainer>
-        <UploadZoneText>{t('Drag & drop a file ')}</UploadZoneText>
-        <UploadZoneButton color="primary">{t('Select a file')}</UploadZoneButton>
+        <UploadZoneText>{t('Drag & drop files')}</UploadZoneText>
+        <UploadZoneButton color="primary">{t('Select files')}</UploadZoneButton>
       </UploadZoneTextContainer>
     ),
     [t],
@@ -99,7 +99,7 @@ export function UploadBox({ onUpload, children, ...props }: PropsWithChildren<Up
   )
 
   return (
-    <UploadZoneWrapper {...getRootProps()} {...props} title={t('Drag & drop or select a file')}>
+    <UploadZoneWrapper {...getRootProps()} {...props} title={t('Drag & drop or select files')}>
       <UploadZoneInput type="file" {...getInputProps()} />
       <UploadZone state={state}>
         <UploadZoneLeft>{<FileIconsContainer>{children}</FileIconsContainer>}</UploadZoneLeft>

--- a/packages_rs/nextclade-web/src/components/FilePicker/UploadBox.tsx
+++ b/packages_rs/nextclade-web/src/components/FilePicker/UploadBox.tsx
@@ -1,93 +1,10 @@
-import React, { PropsWithChildren, useMemo, useState } from 'react'
-
-import type { TFunction } from 'i18next'
+import React, { PropsWithChildren, useMemo } from 'react'
 import { Button } from 'reactstrap'
-import { sanitizeError } from 'src/helpers/sanitizeError'
-import styled, { DefaultTheme } from 'styled-components'
-import { FileRejection, useDropzone } from 'react-dropzone'
+import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 
-import { theme } from 'src/theme'
+import { getUploadZoneTheme, UploadZoneState, useUploadZone } from 'src/components/FilePicker/useUploadZone'
 import { appendDash } from 'src/helpers/appendDash'
-
-export type UpdateErrorsFunction = (prevErrors: string[]) => string[]
-
-export interface MakeOnDropParams {
-  t: TFunction
-
-  onUpload(file: File): void
-
-  setErrors(updateErrors: string[] | UpdateErrorsFunction): void
-}
-
-export function makeOnDrop({ t, onUpload, setErrors }: MakeOnDropParams) {
-  function handleError(error: Error) {
-    if (error instanceof UploadErrorTooManyFiles) {
-      setErrors((prevErrors) => [...prevErrors, t('Only one file is expected')])
-    } else if (error instanceof UploadErrorUnknown) {
-      setErrors((prevErrors) => [...prevErrors, t('Unknown error')])
-    } else {
-      throw error
-    }
-  }
-
-  async function processFiles(acceptedFiles: File[], rejectedFiles: FileRejection[]) {
-    const nFiles = acceptedFiles.length + rejectedFiles.length
-
-    if (nFiles > 1) {
-      throw new UploadErrorTooManyFiles(nFiles)
-    }
-
-    if (acceptedFiles.length !== 1) {
-      throw new UploadErrorTooManyFiles(acceptedFiles.length)
-    }
-
-    const file = acceptedFiles[0]
-    onUpload(file)
-  }
-
-  async function onDrop(acceptedFiles: File[], rejectedFiles: FileRejection[]) {
-    setErrors([])
-    try {
-      await processFiles(acceptedFiles, rejectedFiles)
-    } catch (error: unknown) {
-      handleError(sanitizeError(error))
-    }
-  }
-
-  return (acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
-    // eslint-disable-next-line no-void
-    void onDrop(acceptedFiles, rejectedFiles)
-  }
-}
-
-export enum UploadZoneState {
-  normal = 'normal',
-  accept = 'accept',
-  reject = 'reject',
-  hover = 'hover',
-}
-
-class UploadErrorTooManyFiles extends Error {
-  public readonly nFiles: number
-
-  constructor(nFiles: number) {
-    super(`when uploading: one file is expected, but got ${nFiles}`)
-    this.nFiles = nFiles
-  }
-}
-
-class UploadErrorUnknown extends Error {
-  constructor() {
-    super(`when uploading: unknown error`)
-  }
-}
-
-export type UploadZoneElems = keyof typeof theme.uploadZone
-
-export function getUploadZoneTheme(props: { state: UploadZoneState; theme: DefaultTheme }, elem: UploadZoneElems) {
-  return props.theme.uploadZone[elem][props.state]
-}
 
 export const UploadZoneWrapper = styled.div`
   width: 100%;
@@ -101,15 +18,15 @@ export const UploadZoneWrapper = styled.div`
 
 export const UploadZone = styled.div<{ state: UploadZoneState }>`
   display: flex;
-  height: 100%;
   width: 100%;
+  height: 100%;
   cursor: pointer;
-  border: ${(props) => getUploadZoneTheme(props, 'border')};
+  min-height: ${(props) => props.theme.filePicker.minHeight};
   border-radius: ${(props) => props.theme.filePicker.borderRadius};
+  border: ${(props) => getUploadZoneTheme(props, 'border')};
   color: ${(props) => getUploadZoneTheme(props, 'color')};
   background-color: ${(props) => getUploadZoneTheme(props, 'background')};
   box-shadow: ${(props) => getUploadZoneTheme(props, 'box-shadow')};
-  min-height: ${(props) => props.theme.filePicker.minHeight};
 `
 
 export const UploadZoneInput = styled.input``
@@ -141,13 +58,6 @@ export const UploadZoneText = styled.div`
   text-align: center;
 `
 
-export const UploadZoneTextOr = styled.div`
-  margin-top: 10px;
-  font-size: 0.9rem;
-  font-weight: lighter;
-  text-align: center;
-`
-
 export const UploadZoneButton = styled(Button)`
   margin-top: 10px;
   min-width: 160px;
@@ -155,33 +65,24 @@ export const UploadZoneButton = styled(Button)`
 `
 
 export interface UploaderGenericProps {
-  onUpload(file: File): void
+  onUpload(files: File[]): void
 }
 
 export function UploadBox({ onUpload, children, ...props }: PropsWithChildren<UploaderGenericProps>) {
   const { t } = useTranslation()
-  const [errors, setErrors] = useState<string[]>([])
-
-  const { getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject } = useDropzone({
-    onDrop: makeOnDrop({ t, onUpload, setErrors }),
-    multiple: false,
+  const { state, errors, hasErrors, getRootProps, getInputProps, isDragActive } = useUploadZone({
+    onUpload,
+    multiple: true,
   })
-
-  const hasErrors = errors.length > 0
 
   if (hasErrors) {
     console.warn(`Errors when uploading:\n${errors.map(appendDash).join('\n')}`)
   }
 
-  let state = UploadZoneState.normal
-  if (isDragAccept) state = UploadZoneState.accept
-  else if (isDragReject) state = UploadZoneState.reject
-
   const normal = useMemo(
     () => (
       <UploadZoneTextContainer>
-        <UploadZoneText>{t('Drag & Drop a file here')}</UploadZoneText>
-        <UploadZoneTextOr>{t('or')}</UploadZoneTextOr>
+        <UploadZoneText>{t('Drag & drop a file ')}</UploadZoneText>
         <UploadZoneButton color="primary">{t('Select a file')}</UploadZoneButton>
       </UploadZoneTextContainer>
     ),
@@ -198,7 +99,7 @@ export function UploadBox({ onUpload, children, ...props }: PropsWithChildren<Up
   )
 
   return (
-    <UploadZoneWrapper {...props} {...getRootProps()}>
+    <UploadZoneWrapper {...getRootProps()} {...props} title={t('Drag & drop or select a file')}>
       <UploadZoneInput type="file" {...getInputProps()} />
       <UploadZone state={state}>
         <UploadZoneLeft>{<FileIconsContainer>{children}</FileIconsContainer>}</UploadZoneLeft>

--- a/packages_rs/nextclade-web/src/components/FilePicker/useUploadZone.ts
+++ b/packages_rs/nextclade-web/src/components/FilePicker/useUploadZone.ts
@@ -1,0 +1,98 @@
+import { TFunction } from 'i18next'
+import { useState } from 'react'
+import { FileRejection, useDropzone } from 'react-dropzone'
+import { useTranslation } from 'react-i18next'
+import { sanitizeError } from 'src/helpers/sanitizeError'
+import { theme } from 'src/theme'
+import { DefaultTheme } from 'styled-components'
+
+export enum UploadZoneState {
+  normal = 'normal',
+  accept = 'accept',
+  reject = 'reject',
+  hover = 'hover',
+}
+
+export interface UseUploadZoneParams {
+  onUpload(files: File[]): void
+  multiple?: boolean
+}
+
+export function useUploadZone({ onUpload, multiple = false }: UseUploadZoneParams) {
+  const { t } = useTranslation()
+  const [errors, setErrors] = useState<string[]>([])
+  const hasErrors = errors.length > 0
+
+  const { getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject } = useDropzone({
+    onDrop: makeOnDrop({ t, onUpload, setErrors, multiple }),
+    multiple,
+  })
+
+  let state = UploadZoneState.normal
+  if (isDragAccept) state = UploadZoneState.accept
+  else if (isDragReject) state = UploadZoneState.reject
+
+  return { state, errors, hasErrors, getRootProps, getInputProps, isDragActive }
+}
+
+export interface MakeOnDropParams {
+  t: TFunction
+  onUpload(files: File[]): void
+  setErrors(updateErrors: string[] | ((prevErrors: string[]) => string[])): void
+  multiple: boolean
+}
+
+export function makeOnDrop({ t, onUpload, setErrors, multiple }: MakeOnDropParams) {
+  function handleError(error: Error) {
+    if (error instanceof UploadErrorTooManyFiles) {
+      setErrors((prevErrors) => [...prevErrors, t('Only one file is expected')])
+    } else if (error instanceof UploadErrorUnknown) {
+      setErrors((prevErrors) => [...prevErrors, t('Unknown error')])
+    } else {
+      throw error
+    }
+  }
+
+  async function processFiles(acceptedFiles: File[], rejectedFiles: FileRejection[]) {
+    const nFiles = acceptedFiles.length + rejectedFiles.length
+    if ((!multiple && nFiles > 1) || (!multiple && acceptedFiles.length > 1)) {
+      throw new UploadErrorTooManyFiles(nFiles)
+    }
+    onUpload(acceptedFiles)
+  }
+
+  async function onDrop(acceptedFiles: File[], rejectedFiles: FileRejection[]) {
+    setErrors([])
+    try {
+      await processFiles(acceptedFiles, rejectedFiles)
+    } catch (error: unknown) {
+      handleError(sanitizeError(error))
+    }
+  }
+
+  return (acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
+    // eslint-disable-next-line no-void
+    void onDrop(acceptedFiles, rejectedFiles)
+  }
+}
+
+export type UploadZoneElems = keyof typeof theme.uploadZone
+
+export function getUploadZoneTheme(props: { state: UploadZoneState; theme: DefaultTheme }, elem: UploadZoneElems) {
+  return props.theme.uploadZone[elem][props.state]
+}
+
+class UploadErrorTooManyFiles extends Error {
+  public readonly nFiles: number
+
+  constructor(nFiles: number) {
+    super(`when uploading: one file is expected, but got ${nFiles}`)
+    this.nFiles = nFiles
+  }
+}
+
+class UploadErrorUnknown extends Error {
+  constructor() {
+    super(`when uploading: unknown error`)
+  }
+}


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/740
Resolves: https://github.com/nextstrain/nextclade/issues/342

This allows upload box to accept multiple input fasta sequences.

If multiple files is dropped or provided using the file dialog, the contents is joined with newlines before passing to the algorithm. The order of files in the resulting joined string cannot be guaranteed, due to unknown order of files, which is browser- and OS-dependent.