### PR TITLE
feat(cli): add  headings for help sections

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -1,4 +1,6 @@
-use crate::cli::nextclade_cli::NextcladeRunArgs;
+use crate::cli::nextclade_cli::{
+  NextcladeRunArgs, NextcladeRunInputArgs, NextcladeRunOtherArgs, NextcladeRunOutputArgs,
+};
 use crate::cli::nextclade_ordered_writer::NextcladeOrderedWriter;
 use crate::dataset::dataset_download::{
   dataset_dir_load, dataset_individual_files_load, dataset_zip_load, DatasetFiles,
@@ -38,7 +40,7 @@ pub struct DatasetFilePaths {
 }
 
 pub fn nextclade_get_inputs(run_args: &NextcladeRunArgs, genes: Option<Vec<String>>) -> Result<DatasetFiles, Report> {
-  if let Some(input_dataset) = run_args.input_dataset.as_ref() {
+  if let Some(input_dataset) = run_args.inputs.input_dataset.as_ref() {
     if input_dataset.is_file() && has_extension(input_dataset, "zip") {
       dataset_zip_load(run_args, input_dataset, genes)
     } else if input_dataset.is_dir() {
@@ -54,29 +56,44 @@ pub fn nextclade_get_inputs(run_args: &NextcladeRunArgs, genes: Option<Vec<Strin
   }
 }
 
-pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
-  info!("Command-line arguments:\n{args:#?}");
+pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
+  info!("Command-line arguments:\n{run_args:#?}");
 
   let NextcladeRunArgs {
-    input_fastas: input_fasta,
-    output_all,
-    output_basename,
-    output_selection,
-    output_translations,
-    include_reference,
-    output_fasta,
-    output_ndjson,
-    output_json,
-    output_csv,
-    output_tsv,
-    output_tree,
-    output_insertions,
-    output_errors,
-    jobs,
-    in_order,
-    genes,
-    ..
-  } = args.clone();
+    inputs:
+      NextcladeRunInputArgs {
+        input_fastas,
+        input_dataset,
+        input_ref,
+        input_tree,
+        input_qc_config,
+        input_virus_properties,
+        input_pcr_primers,
+        input_gene_map,
+        genes,
+        ..
+      },
+    outputs:
+      NextcladeRunOutputArgs {
+        output_all,
+        output_basename,
+        output_selection,
+        output_fasta,
+        output_translations,
+        output_ndjson,
+        output_json,
+        output_csv,
+        output_tsv,
+        output_tree,
+        output_insertions,
+        output_errors,
+        include_reference,
+        in_order,
+        ..
+      },
+    other: NextcladeRunOtherArgs { jobs },
+    alignment_params,
+  } = run_args.clone();
 
   let DatasetFiles {
     ref_record,
@@ -85,7 +102,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
     ref gene_map,
     qc_config,
     primers,
-  } = nextclade_get_inputs(&args, genes)?;
+  } = nextclade_get_inputs(&run_args, genes)?;
 
   let ref_seq = &to_nuc_seq(&ref_record.seq)?;
 
@@ -97,7 +114,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
   }
 
   // Merge alignment params coming from CLI arguments
-  alignment_params.merge_opt(args.alignment_params);
+  alignment_params.merge_opt(run_args.alignment_params);
 
   info!("Alignment parameters (final):\n{alignment_params:#?}");
 
@@ -120,7 +137,7 @@ pub fn nextclade_run(args: NextcladeRunArgs) -> Result<(), Report> {
     let outputs = &mut outputs;
 
     s.spawn(|_| {
-      let mut reader = FastaReader::from_paths(&input_fasta).unwrap();
+      let mut reader = FastaReader::from_paths(&input_fastas).unwrap();
       loop {
         let mut record = FastaRecord::default();
         reader.read(&mut record).unwrap();

--- a/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
@@ -73,32 +73,32 @@ pub fn dataset_zip_load(
   let buf_file = BufReader::new(file);
   let mut zip = ZipArchive::new(buf_file)?;
 
-  let ref_record = run_args.input_ref.as_ref().map_or_else(
+  let ref_record = run_args.inputs.input_ref.as_ref().map_or_else(
     || read_one_fasta_str(&zip_read_str(&mut zip, "reference.fasta")?),
     |input_ref| read_one_fasta(input_ref),
   )?;
 
-  let tree = run_args.input_tree.as_ref().map_or_else(
+  let tree = run_args.inputs.input_tree.as_ref().map_or_else(
     || AuspiceTree::from_str(&zip_read_str(&mut zip, "tree.json")?),
     |input_tree| AuspiceTree::from_path(&input_tree),
   )?;
 
-  let qc_config = run_args.input_qc_config.as_ref().map_or_else(
+  let qc_config = run_args.inputs.input_qc_config.as_ref().map_or_else(
     || QcConfig::from_str(&zip_read_str(&mut zip, "qc.json")?),
     |input_qc_config| QcConfig::from_path(&input_qc_config),
   )?;
 
-  let virus_properties = run_args.input_virus_properties.as_ref().map_or_else(
+  let virus_properties = run_args.inputs.input_virus_properties.as_ref().map_or_else(
     || VirusProperties::from_str(&zip_read_str(&mut zip, "virus_properties.json")?),
     |input_virus_properties| VirusProperties::from_path(&input_virus_properties),
   )?;
 
-  let primers = run_args.input_pcr_primers.as_ref().map_or_else(
+  let primers = run_args.inputs.input_pcr_primers.as_ref().map_or_else(
     || PcrPrimer::from_str(&zip_read_str(&mut zip, "primers.csv")?, &ref_record.seq),
     |input_pcr_primers| PcrPrimer::from_path(&input_pcr_primers, &ref_record.seq),
   )?;
 
-  let gene_map = run_args.input_gene_map.as_ref().map_or_else(
+  let gene_map = run_args.inputs.input_gene_map.as_ref().map_or_else(
     || {
       filter_gene_map(
         Some(read_gff3_str(&zip_read_str(&mut zip, "genemap.gff")?)?),
@@ -126,12 +126,12 @@ pub fn dataset_dir_load(
 ) -> Result<DatasetFiles, Report> {
   let input_dataset = dataset_dir.as_ref();
   dataset_load_files(DatasetFilePaths {
-    input_ref: &run_args.input_ref.unwrap_or_else(|| input_dataset.join("reference.fasta")),
-    input_tree: &run_args.input_tree.unwrap_or_else(|| input_dataset.join("tree.json")),
-    input_qc_config: &run_args.input_qc_config.unwrap_or_else(|| input_dataset.join("qc.json")),
-    input_virus_properties: &run_args.input_virus_properties.unwrap_or_else(|| input_dataset.join("virus_properties.json")),
-    input_pcr_primers: &run_args.input_pcr_primers.unwrap_or_else(|| input_dataset.join("primers.csv")),
-    input_gene_map: &run_args.input_gene_map.unwrap_or_else(|| input_dataset.join("genemap.gff")),
+    input_ref: &run_args.inputs.input_ref.unwrap_or_else(|| input_dataset.join("reference.fasta")),
+    input_tree: &run_args.inputs.input_tree.unwrap_or_else(|| input_dataset.join("tree.json")),
+    input_qc_config: &run_args.inputs.input_qc_config.unwrap_or_else(|| input_dataset.join("qc.json")),
+    input_virus_properties: &run_args.inputs.input_virus_properties.unwrap_or_else(|| input_dataset.join("virus_properties.json")),
+    input_pcr_primers: &run_args.inputs.input_pcr_primers.unwrap_or_else(|| input_dataset.join("primers.csv")),
+    input_gene_map: &run_args.inputs.input_gene_map.unwrap_or_else(|| input_dataset.join("genemap.gff")),
   }, genes)
 }
 
@@ -141,12 +141,12 @@ pub fn dataset_individual_files_load(
 ) -> Result<DatasetFiles, Report> {
   #[rustfmt::skip]
   let required_args = &[
-    (String::from("--input-ref"), &run_args.input_ref),
-    (String::from("--input-tree"), &run_args.input_tree),
-    (String::from("--input-gene-map"), &run_args.input_gene_map),
-    (String::from("--input-qc-config"), &run_args.input_qc_config),
-    (String::from("--input-pcr-primers"), &run_args.input_pcr_primers),
-    (String::from("--input-virus-properties"), &run_args.input_virus_properties),
+    (String::from("--input-ref"), &run_args.inputs.input_ref),
+    (String::from("--input-tree"), &run_args.inputs.input_tree),
+    (String::from("--input-gene-map"), &run_args.inputs.input_gene_map),
+    (String::from("--input-qc-config"), &run_args.inputs.input_qc_config),
+    (String::from("--input-pcr-primers"), &run_args.inputs.input_pcr_primers),
+    (String::from("--input-virus-properties"), &run_args.inputs.input_virus_properties),
   ];
 
   #[allow(clippy::single_match_else)]


### PR DESCRIPTION
There are many arguments for the run command, so let's organize them in named sections.

It required splitting args into separate structs and adding `next_help_heading` annotations.

I could not figure out how to change the "OPTIONS" heading where the default --help arguments stays. So I added a fake indentation for all heading as if they are nested under "OPTIONS".

