### PR TITLE
feat(cli): add output file compression

### DIFF
--- a/packages_rs/nextclade/src/io/compression.rs
+++ b/packages_rs/nextclade/src/io/compression.rs
@@ -75,7 +75,7 @@ impl<'r> Decompressor<'r> {
 pub fn guess_compression_from_filepath(filepath: impl AsRef<Path>) -> (CompressionType, String) {
   let filepath = filepath.as_ref();
 
-  match extension(filepath).map(|ext|ext.to_lowercase()) {
+  match extension(filepath).map(|ext| ext.to_lowercase()) {
     None => (CompressionType::None, "".to_owned()),
     Some(ext) => {
       let compression_type: CompressionType = match ext.as_str() {

--- a/packages_rs/nextclade/src/io/csv.rs
+++ b/packages_rs/nextclade/src/io/csv.rs
@@ -1,19 +1,18 @@
 use crate::io::file::create_file;
-use crate::io::fs::{ensure_dir, read_file_to_string};
+use crate::io::fs::read_file_to_string;
 use crate::utils::error::to_eyre_error;
 use csv::{ReaderBuilder as CsvReaderBuilder, Writer as CsvWriterImpl, WriterBuilder as CsvWriterBuilder};
-use eyre::{Report, WrapErr};
+use eyre::Report;
 use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Writes CSV. Each row is a serde-annotated struct.
-pub struct CsvStructWriter<W: 'static + Write + Sync + Send> {
+pub struct CsvStructWriter<W: Write + Send> {
   pub writer: CsvWriterImpl<W>,
 }
 
-impl<W: 'static + Write + Sync + Send> CsvStructWriter<W> {
+impl<W: Write + Send> CsvStructWriter<W> {
   pub fn new(writer: W, delimiter: u8) -> Result<Self, Report> {
     let writer = CsvWriterBuilder::new().delimiter(delimiter).from_writer(writer);
     Ok(Self { writer })
@@ -23,17 +22,12 @@ impl<W: 'static + Write + Sync + Send> CsvStructWriter<W> {
     self.writer.serialize(record)?;
     Ok(())
   }
-
-  pub fn into_inner(self) -> Result<W, Report> {
-    let inner = self.writer.into_inner()?;
-    Ok(inner)
-  }
 }
 
 /// Writes CSV files. Each row is a serde-annotated struct.
 pub struct CsvStructFileWriter {
   pub filepath: PathBuf,
-  pub writer: CsvStructWriter<Box<dyn Write + Sync + Send>>,
+  pub writer: CsvStructWriter<Box<dyn Write + Send>>,
 }
 
 impl CsvStructFileWriter {
@@ -58,12 +52,12 @@ pub trait VecWriter {
 }
 
 /// Writes CSV. Each row is a vec of strings.
-pub struct CsvVecWriter<W: 'static + Write + Send + Sync> {
+pub struct CsvVecWriter<W: Write + Send> {
   pub headers: Vec<String>,
   pub writer: CsvWriterImpl<W>,
 }
 
-impl<W: 'static + Write + Send + Sync> CsvVecWriter<W> {
+impl<W: Write + Send> CsvVecWriter<W> {
   pub fn new(writer: W, delimiter: u8, headers: &[String]) -> Result<Self, Report> {
     let mut writer = CsvWriterBuilder::new().delimiter(delimiter).from_writer(writer);
     writer.write_record(headers)?;
@@ -72,14 +66,9 @@ impl<W: 'static + Write + Send + Sync> CsvVecWriter<W> {
       writer,
     })
   }
-
-  pub fn into_inner(self) -> Result<W, Report> {
-    let inner = self.writer.into_inner()?;
-    Ok(inner)
-  }
 }
 
-impl<W: 'static + Write + Send + Sync> VecWriter for CsvVecWriter<W> {
+impl<W: Write + Send> VecWriter for CsvVecWriter<W> {
   fn write<I: IntoIterator<Item = T>, T: AsRef<[u8]>>(&mut self, values: I) -> Result<(), Report> {
     self.writer.write_record(values)?;
     Ok(())
@@ -90,7 +79,7 @@ impl<W: 'static + Write + Send + Sync> VecWriter for CsvVecWriter<W> {
 pub struct CsvVecFileWriter {
   pub filepath: PathBuf,
   pub headers: Vec<String>,
-  pub writer: CsvVecWriter<Box<dyn Write + Sync + Send>>,
+  pub writer: CsvVecWriter<Box<dyn Write + Send>>,
 }
 
 impl CsvVecFileWriter {

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -1,7 +1,6 @@
 use crate::io::aa::from_aa_seq;
+use crate::io::compression::Decompressor;
 use crate::io::concat::concat;
-use crate::io::decompression::Decompressor;
-use crate::io::fs::ensure_dir;
 use crate::io::gene_map::GeneMap;
 use crate::translate::translate_genes::Translation;
 use crate::{make_error, make_internal_error};
@@ -10,7 +9,7 @@ use log::{info, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{stdin, BufRead, BufReader, BufWriter, Read};
+use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tinytemplate::TinyTemplate;

--- a/packages_rs/nextclade/src/io/insertions_csv.rs
+++ b/packages_rs/nextclade/src/io/insertions_csv.rs
@@ -44,15 +44,17 @@ impl InsertionsCsvWriter {
 }
 
 pub fn insertions_to_csv_string(outputs: &[NextcladeOutputs]) -> Result<String, Report> {
-  let mut writer = CsvStructWriter::new(Vec::<u8>::new(), b',')?;
+  let mut buf = Vec::<u8>::new();
+  {
+    let mut writer = CsvStructWriter::new(&mut buf, b',')?;
 
-  for output in outputs {
-    writer.write(&InsertionCsvEntry {
-      seq_name: &output.seq_name,
-      insertions: format_nuc_insertions(&output.insertions, ";"),
-      aa_insertions: format_aa_insertions(&output.aa_insertions, ";"),
-    })?;
+    for output in outputs {
+      writer.write(&InsertionCsvEntry {
+        seq_name: &output.seq_name,
+        insertions: format_nuc_insertions(&output.insertions, ";"),
+        aa_insertions: format_aa_insertions(&output.aa_insertions, ";"),
+      })?;
+    }
   }
-
-  Ok(String::from_utf8(writer.into_inner()?)?)
+  Ok(String::from_utf8(buf)?)
 }

--- a/packages_rs/nextclade/src/io/mod.rs
+++ b/packages_rs/nextclade/src/io/mod.rs
@@ -1,7 +1,7 @@
 pub mod aa;
+pub mod compression;
 pub mod concat;
 pub mod csv;
-pub mod decompression;
 pub mod errors_csv;
 pub mod fasta;
 pub mod file;

--- a/packages_rs/nextclade/src/io/ndjson.rs
+++ b/packages_rs/nextclade/src/io/ndjson.rs
@@ -4,11 +4,11 @@ use std::fmt::Debug;
 use std::io::{LineWriter, Write};
 use std::path::{Path, PathBuf};
 
-pub struct NdjsonWriter<W: Write + Send + Sync> {
+pub struct NdjsonWriter<W: Write + Send> {
   line_writer: LineWriter<W>,
 }
 
-impl<W: Write + Send + Sync> NdjsonWriter<W> {
+impl<W: Write + Send> NdjsonWriter<W> {
   pub fn new(writer: W) -> Result<Self, Report> {
     let line_writer = LineWriter::new(writer);
     Ok(Self { line_writer })
@@ -23,7 +23,7 @@ impl<W: Write + Send + Sync> NdjsonWriter<W> {
 
 pub struct NdjsonFileWriter {
   filepath: PathBuf,
-  ndjson_writer: NdjsonWriter<Box<dyn Write + Sync + Send>>,
+  ndjson_writer: NdjsonWriter<Box<dyn Write + Send>>,
 }
 
 impl NdjsonFileWriter {


### PR DESCRIPTION
Adds compression support for output files: if output filename contains one of the supported extensions, the outputs will be transparently compressed. Example `--output-fasta=aligned.fasta.xz`. Supported formats as the same as for input decompression: gz, bz2, xz, zstd. Default compression levels are used.


To make it compile, I had to additionally:
 - change some of the lifetime parameters in CSV and NDJSON writer, because they were unnecessarily limiting
 - remove a very tricky `into_inner()` methods in CSV and NDJSON writer, which required `Sync`trait on inner writer, while zstd writer did not support that. For that, in a few places, instead of getting inner writer and getting a string out of it, I managed to just use vec as an inner writer in these places. So `into_inner()` method was no longer needed, same as `Sync` trait bound.