### PR TITLE
fix(cli): prevent writing duplicate csv row

### DIFF
--- a/packages_rs/nextclade/src/io/csv.rs
+++ b/packages_rs/nextclade/src/io/csv.rs
@@ -100,8 +100,7 @@ impl CsvVecFileWriter {
     ensure_dir(&filepath)?;
     let file = File::create(&filepath).wrap_err_with(|| format!("When creating file: {filepath:?}"))?;
     let buf_file = BufWriter::with_capacity(32 * 1024, file);
-    let mut writer = CsvVecWriter::new(buf_file, delimiter, headers)?;
-    writer.write(headers)?;
+    let writer = CsvVecWriter::new(buf_file, delimiter, headers)?;
     Ok(Self {
       filepath: filepath.to_owned(),
       headers: headers.to_owned(),


### PR DESCRIPTION
Some of the CLI CSV and TSV files had two header rows due to an extra function call

