### PR TITLE
feat(cli): make CLI log lines more compact

### DIFF
--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -31,6 +31,10 @@ pub fn ensure_dir(filepath: impl AsRef<Path>) -> Result<(), Report> {
   .wrap_err_with(|| format!("When ensuring parent directory for '{filepath:#?}'"))
 }
 
+pub fn filename_maybe(filepath: impl AsRef<Path>) -> Option<String> {
+  filepath.as_ref().file_name()?.to_str()?.to_owned().into()
+}
+
 pub fn basename(filepath: impl AsRef<Path>) -> Result<String, Report> {
   let filepath = filepath.as_ref();
 

--- a/packages_rs/nextclade/src/utils/global_init.rs
+++ b/packages_rs/nextclade/src/utils/global_init.rs
@@ -1,49 +1,53 @@
+use crate::io::fs::filename_maybe;
+use crate::utils::datetime::{date_format_precise, date_now};
+use env_logger::Env;
+use log::{Level, LevelFilter, Record};
+use owo_colors::OwoColorize;
 use std::env;
 use std::io::Write;
 
-use crate::utils::datetime::{date_format_precise, date_now};
-use color_eyre::owo_colors::OwoColorize;
-use env_logger::Env;
-use log::{Level, LevelFilter, Record};
-
 fn get_current_exe_filename() -> Option<String> {
-  env::current_exe().ok()?.file_name()?.to_str()?.to_owned().into()
+  env::current_exe().ok().and_then(filename_maybe)
 }
 
-fn get_file_line(record: &Record<'_>) -> String {
-  match (record.file(), record.line()) {
-    (Some(file), None) => file.to_owned(),
-    (Some(file), Some(line)) => format!("{:}:{:}", file, line),
+fn get_file_line(record: &Record) -> String {
+  let file = record.file().and_then(filename_maybe);
+  match (file, record.line()) {
+    (Some(file), None) => format!("{file}:",),
+    (Some(file), Some(line)) => format!("{file}:{line:}:"),
     _ => "".to_owned(),
   }
+  .dimmed()
+  .to_string()
 }
 
-fn log_level_str(record: &Record<'_>) -> String {
+fn log_level_str(record: &Record) -> String {
   let mut level_str = record.level().to_string();
-  level_str.truncate(5);
-  format!("{:<5}", level_str)
+  level_str.truncate(1);
+  level_str
 }
 
-fn color_log_level(record: &Record<'_>) -> String {
-  match record.level() {
+fn color_log_level(record: &Record) -> String {
+  let level_str = match record.level() {
     Level::Error => log_level_str(record).red().to_string(),
     Level::Warn => log_level_str(record).yellow().to_string(),
-    Level::Info => log_level_str(record).cyan().to_string(),
-    Level::Debug => log_level_str(record),
+    Level::Info => log_level_str(record).cyan().dimmed().to_string(),
+    Level::Debug => log_level_str(record).green().dimmed().to_string(),
     Level::Trace => log_level_str(record).dimmed().to_string(),
-  }
+  };
+  format!("{:}{level_str}{:}", "[".dimmed(), "]".dimmed())
 }
 
 pub fn setup_logger(filter_level: LevelFilter) {
   env_logger::Builder::from_env(Env::default().default_filter_or("warn"))
     .filter_level(filter_level)
     .format(|buf, record| {
-      let current_exe = get_current_exe_filename().unwrap_or_default();
+      let current_exe = get_current_exe_filename().unwrap_or_default().dimmed().to_string();
       let file_line = get_file_line(record);
       let level = color_log_level(record);
-      let date = date_format_precise(&date_now());
+      let date = date_format_precise(&date_now()).dimmed().to_string();
       let args = record.args();
-      writeln!(buf, "[{date}][{current_exe:}][{level:<5}] {file_line:}: {args}")?;
+      writeln!(buf, "{date} {level:} {file_line:} {args}")?;
       Ok(())
     })
     .init();


### PR DESCRIPTION
This makes the date, severity, file, line parts of the log messages shorter and dimmed, such that the actual messages are more pronounced and the log is less cluttered.

