### PR TITLE
fix(cli): don't treat a lack of extension as error

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -1,5 +1,5 @@
 use crate::io::http_client::ProxyConfig;
-use clap::{AppSettings, ArgEnum, ArgGroup, CommandFactory, Parser, Subcommand, ValueHint};
+use clap::{AppSettings, ArgEnum, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use clap_complete_fig::Fig;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
@@ -511,7 +511,7 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
   // as well as to honor restrictions put by the `--output-selection` flag, if provided.
   if let Some(output_all) = output_all {
     let mut base_name = basename(&input_fasta)?;
-    if extension(&base_name)?.to_lowercase() == "fasta" {
+    if extension(&base_name).map(|ext| ext.to_lowercase()) == Some("fasta".to_owned()) {
       // Additionally handle cases like `.fasta.gz`
       base_name = basename(&base_name)?;
     }

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -1,4 +1,5 @@
 use eyre::{eyre, Report, WrapErr};
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -43,16 +44,9 @@ pub fn basename(filepath: impl AsRef<Path>) -> Result<String, Report> {
   )
 }
 
-pub fn extension(filepath: impl AsRef<Path>) -> Result<String, Report> {
+pub fn extension(filepath: impl AsRef<Path>) -> Option<String> {
   let filepath = filepath.as_ref();
-  Ok(
-    filepath
-      .extension()
-      .ok_or_else(|| eyre!("Cannot get extension of path {filepath:#?}"))?
-      .to_str()
-      .ok_or_else(|| eyre!("Cannot convert extension to string when getting extension of path {filepath:#?}"))?
-      .to_owned(),
-  )
+  filepath.extension().map(OsStr::to_str).flatten().map(str::to_owned)
 }
 
 /// Reads entire file into a string.


### PR DESCRIPTION
After transparent compression was introduced, file extension extraction function `extension()` was implemented such that it fails when there is no file extension.

When gradually removing extensions from compressed `files like .fasta.gz` there are 2 calls tomade `extension()`, which correctly detect 2 extensions. However, it was failing on plain `.fasta` files, because after a single extension was removed there wasn't any more.

Here I chose to treat lack of extension as not an error. `extension()` now returns an `Option<String>`, and when there's no extension it returns `None`. The calling code is updated accordingly.

If there's a situation when we need to fail on lack of file extension, then the `Option` can be converted to an error in the calling code or we might introduce another version of this function.

