### PR TITLE
fix: add missing custom node attrs to tree json

### DIFF
--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -13,6 +13,7 @@ use crate::tree::tree::{
 use crate::types::outputs::NextcladeOutputs;
 use crate::utils::collections::concat_to_vec;
 use itertools::Itertools;
+use serde_json::json;
 use std::collections::BTreeMap;
 
 pub fn tree_attach_new_nodes_in_place(tree: &mut AuspiceTree, results: &[NextcladeOutputs]) {
@@ -82,6 +83,15 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
     )
   };
 
+  #[allow(clippy::from_iter_instead_of_collect)]
+  let other = serde_json::Value::from_iter(
+    result
+      .custom_node_attributes
+      .clone()
+      .into_iter()
+      .map(|(key, val)| (key, json!({ "value": val }))),
+  );
+
   node.children.insert(
     0,
     AuspiceTreeNode {
@@ -104,7 +114,7 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
         has_pcr_primer_changes,
         pcr_primer_changes,
         missing_genes: Some(TreeNodeAttr::new(&format_failed_genes(&result.missing_genes, ", "))),
-        other: serde_json::Value::default(),
+        other,
 
         // TODO
         qc_status: None,


### PR DESCRIPTION
This adds custom node attrs (e.g. pango lineages) to the tree json, that were previously missing.

This should ensure that they are shown on the tree viz as it was in Nextclade v1.

