### PR TITLE
feat(cli): organize verbosity flags towards the end of help message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,6 @@ version = "2.0.0-beta.6"
 dependencies = [
  "assert2",
  "clap 3.1.18",
- "clap-verbosity-flag",
  "clap_complete",
  "clap_complete_fig",
  "color-eyre",

--- a/packages_rs/nextclade-cli/Cargo.toml
+++ b/packages_rs/nextclade-cli/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 [dependencies]
 assert2 = "0.3.6"
 clap = { version = "3.1.8", features = ["derive"] }
-clap-verbosity-flag = "1.0.0"
 clap_complete = "3.1.1"
 clap_complete_fig = "3.1.4"
 color-eyre = "0.6.1"

--- a/packages_rs/nextclade-cli/src/cli/mod.rs
+++ b/packages_rs/nextclade-cli/src/cli/mod.rs
@@ -7,3 +7,4 @@ pub mod nextclade_dataset_get;
 pub mod nextclade_dataset_list;
 pub mod nextclade_loop;
 pub mod nextclade_ordered_writer;
+pub mod verbosity;

--- a/packages_rs/nextclade-cli/src/cli/verbosity.rs
+++ b/packages_rs/nextclade-cli/src/cli/verbosity.rs
@@ -1,0 +1,135 @@
+//! Inspired by clap-verbosity-flag:
+//! https://github.com/rust-cli/clap-verbosity-flag
+use clap::Args;
+use lazy_static::lazy_static;
+use log::{Level, LevelFilter};
+use std::fmt::{Display, Formatter, Result};
+use std::marker::PhantomData;
+
+lazy_static! {
+  static ref VERBOSITIES: &'static [&'static str] = &["off", "error", "warn", "info", "debug", "trace"];
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Verbosity<L: LogLevel = ErrorLevel> {
+  /// Set verbosity level of console output [default: warn]
+  #[clap(long, global = true, possible_values(VERBOSITIES.iter()))]
+  #[clap(conflicts_with = "quiet", conflicts_with = "verbose", conflicts_with = "silent")]
+  #[clap(display_order = 900)]
+  pub verbosity: Option<LevelFilter>,
+
+  /// Disable all console output. Same as `--verbosity=off`
+  #[clap(long, global = true)]
+  #[clap(conflicts_with = "quiet", conflicts_with = "verbose", conflicts_with = "verbosity")]
+  #[clap(display_order = 901)]
+  pub silent: bool,
+
+  /// Make console output more verbose. Add multiple occurrences to increase verbosity further.
+  #[clap(long, short = 'v', parse(from_occurrences), global = true)]
+  #[clap(conflicts_with = "quiet", conflicts_with = "verbosity", conflicts_with = "silent")]
+  #[clap(display_order = 902)]
+  verbose: i8,
+
+  /// Make console output more quiet. Add multiple occurrences to make output even more quiet.
+  #[clap(long, short = 'q', parse(from_occurrences), global = true)]
+  #[clap(conflicts_with = "verbose", conflicts_with = "verbosity")]
+  #[clap(display_order = 903)]
+  quiet: i8,
+
+  #[clap(skip)]
+  phantom: PhantomData<L>,
+}
+
+impl<L: LogLevel> Verbosity<L> {
+  pub fn get_filter_level(&self) -> LevelFilter {
+    // --verbosity=<level> and --silent take priority over -v and -q
+    if self.silent {
+      LevelFilter::Off
+    } else {
+      match self.verbosity {
+        Some(verbosity) => verbosity,
+        None => self.log_level_filter(),
+      }
+    }
+  }
+
+  /// Get the log level.
+  ///
+  /// `None` means all output is disabled.
+  pub fn log_level(&self) -> Option<Level> {
+    level_enum(self.verbosity())
+  }
+
+  /// Get the log level filter.
+  pub fn log_level_filter(&self) -> LevelFilter {
+    level_enum(self.verbosity()).map_or(LevelFilter::Off, |l| l.to_level_filter())
+  }
+
+  /// If the user requested complete silence (i.e. not just no-logging).
+  pub fn is_silent(&self) -> bool {
+    self.log_level().is_none()
+  }
+
+  fn verbosity(&self) -> i8 {
+    level_value(L::default()) - self.quiet + self.verbose
+  }
+}
+
+const fn level_value(level: Option<Level>) -> i8 {
+  match level {
+    None => -1,
+    Some(Level::Error) => 0,
+    Some(Level::Warn) => 1,
+    Some(Level::Info) => 2,
+    Some(Level::Debug) => 3,
+    Some(Level::Trace) => 4,
+  }
+}
+
+const fn level_enum(verbosity: i8) -> Option<Level> {
+  match verbosity {
+    i8::MIN..=-1 => None,
+    0 => Some(Level::Error),
+    1 => Some(Level::Warn),
+    2 => Some(Level::Info),
+    3 => Some(Level::Debug),
+    4..=i8::MAX => Some(Level::Trace),
+  }
+}
+
+impl<L: LogLevel> Display for Verbosity<L> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    write!(f, "{}", self.verbosity())
+  }
+}
+
+pub trait LogLevel {
+  fn default() -> Option<Level>;
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ErrorLevel;
+
+impl LogLevel for ErrorLevel {
+  fn default() -> Option<Level> {
+    Some(Level::Error)
+  }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct WarnLevel;
+
+impl LogLevel for WarnLevel {
+  fn default() -> Option<Level> {
+    Some(Level::Warn)
+  }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct InfoLevel;
+
+impl LogLevel for InfoLevel {
+  fn default() -> Option<Level> {
+    Some(Level::Info)
+  }
+}


### PR DESCRIPTION
Currently --verbosity, --silent, -v and -q args are missorted in the --help message text.

Here I inline the `clap-verbosity-flag` crate (only 1 file) and modify it, adding our custom flags and `display_order` annotations, such that the args are shown in the very end of the message, just before the `--help` arg.

