### PR TITLE
feat(cli): support compressed fasta files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +348,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -814,13 +838,11 @@ checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -1140,6 +1162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06754c4acf47d49c727d5665ca9fb828851cda315ed3bd51edd148ef78a8772"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1334,6 +1376,7 @@ dependencies = [
  "auto_ops",
  "bio",
  "bio-types",
+ "bzip2",
  "chrono",
  "clap 3.1.18",
  "clap-verbosity-flag",
@@ -1345,6 +1388,7 @@ dependencies = [
  "ctor",
  "env_logger",
  "eyre",
+ "flate2",
  "getrandom",
  "indexmap",
  "itertools",
@@ -1363,8 +1407,12 @@ dependencies = [
  "rstest_reuse",
  "serde",
  "serde_json",
+ "strum 0.24.0",
+ "strum_macros 0.24.0",
  "traversal",
  "validator",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -1679,6 +1727,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -2957,7 +3011,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -17,7 +17,6 @@ assert2 = "0.3.6"
 auto_ops = "0.3.0"
 bio = "0.41.0"
 bio-types = "0.12.1"
-bzip2 = "0.4.3"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std", "wasmbind"] }
 clap = { version = "3.1.8", features = ["derive"] }
 clap-verbosity-flag = "1.0.0"
@@ -48,11 +47,14 @@ strum = "0.24.0"
 strum_macros = "0.24.0"
 traversal = "0.1.2"
 validator = { version = "0.14.0", features = ["derive"] }
-xz2 = "0.1.7"
-zstd = { version = "0.11.2+zstd.1.5.2", features = ["zstdmt"] }
 
 [target.'cfg(all(target_family = "linux", target_arch = "x86_64"))'.dependencies]
 mimalloc = { version = "0.1.28", default-features = false, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bzip2 = "0.4.3"
+xz2 = "0.1.7"
+zstd = { version = "0.11.2+zstd.1.5.2", features = ["zstdmt"] }
 
 [dev-dependencies]
 assert2 = "0.3.6"

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -17,6 +17,7 @@ assert2 = "0.3.6"
 auto_ops = "0.3.0"
 bio = "0.41.0"
 bio-types = "0.12.1"
+bzip2 = "0.4.3"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std", "wasmbind"] }
 clap = { version = "3.1.8", features = ["derive"] }
 clap-verbosity-flag = "1.0.0"
@@ -27,6 +28,7 @@ csv = "1.1.6"
 ctor = "0.1.22"
 env_logger = "0.9.0"
 eyre = "0.6.8"
+flate2 = "1.0.24"
 getrandom = "0.2.6"
 indexmap = { version = "1.8.1", features = ["serde"] }
 itertools = "0.10.3"
@@ -42,9 +44,12 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order", "indexmap", "unbounded_depth"] }
+strum = "0.24.0"
+strum_macros = "0.24.0"
 traversal = "0.1.2"
 validator = { version = "0.14.0", features = ["derive"] }
-
+xz2 = "0.1.7"
+zstd = { version = "0.11.2+zstd.1.5.2", features = ["zstdmt"] }
 
 [target.'cfg(all(target_family = "linux", target_arch = "x86_64"))'.dependencies]
 mimalloc = { version = "0.1.28", default-features = false, optional = true }

--- a/packages_rs/nextclade/src/io/decompression.rs
+++ b/packages_rs/nextclade/src/io/decompression.rs
@@ -61,7 +61,7 @@ pub fn guess_compression_from_filepath(filepath: impl AsRef<Path>) -> Result<(Co
 
   let ext = extension(filepath)?;
 
-  let compression_type: CompressionType = match ext.as_str() {
+  let compression_type: CompressionType = match ext.to_lowercase().as_str() {
     "gz" => CompressionType::Gzip,
     "bz2" => CompressionType::Bzip2,
     "xz" => CompressionType::Xz,

--- a/packages_rs/nextclade/src/io/decompression.rs
+++ b/packages_rs/nextclade/src/io/decompression.rs
@@ -1,0 +1,96 @@
+use crate::io::fs::extension;
+use crate::utils::error::report_to_string;
+use bzip2::read::MultiBzDecoder;
+use color_eyre::{Help, SectionExt};
+use eyre::{eyre, Report, WrapErr};
+use flate2::read::GzDecoder;
+use log::debug;
+use std::io::{ErrorKind, Read};
+use std::path::Path;
+use xz2::read::XzDecoder;
+use zstd::Decoder as ZstdDecoder;
+
+#[derive(strum_macros::Display, Clone)]
+pub enum CompressionType {
+  Gzip,
+  Bzip2,
+  Xz,
+  Zstandard,
+  None,
+}
+
+pub struct Decompressor<'r> {
+  decompressor: Box<dyn Read + 'r>,
+  compression_type: CompressionType,
+  filepath: Option<String>,
+}
+
+impl<'r> Decompressor<'r> {
+  pub fn new<R: 'r + Read>(reader: R, compression_type: &CompressionType) -> Result<Self, Report> {
+    let decompressor: Box<dyn Read> = match compression_type {
+      CompressionType::Gzip => Box::new(GzDecoder::new(reader)),
+      CompressionType::Bzip2 => Box::new(MultiBzDecoder::new(reader)),
+      CompressionType::Xz => Box::new(XzDecoder::new(reader)),
+      CompressionType::Zstandard => Box::new(ZstdDecoder::new(reader)?),
+      CompressionType::None => Box::new(reader),
+    };
+
+    Ok(Self {
+      decompressor,
+      compression_type: compression_type.clone(),
+      filepath: None,
+    })
+  }
+
+  pub fn from_str_and_path(content: &'r str, filepath: impl AsRef<Path>) -> Result<Self, Report> {
+    let filepath = filepath.as_ref();
+    let reader = content.as_bytes();
+    let (compression_type, ext) = guess_compression_from_filepath(filepath)?;
+    Self::new(reader, &compression_type)
+  }
+
+  pub fn from_path<R: 'static + Read>(reader: R, filepath: impl AsRef<Path>) -> Result<Self, Report> {
+    let filepath = filepath.as_ref();
+    let (compression_type, ext) = guess_compression_from_filepath(filepath)?;
+    Self::new(reader, &compression_type)
+  }
+}
+
+pub fn guess_compression_from_filepath(filepath: impl AsRef<Path>) -> Result<(CompressionType, String), Report> {
+  let filepath = filepath.as_ref();
+
+  let ext = extension(filepath)?;
+
+  let compression_type: CompressionType = match ext.as_str() {
+    "gz" => CompressionType::Gzip,
+    "bz2" => CompressionType::Bzip2,
+    "xz" => CompressionType::Xz,
+    "zst" => CompressionType::Zstandard,
+    _ => CompressionType::None,
+  };
+
+  debug!(
+    "When processing '{filepath:#?}': Decompressor detected file extension '{ext}'. \
+    It will be using decompression algorithm: '{compression_type}'"
+  );
+
+  Ok((compression_type, ext))
+}
+
+impl<'r> Read for Decompressor<'r> {
+  fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    self
+      .decompressor
+      .read(buf)
+      .wrap_err_with(|| "While decompressing file")
+      .with_section(|| {
+        self
+          .filepath
+          .clone()
+          .unwrap_or_else(|| "None".to_owned())
+          .header("Filename")
+      })
+      .with_section(|| self.compression_type.clone().header("Decompressor"))
+      .map_err(|report| std::io::Error::new(ErrorKind::Other, report_to_string(&report)))
+  }
+}

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -41,6 +41,18 @@ pub fn basename(filepath: impl AsRef<Path>) -> Result<String, Report> {
   )
 }
 
+pub fn extension(filepath: impl AsRef<Path>) -> Result<String, Report> {
+  let filepath = filepath.as_ref();
+  Ok(
+    filepath
+      .extension()
+      .ok_or_else(|| eyre!("Cannot get extension of path {filepath:#?}"))?
+      .to_str()
+      .ok_or_else(|| eyre!("Cannot convert extension to string when getting extension of path {filepath:#?}"))?
+      .to_owned(),
+  )
+}
+
 /// Reads entire file into a string.
 /// Compared to `std::fs::read_to_string` uses buffered reader
 pub fn read_file_to_string(filepath: impl AsRef<Path>) -> Result<String, Report> {

--- a/packages_rs/nextclade/src/io/mod.rs
+++ b/packages_rs/nextclade/src/io/mod.rs
@@ -1,5 +1,6 @@
 pub mod aa;
 pub mod csv;
+pub mod decompression;
 pub mod errors_csv;
 pub mod fasta;
 pub mod fs;


### PR DESCRIPTION
This allows to provide compressed fasta files to Nextalign And Nextclade CLI.

If the path in `--input-fasta` contains one of the well-known extensions for compressed files, then it will be decompressed on the fly.

The following compression types are supported:
 - gzip (.gz)
 - bzip2 (.bz2)
 - lzma/lzma2 (.xz)
 - zstandard (.zst)

All other files are passed to fasta parser as is.


