### PR TITLE
fix(cli): don't crash on unknown nucleotide characters

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
@@ -96,19 +96,20 @@ pub fn nextalign_run(args: NextalignRunArgs) -> Result<(), Report> {
 
         for FastaRecord { seq_name, seq, index } in &fasta_receiver {
           info!("Processing sequence '{seq_name}'");
-          let qry_seq = to_nuc_seq(&seq)
-            .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
-            .unwrap();
 
-          let outputs_or_err = nextalign_run_one(
-            &qry_seq,
-            ref_seq,
-            ref_peptides,
-            gene_map,
-            gap_open_close_nuc,
-            gap_open_close_aa,
-            alignment_params,
-          );
+          let outputs_or_err = to_nuc_seq(&seq)
+            .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
+            .and_then(|qry_seq| {
+              nextalign_run_one(
+                &qry_seq,
+                ref_seq,
+                ref_peptides,
+                gene_map,
+                gap_open_close_nuc,
+                gap_open_close_aa,
+                alignment_params,
+              )
+            });
 
           let record = NextalignRecord {
             index,

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -151,24 +151,25 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
 
         for FastaRecord { seq_name, seq, index } in &fasta_receiver {
           info!("Processing sequence '{seq_name}'");
-          let qry_seq = to_nuc_seq(&seq)
-            .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
-            .unwrap();
 
-          let outputs_or_err = nextclade_run_one(
-            &seq_name,
-            &qry_seq,
-            ref_seq,
-            ref_peptides,
-            gene_map,
-            primers,
-            tree,
-            qc_config,
-            virus_properties,
-            gap_open_close_nuc,
-            gap_open_close_aa,
-            alignment_params,
-          );
+          let outputs_or_err = to_nuc_seq(&seq)
+            .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
+            .and_then(|qry_seq| {
+              nextclade_run_one(
+                &seq_name,
+                &qry_seq,
+                ref_seq,
+                ref_peptides,
+                gene_map,
+                primers,
+                tree,
+                qc_config,
+                virus_properties,
+                gap_open_close_nuc,
+                gap_open_close_aa,
+                alignment_params,
+              )
+            });
 
           let record = NextcladeRecord {
             index,


### PR DESCRIPTION
Nextclade v2 crashes when encounters unknown nucleotide letters when converting fasta string to the internal sequence representation.

This PR aligns behavior with v1: sequences with unknown nucleotide letters are now ignored, excluded from results, added to errors.csv, the warning message is printed and the run continues.

