### PR TITLE
fix(web): avoid race condition in fasta download vs analysis launch

### DIFF
--- a/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -22,19 +22,18 @@ import {
 import { numThreadsAtom, showNewRunPopupAtom } from 'src/state/settings.state'
 import { LaunchAnalysisInputs, launchAnalysis, LaunchAnalysisCallbacks } from 'src/workers/launchAnalysis'
 import {
+  qrySeqInputsStorageAtom,
   refSeqInputAtom,
   geneMapInputAtom,
   refTreeInputAtom,
   qcConfigInputAtom,
   virusPropertiesInputAtom,
   primersCsvInputAtom,
-  useQuerySeqInputs,
 } from 'src/state/inputs.state'
 
 export function useRunAnalysis() {
   const router = useRouter()
   const dispatch = useDispatch()
-  const { qryInputs } = useQuerySeqInputs()
 
   return useRecoilCallback(
     ({ set, reset, snapshot: { getPromise } }) =>
@@ -46,6 +45,8 @@ export function useRunAnalysis() {
 
         const numThreads = getPromise(numThreadsAtom)
         const datasetCurrent = getPromise(datasetCurrentAtom)
+
+        const qryInputs = getPromise(qrySeqInputsStorageAtom)
 
         const inputs: LaunchAnalysisInputs = {
           ref_seq_str: getPromise(refSeqInputAtom),
@@ -98,6 +99,6 @@ export function useRunAnalysis() {
             set(globalErrorAtom, sanitizeError(error))
           })
       },
-    [router, dispatch, qryInputs],
+    [router, dispatch],
   )
 }

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -16,9 +16,9 @@ import {
   geneMapInputAtom,
   primersCsvInputAtom,
   qcConfigInputAtom,
+  qrySeqInputsStorageAtom,
   refSeqInputAtom,
   refTreeInputAtom,
-  useQuerySeqInputs,
   virusPropertiesInputAtom,
 } from 'src/state/inputs.state'
 import {
@@ -79,7 +79,6 @@ export function RecoilStateInitializer() {
   const { query: urlQuery } = useMemo(() => parseUrl(router.asPath), [router.asPath])
 
   const [initialized, setInitialized] = useRecoilState(isInitializedAtom)
-  const { addQryInputs } = useQuerySeqInputs()
 
   const run = useRunAnalysis()
 
@@ -113,7 +112,7 @@ export function RecoilStateInitializer() {
       .then(() => {
         const qrySeqInput = createInputFromUrlParamMaybe(urlQuery, 'input-fasta')
         if (qrySeqInput) {
-          addQryInputs([qrySeqInput])
+          set(qrySeqInputsStorageAtom, [qrySeqInput])
         }
 
         set(refSeqInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-root-seq'))

--- a/packages_rs/nextclade-web/src/state/inputs.state.ts
+++ b/packages_rs/nextclade-web/src/state/inputs.state.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { atom, selector, useRecoilState, useResetRecoilState } from 'recoil'
 import { AlgorithmInput } from 'src/algorithms/types'
 
-const qrySeqInputsStorageAtom = atom<AlgorithmInput[]>({
+export const qrySeqInputsStorageAtom = atom<AlgorithmInput[]>({
   key: 'qrySeqInputsStorage',
   default: [],
 })

--- a/packages_rs/nextclade-web/src/workers/launchAnalysis.ts
+++ b/packages_rs/nextclade-web/src/workers/launchAnalysis.ts
@@ -46,7 +46,7 @@ const DATASET_FILE_NAME_MAPPING: Record<keyof LaunchAnalysisInputs, keyof Datase
 }
 
 export async function launchAnalysis(
-  qryFastaInputs: AlgorithmInput[],
+  qryFastaInputs: Promise<AlgorithmInput[]>,
   paramInputs: LaunchAnalysisInputs,
   callbacks: LaunchAnalysisCallbacks,
   datasetPromise: Promise<Dataset | undefined>,
@@ -55,7 +55,7 @@ export async function launchAnalysis(
   const { onGlobalStatus, onInitialData, onParsedFasta, onAnalysisResult, onTree, onError, onComplete } = callbacks
 
   // Resolve inputs into the actual strings
-  const qryFastaStr = await getQueryFasta(qryFastaInputs)
+  const qryFastaStr = await getQueryFasta(await qryFastaInputs)
 
   const dataset = await datasetPromise
   if (!dataset) {


### PR DESCRIPTION
Sometimes (timing-dependent) sequences were not fully downloaded when analysis started, because the recoil atom have not yet been set at this point.

This PR ensures that sequences are obtained from recoil in form of a `Promise` and launcher `await`s until it resolves.

Additionally, I removed the `useQuerySequences()` custom hook usage in the app initialization, because App component can render multiple times and this have caused multiple copes of the same fasta added provided via URL params. Instead moved this code into the effect that runs only once.

