### PR TITLE
fix(cli): correctly find base name in cases like .fasta.gz

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::LevelFilter;
 use nextclade::align::params::AlignPairwiseParamsOptional;
-use nextclade::io::fs::basename;
+use nextclade::io::fs::{basename, extension};
 use nextclade::utils::global_init::setup_logger;
 use nextclade::{getenv, make_error};
 use std::fmt::Debug;
@@ -510,7 +510,13 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
   // while taking care to preserve values of any individual `--output-*` flags,
   // as well as to honor restrictions put by the `--output-selection` flag, if provided.
   if let Some(output_all) = output_all {
-    let output_basename = output_basename.get_or_insert(basename(&input_fasta)?);
+    let mut base_name = basename(&input_fasta)?;
+    if extension(&base_name)?.to_lowercase() == "fasta" {
+      // Additionally handle cases like `.fasta.gz`
+      base_name = basename(&base_name)?;
+    }
+
+    let output_basename = output_basename.get_or_insert(base_name);
     let default_output_file_path = output_all.join(&output_basename);
 
     // If `--output-selection` is empty or contains `all`, then fill it with all possible variants

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -35,8 +35,7 @@ pub fn basename(filepath: impl AsRef<Path>) -> Result<String, Report> {
 
   Ok(
     filepath
-      .with_extension("")
-      .file_name()
+      .file_stem()
       .ok_or_else(|| eyre!("Cannot get filename of path {filepath:#?}"))?
       .to_str()
       .ok_or_else(|| eyre!("Cannot get basename of path {filepath:#?}"))?


### PR DESCRIPTION
This allows to strip not only `.fasta`, but also `.fasta.gz` and similar, when deducing file base name which is used for creating output file names.

