### PR TITLE
fix(web): rectify incorrect field name

### DIFF
--- a/packages_rs/nextclade-web/src/filtering/filterByAminoacidChanges.ts
+++ b/packages_rs/nextclade-web/src/filtering/filterByAminoacidChanges.ts
@@ -27,7 +27,10 @@ export function filterByAminoacidChanges(aaFilter: string) {
     const { aaSubstitutions, aaDeletions } = result.result.analysisResult
 
     // Make deletions look like substitutions
-    const aaDeletionsLikeSubstitutions = aaDeletions.map((del) => ({ ...del, queryAa: AMINOACID_GAP }))
+    const aaDeletionsLikeSubstitutions: AminoacidSubstitution[] = aaDeletions.map((del) => ({
+      ...del,
+      queryAA: AMINOACID_GAP,
+    }))
 
     // We want to search for both, the substitutions and deletions
     const aaChanges = [...aaSubstitutions, ...aaDeletionsLikeSubstitutions]


### PR DESCRIPTION
This was sometimes causing a crash of the web app when filtering by aminoacids. The filed `queryAa` was not spelled correctly and the lodash `intersectionWith()` function's typings did not catch the type mismatch.

