### PR TITLE
chore(ci): ensure better compatibility of linux gnu binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
             declare -a TARGETS=(
               "aarch64-apple-darwin"
               "aarch64-unknown-linux-gnu"
+              "aarch64-unknown-linux-musl"
               "wasm32-unknown-unknown"
               "x86_64-apple-darwin"
               "x86_64-pc-windows-gnu"
@@ -428,11 +429,12 @@ workflows:
           matrix:
             parameters:
               target_arch:
-                - x86_64-apple-darwin
                 - aarch64-apple-darwin
-                - x86_64-unknown-linux-gnu
-                - x86_64-pc-windows-gnu
                 - aarch64-unknown-linux-gnu
+                - aarch64-unknown-linux-musl
+                - x86_64-apple-darwin
+                - x86_64-pc-windows-gnu
+                - x86_64-unknown-linux-gnu
                 - x86_64-unknown-linux-musl
 
       - Release-Cli-Github:
@@ -442,11 +444,12 @@ workflows:
             - nextclade_github
 
           requires:
-            - Build-Cli-x86_64-apple-darwin
             - Build-Cli-aarch64-apple-darwin
-            - Build-Cli-x86_64-unknown-linux-gnu
-            - Build-Cli-x86_64-pc-windows-gnu
             - Build-Cli-aarch64-unknown-linux-gnu
+            - Build-Cli-aarch64-unknown-linux-musl
+            - Build-Cli-x86_64-apple-darwin
+            - Build-Cli-x86_64-pc-windows-gnu
+            - Build-Cli-x86_64-unknown-linux-gnu
             - Build-Cli-x86_64-unknown-linux-musl
 
       - Release-Cli-Docker:

--- a/docker-cross
+++ b/docker-cross
@@ -10,6 +10,7 @@ function abspath() {
 declare -a TARGETS=(
   "aarch64-apple-darwin"
   "aarch64-unknown-linux-gnu"
+  "aarch64-unknown-linux-musl"
   "x86_64-apple-darwin"
   "x86_64-pc-windows-gnu"
   "x86_64-unknown-linux-gnu"

--- a/docker-dev
+++ b/docker-dev
@@ -30,7 +30,7 @@ export DOCKER_CONTAINER_NAME="${DOCKER_IMAGE_NAME_SAFE}-$(date +%s)"
 export USER=user
 export GROUP=user
 
-export BUILD_DIR_REL=".build/docker/${PACKAGE_DIR_REL}"
+export BUILD_DIR_REL=".build/docker${CROSS:+-$CROSS}/${PACKAGE_DIR_REL}"
 export BUILD_DIR="$(abspath "${PACKAGE_DIR}/${BUILD_DIR_REL}")"
 export BUILD_DIR_TEST="${BUILD_DIR}/test"
 
@@ -268,9 +268,14 @@ if [ "${WASM}" == "1" ]; then
   CROSS="wasm32-unknown-unknown"
 fi
 
+DOCKER_BASE_IMAGE="${DOCKER_BASE_IMAGE:=ubuntu:20.04}"
 DOCKER_TARGET="dev"
 RUST_TARGET=""
 if [ -n "${CROSS:-}" ]; then
+  if [[ "${CROSS}" == *-gnu ]]; then
+    DOCKER_BASE_IMAGE="debian:9.13"
+  fi
+
   DOCKER_TARGET="cross-${CROSS}"
   RUST_TARGET="--target=${CROSS}"
 fi
@@ -300,6 +305,7 @@ if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER
     --cache-from="${DOCKER_REPO}:${DOCKER_TARGET}" \
     --cache-from="${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER_IMAGE_VERSION}" \
     --network=host \
+    --build-arg="DOCKER_BASE_IMAGE=${DOCKER_BASE_IMAGE}" \
     --build-arg="UID=$(id -u)" \
     --build-arg="GID=$(id -g)" \
     --build-arg="USER=user" \

--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -205,20 +205,16 @@ USER 0
 SHELL ["bash", "-euxo", "pipefail", "-c"]
 
 RUN set -euxo pipefail >/dev/null \
-&& export DEBIAN_FRONTEND=noninteractive \
-&& apt-get update -qq --yes \
-&& apt-get install -qq --no-install-recommends --yes \
-  musl-dev \
-  musl-tools \
->/dev/null \
-&& apt-get clean autoclean >/dev/null \
-&& apt-get autoremove --yes >/dev/null \
-&& rm -rf /var/lib/apt/lists/*
+&& curl -fsSL "https://more.musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz" | tar -C "/usr" -xz --strip-components=1
 
 USER ${USER}
 
 RUN set -euxo pipefail >/dev/null \
 && rustup target add x86_64-unknown-linux-musl
+
+ENV CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
+ENV CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
 
 
 # Cross-compilation to WebAssembly
@@ -256,6 +252,26 @@ RUN set -euxo pipefail >/dev/null \
 ENV CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+
+# Cross-compilation for Linux ARM64 with libmusl
+FROM base as cross-aarch64-unknown-linux-musl
+
+USER 0
+
+SHELL ["bash", "-euxo", "pipefail", "-c"]
+
+RUN set -euxo pipefail >/dev/null \
+&& curl -fsSL "https://more.musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz" | tar -C "/usr" -xz --strip-components=1
+
+USER ${USER}
+
+RUN set -euxo pipefail >/dev/null \
+&& rustup target add aarch64-unknown-linux-musl
+
+ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+ENV CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
 
 
 # Cross-compilation for Windows x86_64

--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -1,7 +1,6 @@
-# Freeze base image version to
-# ubuntu:20.04 (pushed 2022-04-21T23:04:30.548037Z)
-# https://hub.docker.com/layers/ubuntu/library/ubuntu/20.04/images/sha256-7b3e30a1f373b0621681f13b92feb928129c1c38977481ee788a793fcae64fb9
-FROM ubuntu@sha256:7b3e30a1f373b0621681f13b92feb928129c1c38977481ee788a793fcae64fb9 as base
+ARG DOCKER_BASE_IMAGE
+
+FROM $DOCKER_BASE_IMAGE as base
 
 SHELL ["bash", "-euxo", "pipefail", "-c"]
 
@@ -15,6 +14,7 @@ RUN set -euxo pipefail >/dev/null \
 && export DEBIAN_FRONTEND=noninteractive \
 && apt-get update -qq --yes \
 && apt-get install -qq --no-install-recommends --yes \
+  apt-transport-https \
   bash \
   bash-completion \
   build-essential \
@@ -163,7 +163,6 @@ RUN set -euxo pipefail >/dev/null \
 && cargo quickinstall cargo-audit \
 && cargo quickinstall cargo-deny \
 && cargo quickinstall cargo-edit \
-&& cargo quickinstall cargo-generate \
 && cargo quickinstall cargo-watch \
 && cargo quickinstall wasm-pack \
 && cargo quickinstall xargo


### PR DESCRIPTION
 - [x] build aarch64-unknown-linux-gnu and x86_64-unknown-linux-gnu binaries on Debian 9, so that it links older shared libs. This should allow running on wider spectrum of Linux distros with various versions of glibc and libgcc.
 - [x] add ARM linux musl binaries
 - [x] use musl gcc from the official musl website for both ARM and x86_64 builds for consistency
