### PR TITLE
feat(cli): make input fasta arg positional, allow multiple files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ name = "nextclade"
 version = "2.0.0-alpha.12"
 dependencies = [
  "assert2",
+ "atty",
  "auto_ops",
  "bio",
  "bio-types",

--- a/packages_rs/nextclade-cli/src/cli/common.rs
+++ b/packages_rs/nextclade-cli/src/cli/common.rs
@@ -1,0 +1,17 @@
+use nextclade::io::fs::{basename_maybe, extension};
+use std::path::PathBuf;
+
+pub fn get_fasta_basename(input_fasta: &[PathBuf]) -> Option<String> {
+  match input_fasta {
+    [single_fasta] => {
+      let base_name = basename_maybe(single_fasta)?;
+      if extension(&base_name).map(|ext| ext.to_lowercase()) == Some("fasta".to_owned()) {
+        // Additionally handle cases like `.fasta.gz`
+        basename_maybe(&base_name)
+      } else {
+        Some(base_name)
+      }
+    }
+    _ => None,
+  }
+}

--- a/packages_rs/nextclade-cli/src/cli/mod.rs
+++ b/packages_rs/nextclade-cli/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod common;
 pub mod nextalign_cli;
 pub mod nextalign_loop;
 pub mod nextalign_ordered_writer;

--- a/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
@@ -60,7 +60,7 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
     let (result_sender, result_receiver) = crossbeam_channel::bounded::<NextalignRecord>(CHANNEL_SIZE);
 
     s.spawn(|_| {
-      let mut reader = FastaReader::from_path(&input_fasta).unwrap();
+      let mut reader = FastaReader::from_paths(&input_fasta).unwrap();
       loop {
         let mut record = FastaRecord::default();
         reader.read(&mut record).unwrap();

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -1,3 +1,4 @@
+use crate::cli::common::get_fasta_basename;
 use crate::io::http_client::ProxyConfig;
 use clap::{AppSettings, ArgEnum, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Generator, Shell};
@@ -8,7 +9,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::LevelFilter;
 use nextclade::align::params::AlignPairwiseParamsOptional;
-use nextclade::io::fs::{basename, extension};
+use nextclade::io::fs::{basename_maybe, extension};
 use nextclade::utils::global_init::setup_logger;
 use nextclade::{getenv, make_error};
 use std::fmt::Debug;
@@ -210,9 +211,8 @@ pub enum NextcladeOutputSelection {
 #[derive(Parser, Debug)]
 pub struct NextcladeRunArgs {
   /// Path to a FASTA file with input sequences
-  #[clap(long, short = 'i', visible_alias("sequences"))]
   #[clap(value_hint = ValueHint::FilePath)]
-  pub input_fasta: PathBuf,
+  pub input_fasta: Vec<PathBuf>,
 
   /// Path to a directory containing a dataset.
   ///
@@ -492,17 +492,17 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
   let NextcladeRunArgs {
     input_fasta,
     output_all,
-    ref mut output_basename,
-    ref mut output_ndjson,
-    ref mut output_json,
-    ref mut output_csv,
-    ref mut output_tsv,
-    ref mut output_tree,
-    ref mut output_errors,
-    ref mut output_fasta,
-    ref mut output_insertions,
-    ref mut output_translations,
-    ref mut output_selection,
+    output_basename,
+    output_ndjson,
+    output_json,
+    output_csv,
+    output_tsv,
+    output_tree,
+    output_errors,
+    output_fasta,
+    output_insertions,
+    output_translations,
+    output_selection,
     ..
   } = run_args;
 
@@ -510,13 +510,10 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
   // while taking care to preserve values of any individual `--output-*` flags,
   // as well as to honor restrictions put by the `--output-selection` flag, if provided.
   if let Some(output_all) = output_all {
-    let mut base_name = basename(&input_fasta)?;
-    if extension(&base_name).map(|ext| ext.to_lowercase()) == Some("fasta".to_owned()) {
-      // Additionally handle cases like `.fasta.gz`
-      base_name = basename(&base_name)?;
-    }
+    let output_basename = output_basename
+      .clone()
+      .unwrap_or_else(|| get_fasta_basename(input_fasta).unwrap_or_else(|| "nextclade".to_owned()));
 
-    let output_basename = output_basename.get_or_insert(base_name);
     let default_output_file_path = output_all.join(&output_basename);
 
     // If `--output-selection` is empty or contains `all`, then fill it with all possible variants

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -110,7 +110,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
     let outputs = &mut outputs;
 
     s.spawn(|_| {
-      let mut reader = FastaReader::from_path(&input_fasta).unwrap();
+      let mut reader = FastaReader::from_paths(&input_fasta).unwrap();
       loop {
         let mut record = FastaRecord::default();
         reader.read(&mut record).unwrap();

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -53,6 +53,7 @@ validator = { version = "0.14.0", features = ["derive"] }
 mimalloc = { version = "0.1.28", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+atty = "0.2.14"
 bzip2 = "0.4.3"
 xz2 = "0.1.7"
 zstd = { version = "0.11.2+zstd.1.5.2", features = ["zstdmt"] }

--- a/packages_rs/nextclade/src/io/concat.rs
+++ b/packages_rs/nextclade/src/io/concat.rs
@@ -1,0 +1,75 @@
+/// concat.rs
+///
+/// Taken with modifications from
+/// https://github.com/frangio/concat.rs/blob/d416d3b3c03ba18c0541b7fa63e6e89f3c43e0fe/src/lib.rs
+///
+/// Credits: Francisco (@frangio)
+///
+/// Provides the Concat reader adaptor, which wraps around an iterator of readers and exposes its
+/// items' contents sequentially. Thus, the contents read from a Concat instance will be the
+/// concatenation of the items' contents.
+use std::io::{Read, Result};
+
+pub fn concat<I>(iter: I) -> Concat<I>
+where
+  I: Iterator,
+  <I as Iterator>::Item: Read,
+{
+  Concat::<I>::from(iter)
+}
+
+pub struct Concat<I>
+where
+  I: Iterator,
+  <I as Iterator>::Item: Read,
+{
+  iter: I,
+  curr: Option<<I as Iterator>::Item>,
+}
+
+impl<I> Concat<I>
+where
+  I: Iterator,
+  <I as Iterator>::Item: Read,
+{
+  /// Returns a reference to the item last read, or None if the iterator has been exhausted.
+  ///
+  /// This is useful for error handling and reporting: if a read operation fails, the reference
+  /// returned will point to the item which caused the the error.
+  pub fn current(&self) -> Option<&<I as Iterator>::Item> {
+    self.curr.as_ref()
+  }
+}
+
+impl<I> From<I> for Concat<I>
+where
+  I: Iterator,
+  <I as Iterator>::Item: Read,
+{
+  fn from(mut iter: I) -> Concat<I> {
+    let curr = iter.next();
+
+    Concat { iter, curr }
+  }
+}
+
+impl<I> Read for Concat<I>
+where
+  I: Iterator,
+  <I as Iterator>::Item: Read,
+{
+  fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+    let n = match self.curr {
+      None => 0,
+      Some(ref mut r) => r.read(buf)?,
+    };
+
+    if n > 0 || buf.is_empty() || self.curr.is_none() {
+      Ok(n)
+    } else {
+      // The current reader reached the end so we have to advance the iterator and try again.
+      self.curr = self.iter.next();
+      self.read(buf)
+    }
+  }
+}

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -6,11 +6,11 @@ use crate::io::gene_map::GeneMap;
 use crate::translate::translate_genes::Translation;
 use crate::{make_error, make_internal_error};
 use eyre::{Report, WrapErr};
-use log::trace;
+use log::{info, trace};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Read};
+use std::io::{stdin, BufRead, BufReader, BufWriter, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tinytemplate::TinyTemplate;
@@ -75,6 +75,11 @@ impl<'a> FastaReader<'a> {
 
   /// Reads multiple files sequentially given a set of paths
   pub fn from_paths<P: AsRef<Path>>(filepaths: &[P]) -> Result<Self, Report> {
+    if filepaths.is_empty() {
+      info!("Reading input fasta from standard input");
+      return Ok(Self::new(Box::new(BufReader::new(stdin()))));
+    }
+
     let readers: Vec<Box<dyn BufRead + 'a>> = filepaths
       .iter()
       .map(|filepath| -> Result<Box<dyn BufRead + 'a>, Report> {

--- a/packages_rs/nextclade/src/io/file.rs
+++ b/packages_rs/nextclade/src/io/file.rs
@@ -1,0 +1,23 @@
+use crate::io::fs::ensure_dir;
+use eyre::{Report, WrapErr};
+use log::info;
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::{stdout, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+pub fn create_file(filepath: impl AsRef<Path>) -> Result<Box<dyn Write + Sync + Send>, Report> {
+  let filepath = filepath.as_ref();
+
+  let file: Box<dyn Write + Sync + Send> = if filepath == PathBuf::from("-") {
+    info!("File path is '-', writing to standard output");
+    Box::new(stdout())
+  } else {
+    ensure_dir(&filepath)?;
+    Box::new(File::create(&filepath).wrap_err_with(|| format!("When creating file: {filepath:?}"))?)
+  };
+
+  let writer = BufWriter::with_capacity(32 * 1024, file);
+
+  Ok(Box::new(writer))
+}

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -31,17 +31,8 @@ pub fn ensure_dir(filepath: impl AsRef<Path>) -> Result<(), Report> {
   .wrap_err_with(|| format!("When ensuring parent directory for '{filepath:#?}'"))
 }
 
-pub fn basename(filepath: impl AsRef<Path>) -> Result<String, Report> {
-  let filepath = filepath.as_ref();
-
-  Ok(
-    filepath
-      .file_stem()
-      .ok_or_else(|| eyre!("Cannot get filename of path {filepath:#?}"))?
-      .to_str()
-      .ok_or_else(|| eyre!("Cannot get basename of path {filepath:#?}"))?
-      .to_owned(),
-  )
+pub fn basename_maybe(filepath: impl AsRef<Path>) -> Option<String> {
+  filepath.as_ref().file_stem()?.to_str()?.to_owned().into()
 }
 
 pub fn extension(filepath: impl AsRef<Path>) -> Option<String> {

--- a/packages_rs/nextclade/src/io/json.rs
+++ b/packages_rs/nextclade/src/io/json.rs
@@ -1,8 +1,6 @@
-use crate::io::fs::ensure_dir;
+use crate::io::file::create_file;
 use eyre::{Report, WrapErr};
 use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::BufWriter;
 use std::path::Path;
 
 pub fn json_parse<T: for<'de> Deserialize<'de>>(s: &str) -> Result<T, Report> {
@@ -15,14 +13,7 @@ pub fn json_stringify<T: Serialize>(obj: &T) -> Result<String, Report> {
 }
 
 pub fn json_write<T: Serialize>(filepath: impl AsRef<Path>, obj: &T) -> Result<(), Report> {
-  const BUF_SIZE: usize = 2 * 1024 * 1024;
-
-  let filepath = filepath.as_ref().to_owned();
-
-  ensure_dir(&filepath)?;
-
-  let file = File::create(&filepath).wrap_err_with(|| format!("When writing file: {filepath:#?}"))?;
-  let buf_writer = BufWriter::with_capacity(BUF_SIZE, file);
-
-  serde_json::to_writer_pretty(buf_writer, &obj).wrap_err("When writing JSON to file: {filepath:#?}")
+  let filepath = filepath.as_ref();
+  let file = create_file(filepath)?;
+  serde_json::to_writer_pretty(file, &obj).wrap_err("When writing JSON to file: {filepath:#?}")
 }

--- a/packages_rs/nextclade/src/io/mod.rs
+++ b/packages_rs/nextclade/src/io/mod.rs
@@ -1,4 +1,5 @@
 pub mod aa;
+pub mod concat;
 pub mod csv;
 pub mod decompression;
 pub mod errors_csv;

--- a/packages_rs/nextclade/src/io/mod.rs
+++ b/packages_rs/nextclade/src/io/mod.rs
@@ -4,6 +4,7 @@ pub mod csv;
 pub mod decompression;
 pub mod errors_csv;
 pub mod fasta;
+pub mod file;
 pub mod fs;
 pub mod gene_map;
 pub mod gff3;

--- a/packages_rs/nextclade/src/io/ndjson.rs
+++ b/packages_rs/nextclade/src/io/ndjson.rs
@@ -1,15 +1,14 @@
-use crate::io::fs::ensure_dir;
+use crate::io::file::create_file;
 use eyre::{Report, WrapErr};
 use std::fmt::Debug;
-use std::fs::File;
-use std::io::{BufReader, BufWriter, LineWriter, Write};
+use std::io::{LineWriter, Write};
 use std::path::{Path, PathBuf};
 
-pub struct NdjsonWriter<W: Write + Debug + Send + Sync> {
+pub struct NdjsonWriter<W: Write + Send + Sync> {
   line_writer: LineWriter<W>,
 }
 
-impl<W: 'static + Write + Debug + Send + Sync> NdjsonWriter<W> {
+impl<W: Write + Send + Sync> NdjsonWriter<W> {
   pub fn new(writer: W) -> Result<Self, Report> {
     let line_writer = LineWriter::new(writer);
     Ok(Self { line_writer })
@@ -20,33 +19,20 @@ impl<W: 'static + Write + Debug + Send + Sync> NdjsonWriter<W> {
     self.line_writer.write_all(b"\n")?;
     Ok(())
   }
-
-  pub fn into_inner(self) -> Result<W, Report> {
-    let inner = self.line_writer.into_inner()?;
-    Ok(inner)
-  }
 }
 
 pub struct NdjsonFileWriter {
   filepath: PathBuf,
-  ndjson_writer: NdjsonWriter<BufWriter<File>>,
+  ndjson_writer: NdjsonWriter<Box<dyn Write + Sync + Send>>,
 }
 
 impl NdjsonFileWriter {
   pub fn new(filepath: impl AsRef<Path>) -> Result<Self, Report> {
-    const BUF_SIZE: usize = 2 * 1024 * 1024;
-
-    let filepath = filepath.as_ref().to_owned();
-
-    ensure_dir(&filepath)?;
-
-    let file = File::create(&filepath).wrap_err_with(|| format!("When writing file: {filepath:#?}"))?;
-    let buf_writer = BufWriter::with_capacity(BUF_SIZE, file);
-
-    let line_writer = NdjsonWriter::new(buf_writer)?;
-
+    let filepath = filepath.as_ref();
+    let file = create_file(filepath)?;
+    let line_writer = NdjsonWriter::new(file)?;
     Ok(Self {
-      filepath,
+      filepath: filepath.to_owned(),
       ndjson_writer: line_writer,
     })
   }

--- a/packages_rs/nextclade/src/io/results_json.rs
+++ b/packages_rs/nextclade/src/io/results_json.rs
@@ -89,9 +89,12 @@ pub fn results_to_json_string(
 }
 
 pub fn results_to_ndjson_string(outputs: &[NextcladeOutputs]) -> Result<String, Report> {
-  let mut writer = NdjsonWriter::new(Vec::<u8>::new())?;
-  for output in outputs {
-    writer.write(output)?;
+  let mut buf = Vec::<u8>::new();
+  {
+    let mut writer = NdjsonWriter::new(&mut buf)?;
+    for output in outputs {
+      writer.write(output)?;
+    }
   }
-  Ok(String::from_utf8(writer.into_inner()?)?)
+  Ok(String::from_utf8(buf)?)
 }


### PR DESCRIPTION
 - [x] Removes `--input-fasta` flag in favor of providing input sequence file names as positional arguments
 - [x] Multiple files can be provided by passing multiple positional arguments
 - [x] Files can be plain fasta or compressed
 - [x] Different files can have different compression
 - [x] Read from stdin if no positional arguments provided
 - [x] Warn if no positional arguments provided and stdin is a TTY
 - [x] Output to stdout if filename is `-`


One quirk is that now if `--output-basename` is not provided, and input has multiple fasta files it's unclear which one to use for finding basename of output files. I opted for:
 - taking the name of the file if only one provided, just like before
 - hardcoded string "nextclade"/"nextalign" if there are multiple input files or no files (stdin)


Examples:

```
# Single file
nextclade run -D dataset/ -O out/ 1.fasta

# Multiple files
nextclade run -D dataset/ -O out/ 1.fasta 2.fasta 3.fasta

# Multiple files with different compression
nextclade run -D dataset/ -O out/ 1.fasta 2.fasta.gz 3.fasta.zst

# Wildcard (expanded by shell)
nextclade run -D dataset/ -O out/ *.fasta

# Wildcard (expanded by shell), including compressed files
nextclade run -D dataset/ -O out/ *.fasta*

# Reading from standard input (only plain, uncompressed fasta)
cat 1.fasta 2.fasta | nextclade run -D dataset/ -O out/

# Reading from standard input, compressed (external decompression)
xzcat 1.fasta.xz 2.fasta.xz | nextclade run -D dataset/ -O out/

# Output to stdout if filename is "-"
nextclade run -D dataset/ --output-tsv=- 1.fasta | process_nextclade_tsv_further

# 3-stage Pipeline
xzcat *.fasta.xz | 
nextclade run -D dataset/ --output-tsv=- 1.fasta | 
process_nextclade_tsv_further

# Nextalign works as well
xzcat *.fasta.xz | 
nextalign run -r ref.fasta -m genemap.gff -o - |
process_aligned_fasta
```
