### PR TITLE
feat: sort mutations, deletions and insertions

### DIFF
--- a/packages_rs/nextclade/src/align/insertions_strip.rs
+++ b/packages_rs/nextclade/src/align/insertions_strip.rs
@@ -8,9 +8,10 @@ use eyre::Report;
 use itertools::Itertools;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::Ordering;
 use std::str::FromStr;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Insertion<T: Letter<T>> {
   pub pos: i32,
 
@@ -30,6 +31,19 @@ impl<T: Letter<T>> Insertion<T> {
 }
 
 pub type NucIns = Insertion<Nuc>;
+
+/// Order amino acid insertions by gene, position, then length
+impl<T: Letter<T>> Ord for Insertion<T> {
+  fn cmp(&self, other: &Self) -> Ordering {
+    (self.pos, self.ins.len()).cmp(&(other.pos, other.ins.len()))
+  }
+}
+
+impl<T: Letter<T>> PartialOrd for Insertion<T> {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StripInsertionsResult<T: Letter<T>> {
@@ -81,6 +95,7 @@ pub fn insertions_strip<T: Letter<T>>(qry_seq: &[T], ref_seq: &[T]) -> StripInse
 
   qry_stripped.shrink_to_fit();
   insertions.shrink_to_fit();
+  insertions.sort();
 
   // Remove gaps from ref
   let mut ref_stripped = ref_seq.to_vec();
@@ -93,7 +108,7 @@ pub fn insertions_strip<T: Letter<T>>(qry_seq: &[T], ref_seq: &[T]) -> StripInse
   }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AaIns {
   pub gene: String,
@@ -102,6 +117,19 @@ pub struct AaIns {
   #[serde(serialize_with = "serde_serialize_seq")]
   #[serde(deserialize_with = "serde_deserialize_seq")]
   pub ins: Vec<Aa>,
+}
+
+/// Order amino acid insertions by gene, position, then length
+impl Ord for AaIns {
+  fn cmp(&self, other: &Self) -> Ordering {
+    (&self.gene, self.pos, self.ins.len()).cmp(&(&other.gene, other.pos, other.ins.len()))
+  }
+}
+
+impl PartialOrd for AaIns {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
 }
 
 pub fn get_aa_insertions(translations: &[Translation]) -> Vec<AaIns> {
@@ -114,6 +142,7 @@ pub fn get_aa_insertions(translations: &[Translation]) -> Vec<AaIns> {
         ins,
       })
     })
+    .sorted()
     .collect_vec()
 }
 

--- a/packages_rs/nextclade/src/align/insertions_strip.rs
+++ b/packages_rs/nextclade/src/align/insertions_strip.rs
@@ -32,7 +32,7 @@ impl<T: Letter<T>> Insertion<T> {
 
 pub type NucIns = Insertion<Nuc>;
 
-/// Order amino acid insertions by gene, position, then length
+/// Order nuc insertions by position, then length
 impl<T: Letter<T>> Ord for Insertion<T> {
   fn cmp(&self, other: &Self) -> Ordering {
     (self.pos, self.ins.len()).cmp(&(other.pos, other.ins.len()))

--- a/packages_rs/nextclade/src/analyze/aa_changes.rs
+++ b/packages_rs/nextclade/src/analyze/aa_changes.rs
@@ -67,10 +67,10 @@ impl ToString for AaSub {
   }
 }
 
-/// Order substitutions by position, then ref character, then query character
+/// Order amino acid substitutions by gene, position, then ref character, then query character
 impl Ord for AaSub {
   fn cmp(&self, other: &Self) -> Ordering {
-    (self.pos, self.reff, self.qry).cmp(&(other.pos, other.reff, other.qry))
+    (&self.gene, self.pos, self.reff, self.qry).cmp(&(&other.gene, other.pos, other.reff, other.qry))
   }
 }
 
@@ -112,10 +112,10 @@ impl ToString for AaDel {
   }
 }
 
-/// Order substitutions by position, then ref character, then query character
+/// Order amino acid deletions by gene, position, then ref character, then query character
 impl Ord for AaDel {
   fn cmp(&self, other: &Self) -> Ordering {
-    (self.pos, self.reff).cmp(&(other.pos, other.reff))
+    (&self.gene, self.pos, self.reff).cmp(&(&other.gene, other.pos, other.reff))
   }
 }
 
@@ -262,8 +262,8 @@ pub fn find_aa_changes(
       output
     });
 
-  changes.aa_substitutions.sort_by_key(|sub| sub.pos);
-  changes.aa_deletions.sort_by_key(|del| del.pos);
+  changes.aa_substitutions.sort();
+  changes.aa_deletions.sort();
 
   Ok(changes)
 }

--- a/packages_rs/nextclade/src/analyze/nuc_changes.rs
+++ b/packages_rs/nextclade/src/analyze/nuc_changes.rs
@@ -59,6 +59,9 @@ pub fn find_nuc_changes(qry_aln: &[Nuc], ref_aln: &[Nuc]) -> FindNucChangesOutpu
     }
   }
 
+  substitutions.sort();
+  deletions.sort();
+
   FindNucChangesOutput {
     substitutions,
     deletions,


### PR DESCRIPTION
This adds sorting of nuc and aa mutations, deletions and insertions right after they are extracted. This should ensure that they are sorted in the the output files, which improves readability.

