### PR TITLE
fix(web): ensure init errors are not hidden

### DIFF
--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -98,6 +98,7 @@ export function RecoilStateInitializer() {
       .catch((error) => {
         // Dataset error is fatal and we want error to be handled in the ErrorBoundary
         setInitialized(false)
+        set(globalErrorAtom, sanitizeError(error))
         throw error
       })
       .then(({ datasets, defaultDatasetName, defaultDatasetNameFriendly, currentDatasetName }) => {


### PR DESCRIPTION
Nextclade Web has been hiding some of the errors that occur during initialization. Notably, if dataset server is not reachable or dataset index fetch fails for any reason, then Nextclade would just show loading spinner indefinitely.

This PR ensures that the error is properly handled and that an error message is shown in these cases.

