### PR TITLE
DO NOT MERGE: don't award matches with unknown state the full match score

### DIFF
--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -115,7 +115,11 @@ pub fn score_matrix<T: Letter<T>>(
         if qpos - 1 >= stripes[ri - 1].begin && qpos - 1 < stripes[ri - 1].end {
           // ^ If stripes allow to move up diagonally to upper left
           if T::lookup_match_score(qry_seq[qpos - 1], ref_seq[ri - 1]) > 0 {
-            score = scores[(ri - 1, qpos - 1)] + params.score_match;
+            if qry_seq[qpos - 1].is_unknown() || ref_seq[ri - 1].is_unknown() {
+              score = scores[(ri - 1, qpos - 1)];
+            } else {
+              score = scores[(ri - 1, qpos - 1)] + params.score_match;
+            }
           } else {
             score = scores[(ri - 1, qpos - 1)] - params.penalty_mismatch;
           };

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -116,7 +116,7 @@ pub fn score_matrix<T: Letter<T>>(
           // ^ If stripes allow to move up diagonally to upper left
           if T::lookup_match_score(qry_seq[qpos - 1], ref_seq[ri - 1]) > 0 {
             if qry_seq[qpos - 1].is_unknown() || ref_seq[ri - 1].is_unknown() {
-              score = scores[(ri - 1, qpos - 1)];
+              score = scores[(ri - 1, qpos - 1)] + params.score_match - 1;
             } else {
               score = scores[(ri - 1, qpos - 1)] + params.score_match;
             }


### PR DESCRIPTION
We currently award a match `score_match` (3) and penalize a mismatch with `mismatch_penalty` (1). Ambiguous characters (`N`) match every other character and are thus always award the full score. In some situations, this is undesirable. Of the following, the second one would be the more sensible alignment (pair `C` with `C` and treat `N` as insertion):
```
AT-CCTCC
ATCCNTCC
```
```
ATCC-TCC
ATCCNTCC
```
But preferring non-ambig matches can also have unexpected consequences. we might have additional indels when the score difference is too high. if we wanted to change this behavior, it is thus best to keep the ambiguous match score as close to the full match score as possible. 

On a related note, our match/mismatch parametrization is not completely redundant because they are compared to the terminal gaps are not penalized and thus implicitly score 0. 

