### PR TITLE
fix(cli): remove stdin from description of --output-translations arg

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -206,7 +206,7 @@ pub struct NextalignRunArgs {
   /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
   ///
   /// If filename ends with one of the supported file extensions: `gz`, `bz2`, `xz`, `zstd`, it will be transparently
-  /// compressed. If a filename is "-" then the output will be written uncompressed to standard output (stdout).
+  /// compressed.
   ///
   /// Example for bash shell:
   ///

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -400,7 +400,7 @@ pub struct NextcladeRunArgs {
   /// Takes precedence over paths configured with `--output-all`, `--output-basename` and `--output-selection`.
   ///
   /// If filename ends with one of the supported file extensions: `gz`, `bz2`, `xz`, `zstd`, it will be transparently
-  /// compressed. If a filename is "-" then the output will be written uncompressed to standard output (stdout).
+  /// compressed.
   ///
   /// Example for bash shell:
   ///


### PR DESCRIPTION
Translations cannot be written to stdout because there are many files

