### PR TITLE
feat(web): allow multiple input fasta and control over them

### DIFF
--- a/packages_rs/nextclade-web/src/components/Common/ButtonTransparent.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/ButtonTransparent.tsx
@@ -2,9 +2,9 @@ import { Button, ButtonProps } from 'reactstrap'
 import styled from 'styled-components'
 
 export interface ButtonTransparentProps extends ButtonProps {
-  height: string
+  height?: string
   width?: string
-  fontSize: string
+  fontSize?: string
 }
 
 export const ButtonTransparent = styled(Button)<ButtonTransparentProps>`

--- a/packages_rs/nextclade-web/src/components/FilePicker/FilePicker.tsx
+++ b/packages_rs/nextclade-web/src/components/FilePicker/FilePicker.tsx
@@ -45,6 +45,7 @@ const TabsContentStyled = styled(TabsContent)`
 `
 
 export interface FilePickerProps extends StrictOmit<HTMLProps<HTMLDivElement>, 'onInput' | 'onError' | 'as' | 'ref'> {
+  multiple?: boolean
   compact?: boolean
   title: string
   icon: ReactNode
@@ -54,12 +55,14 @@ export interface FilePickerProps extends StrictOmit<HTMLProps<HTMLDivElement>, '
   error?: string
   isInProgress?: boolean
   inputRef?: Ref<HTMLInputElement | null>
-  onInput(input: AlgorithmInput): void
-  onRemove(_0: unknown): void
+  onInput?(input: AlgorithmInput): void
+  onInputs?(inputs: AlgorithmInput[]): void
+  onRemove?(_0: unknown): void
   onError?(error: string): void
 }
 
 export function FilePicker({
+  multiple = false,
   compact,
   title,
   icon,
@@ -69,6 +72,7 @@ export function FilePicker({
   error,
   isInProgress,
   onInput,
+  onInputs,
   onRemove,
   onError,
   inputRef,
@@ -79,30 +83,42 @@ export function FilePicker({
 
   const onFiles = useCallback(
     (files: File[]) => {
-      onInput(new AlgorithmInputFile(files))
+      if (multiple) {
+        onInputs?.(files.map((file) => new AlgorithmInputFile(file)))
+      } else if (files.length > 0) {
+        onInput?.(new AlgorithmInputFile(files[0]))
+      }
     },
-    [onInput],
+    [multiple, onInput, onInputs],
   )
 
   const onUrl = useCallback(
     (url: string) => {
-      onInput(new AlgorithmInputUrl(url))
+      if (multiple) {
+        onInputs?.([new AlgorithmInputUrl(url)])
+      } else {
+        onInput?.(new AlgorithmInputUrl(url))
+      }
     },
-    [onInput],
+    [multiple, onInput, onInputs],
   )
 
   const onPaste = useCallback(
     (content: string) => {
-      onInput(new AlgorithmInputString(content))
+      if (multiple) {
+        onInputs?.([new AlgorithmInputString(content)])
+      } else {
+        onInput?.(new AlgorithmInputString(content))
+      }
     },
-    [onInput],
+    [multiple, onInput, onInputs],
   )
 
   // eslint-disable-next-line no-void
   void onError
 
   const clearAndRemove = useCallback(() => {
-    onRemove([])
+    onRemove?.([])
   }, [onRemove])
 
   const tabs = useMemo(
@@ -113,7 +129,9 @@ export function FilePicker({
         body: compact ? (
           <UploadBoxCompact onUpload={onFiles}>{icon}</UploadBoxCompact>
         ) : (
-          <UploadBox onUpload={onFiles}>{icon}</UploadBox>
+          <UploadBox onUpload={onFiles} multiple>
+            {icon}
+          </UploadBox>
         ),
       },
       {

--- a/packages_rs/nextclade-web/src/components/FilePicker/UploadBox.tsx
+++ b/packages_rs/nextclade-web/src/components/FilePicker/UploadBox.tsx
@@ -64,15 +64,16 @@ export const UploadZoneButton = styled(Button)`
   min-height: 50px;
 `
 
-export interface UploaderGenericProps {
+export interface UploadBoxProps {
   onUpload(files: File[]): void
+  multiple?: boolean
 }
 
-export function UploadBox({ onUpload, children, ...props }: PropsWithChildren<UploaderGenericProps>) {
+export function UploadBox({ onUpload, children, multiple = false, ...props }: PropsWithChildren<UploadBoxProps>) {
   const { t } = useTranslation()
   const { state, errors, hasErrors, getRootProps, getInputProps, isDragActive } = useUploadZone({
     onUpload,
-    multiple: true,
+    multiple,
   })
 
   if (hasErrors) {

--- a/packages_rs/nextclade-web/src/components/Main/MainInputFormSequencesCurrent.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/MainInputFormSequencesCurrent.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useMemo } from 'react'
+import { Button, Col, Container, Row } from 'reactstrap'
+import styled from 'styled-components'
+import { ImCross } from 'react-icons/im'
+import { rgba } from 'polished'
+
+import { AlgorithmInput } from 'src/algorithms/types'
+import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { useQuerySeqInputs } from 'src/state/inputs.state'
+
+const SequencesCurrentWrapper = styled(Container)`
+  border: 1px #ccc9 solid;
+  border-radius: 5px;
+`
+
+const InputFileInfoWrapper = styled.section`
+  box-shadow: ${(props) => `1px 1px 5px ${rgba(props.theme.black, 0.1)}`};
+  border: 1px #ccc9 solid;
+  border-radius: 5px;
+  margin: 0.5rem 0;
+  padding: 0.5rem 1rem;
+`
+
+export interface InputFileInfoProps {
+  input: AlgorithmInput
+  index: number
+}
+
+export function InputFileInfo({ input, index }: InputFileInfoProps) {
+  const { t } = useTranslationSafe()
+  const { removeQryInput } = useQuerySeqInputs()
+  const onRemoveClicked = useCallback(() => {
+    removeQryInput(index)
+  }, [index, removeQryInput])
+
+  return (
+    <InputFileInfoWrapper>
+      <Row noGutters className="d-flex">
+        <Col className="flex-grow-1">{input.description}</Col>
+        <ButtonTransparent title={t('Remove this input')} onClick={onRemoveClicked}>
+          <ImCross />
+        </ButtonTransparent>
+      </Row>
+    </InputFileInfoWrapper>
+  )
+}
+
+export function MainInputFormSequencesCurrent() {
+  const { t } = useTranslationSafe()
+  const { qryInputs, clearQryInputs } = useQuerySeqInputs()
+
+  const inputComponents = useMemo(
+    () => (
+      <Row noGutters>
+        <Col>
+          {qryInputs.map((input, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <InputFileInfo key={`${input.name} ${index}`} input={input} index={index} />
+          ))}
+        </Col>
+      </Row>
+    ),
+    [qryInputs],
+  )
+
+  const removeButton = useMemo(
+    () =>
+      qryInputs.length > 0 ? (
+        <Row noGutters>
+          <Col className="d-flex w-100">
+            <Button className="ml-auto" color="link" onClick={clearQryInputs} title={t('Remove all input files')}>
+              {t('Remove all')}
+            </Button>
+          </Col>
+        </Row>
+      ) : null,
+
+    [clearQryInputs, qryInputs.length, t],
+  )
+  const headerText = useMemo(() => {
+    if (qryInputs.length === 0) {
+      return null
+    }
+    return (
+      <Row noGutters>
+        <Col>
+          <h4>{t("Sequence data you've added")}</h4>
+        </Col>
+      </Row>
+    )
+  }, [qryInputs.length, t])
+
+  if (qryInputs.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="my-2">
+      {headerText}
+      <SequencesCurrentWrapper>
+        <Row noGutters>
+          <Col>
+            {inputComponents}
+            {removeButton}
+          </Col>
+        </Row>
+      </SequencesCurrentWrapper>
+    </section>
+  )
+}

--- a/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -22,18 +22,19 @@ import {
 import { numThreadsAtom, showNewRunPopupAtom } from 'src/state/settings.state'
 import { LaunchAnalysisInputs, launchAnalysis, LaunchAnalysisCallbacks } from 'src/workers/launchAnalysis'
 import {
-  qrySeqInputAtom,
   refSeqInputAtom,
   geneMapInputAtom,
   refTreeInputAtom,
   qcConfigInputAtom,
   virusPropertiesInputAtom,
   primersCsvInputAtom,
+  useQuerySeqInputs,
 } from 'src/state/inputs.state'
 
 export function useRunAnalysis() {
   const router = useRouter()
   const dispatch = useDispatch()
+  const { qryInputs } = useQuerySeqInputs()
 
   return useRecoilCallback(
     ({ set, reset, snapshot: { getPromise } }) =>
@@ -45,7 +46,6 @@ export function useRunAnalysis() {
 
         const numThreads = getPromise(numThreadsAtom)
         const datasetCurrent = getPromise(datasetCurrentAtom)
-        const qrySeq = getPromise(qrySeqInputAtom)
 
         const inputs: LaunchAnalysisInputs = {
           ref_seq_str: getPromise(refSeqInputAtom),
@@ -91,13 +91,13 @@ export function useRunAnalysis() {
           .push('/results', '/results')
           .then(async () => {
             set(analysisStatusGlobalAtom, AlgorithmGlobalStatus.initWorkers)
-            return launchAnalysis(qrySeq, inputs, callbacks, datasetCurrent, numThreads)
+            return launchAnalysis(qryInputs, inputs, callbacks, datasetCurrent, numThreads)
           })
           .catch((error) => {
             set(analysisStatusGlobalAtom, AlgorithmGlobalStatus.failed)
             set(globalErrorAtom, sanitizeError(error))
           })
       },
-    [router, dispatch],
+    [router, dispatch, qryInputs],
   )
 }

--- a/packages_rs/nextclade-web/src/io/AlgorithmInput.ts
+++ b/packages_rs/nextclade-web/src/io/AlgorithmInput.ts
@@ -1,10 +1,8 @@
-import { concurrent } from 'fasy'
 import { AlgorithmInput, AlgorithmInputType, Dataset } from 'src/algorithms/types'
 import { axiosFetchRaw } from 'src/io/axiosFetch'
 
 import { readFile } from 'src/helpers/readFile'
 import { numbro } from 'src/i18n/i18n'
-import { sumBy } from 'lodash'
 
 function formatBytes(bytes: number) {
   let mantissa = 1
@@ -20,28 +18,22 @@ function formatBytes(bytes: number) {
 export class AlgorithmInputFile implements AlgorithmInput {
   public readonly type: AlgorithmInputType = AlgorithmInputType.File as const
 
-  private readonly files: File[]
+  private readonly file: File
 
-  constructor(files: File[]) {
-    this.files = files
+  constructor(file: File) {
+    this.file = file
   }
 
   public get name(): string {
-    return this.files.map((file) => file.name).join(', ')
+    return this.file.name
   }
 
   public get description(): string {
-    if (this.files.length === 1) {
-      return `${this.name} (${formatBytes(this.files[0].size)})`
-    }
-
-    const size = sumBy(this.files, (file) => file.size)
-    return `${this.files.length} files (total ${formatBytes(size)})`
+    return `${this.name} (${formatBytes(this.file.size)})`
   }
 
   public async getContent(): Promise<string> {
-    const strs = await concurrent.map(async (file) => readFile(file), this.files)
-    return strs.join('\n')
+    return readFile(this.file)
   }
 }
 
@@ -101,7 +93,8 @@ export class AlgorithmInputDefault implements AlgorithmInput {
   }
 
   public get name(): string {
-    return `${this.dataset.attributes.name.value} example`
+    const { value, valueFriendly } = this.dataset.attributes.name
+    return `${valueFriendly ?? value} example sequences`
   }
 
   public get description(): string {

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -16,9 +16,9 @@ import {
   geneMapInputAtom,
   primersCsvInputAtom,
   qcConfigInputAtom,
-  qrySeqInputAtom,
   refSeqInputAtom,
   refTreeInputAtom,
+  useQuerySeqInputs,
   virusPropertiesInputAtom,
 } from 'src/state/inputs.state'
 import {
@@ -79,6 +79,7 @@ export function RecoilStateInitializer() {
   const { query: urlQuery } = useMemo(() => parseUrl(router.asPath), [router.asPath])
 
   const [initialized, setInitialized] = useRecoilState(isInitializedAtom)
+  const { addQryInputs } = useQuerySeqInputs()
 
   const run = useRunAnalysis()
 
@@ -111,7 +112,9 @@ export function RecoilStateInitializer() {
       })
       .then(() => {
         const qrySeqInput = createInputFromUrlParamMaybe(urlQuery, 'input-fasta')
-        set(qrySeqInputAtom, qrySeqInput)
+        if (qrySeqInput) {
+          addQryInputs([qrySeqInput])
+        }
 
         set(refSeqInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-root-seq'))
         set(geneMapInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-gene-map'))

--- a/packages_rs/nextclade-web/src/state/inputs.state.ts
+++ b/packages_rs/nextclade-web/src/state/inputs.state.ts
@@ -1,11 +1,33 @@
-import { isNil } from 'lodash'
-import { atom, selector } from 'recoil'
+import { isEmpty } from 'lodash'
+import { useCallback } from 'react'
+import { atom, selector, useRecoilState, useResetRecoilState } from 'recoil'
 import { AlgorithmInput } from 'src/algorithms/types'
 
-export const qrySeqInputAtom = atom<AlgorithmInput | undefined>({
-  key: 'qrySeqInput',
-  default: undefined,
+const qrySeqInputsStorageAtom = atom<AlgorithmInput[]>({
+  key: 'qrySeqInputsStorage',
+  default: [],
 })
+
+export function useQuerySeqInputs() {
+  const [qryInputs, setQryInputs] = useRecoilState(qrySeqInputsStorageAtom)
+  const clearQryInputs = useResetRecoilState(qrySeqInputsStorageAtom)
+
+  const addQryInputs = useCallback(
+    (newInputs: AlgorithmInput[]) => {
+      setQryInputs((inputs) => [...inputs, ...newInputs])
+    },
+    [setQryInputs],
+  )
+
+  const removeQryInput = useCallback(
+    (index: number) => {
+      setQryInputs((inputs) => inputs.filter((_, i) => i !== index))
+    },
+    [setQryInputs],
+  )
+
+  return { qryInputs, addQryInputs, removeQryInput, clearQryInputs }
+}
 
 export const refSeqInputAtom = atom<AlgorithmInput | undefined>({
   key: 'refSeqInput',
@@ -40,7 +62,7 @@ export const primersCsvInputAtom = atom<AlgorithmInput | undefined>({
 export const hasRequiredInputsAtom = selector({
   key: 'hasRequiredInputs',
   get({ get }) {
-    return !isNil(get(qrySeqInputAtom))
+    return !isEmpty(get(qrySeqInputsStorageAtom))
   },
 })
 
@@ -49,7 +71,7 @@ export const inputResetAtom = selector<undefined>({
   key: 'inputReset',
   get: () => undefined,
   set({ reset }) {
-    reset(qrySeqInputAtom)
+    reset(qrySeqInputsStorageAtom)
     reset(refSeqInputAtom)
     reset(geneMapInputAtom)
     reset(refTreeInputAtom)


### PR DESCRIPTION
This adds a widget which displays a list of currently added fasta files, URLs and pasted snippets and allows to manage them.

Features:
 - Add and remove files, URLs or pasted snippets one by one
 - One or multiple files can be dropped or selected using file manager
 - Example sequences can also be added to the list by clicking to the usual link button

Quirks:
 - "Run automatically" if enabled, launches analysis right after the last drop, file selection, url or sequence paste. Multiple files can still be dropped, but only once.
 - What's shown on the screenshot below does not fully fit to 1080p screen, so requires scrolling to operate


![01](https://user-images.githubusercontent.com/9403403/173740035-1b1f8d75-a86a-4315-a65c-76bc7fe75cd9.png)

