### PR TITLE
fix(web): make 'invalid range' warning condition more optimistic

### DIFF
--- a/packages_rs/nextclade-web/src/helpers/formatRange.ts
+++ b/packages_rs/nextclade-web/src/helpers/formatRange.ts
@@ -1,6 +1,9 @@
 export function formatRange(begin: number, end: number) {
   if (begin > end) {
     console.warn(`formatRange: Attempted to format an invalid range: \`[${begin}; ${end})\`. This is probably a bug.`)
+  }
+
+  if (begin >= end) {
     return 'empty range'
   }
 

--- a/packages_rs/nextclade-web/src/helpers/formatRange.ts
+++ b/packages_rs/nextclade-web/src/helpers/formatRange.ts
@@ -1,5 +1,5 @@
 export function formatRange(begin: number, end: number) {
-  if (begin >= end) {
+  if (begin > end) {
     console.warn(`formatRange: Attempted to format an invalid range: \`[${begin}; ${end})\`. This is probably a bug.`)
     return 'empty range'
   }


### PR DESCRIPTION
This avoids a warning when the range is empty as we now consider an empty range  a valid case.

Notably, we've encountered this when a frame shift happens to be due to a 1-base deletion of a stop codon. In this case we still want to report a frame shift situation, even if the frame shift range is technically empty.

