### PR TITLE
fix: add missing qc status to tree json

### DIFF
--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -104,10 +104,8 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
         has_pcr_primer_changes,
         pcr_primer_changes,
         missing_genes: Some(TreeNodeAttr::new(&format_failed_genes(&result.missing_genes, ", "))),
+        qc_status: Some(TreeNodeAttr::new(&result.qc.overall_status.to_string())),
         other: serde_json::Value::default(),
-
-        // TODO
-        qc_status: None,
       },
       children: vec![],
       tmp: TreeNodeTempData::default(),


### PR DESCRIPTION
This adds qc status to the tree json, previously missing.

This should ensure that they QC status is shown on the tree viz as it was in Nextclade v1.

