### PR TITLE
feat: retry with reverse complement when seed matching fails

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
@@ -115,6 +115,8 @@ pub fn nextalign_run(run_args: NextalignRunArgs) -> Result<(), Report> {
           .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
           .and_then(|qry_seq| {
             nextalign_run_one(
+              index,
+              &seq_name,
               &qry_seq,
               ref_seq,
               ref_peptides,

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -178,6 +178,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
           .wrap_err_with(|| format!("When processing sequence #{index} '{seq_name}'"))
           .and_then(|qry_seq| {
             nextclade_run_one(
+              index,
               &seq_name,
               &qry_seq,
               ref_seq,

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -2,6 +2,7 @@ use crate::cli::nextclade_loop::NextcladeRecord;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::warn;
+use nextclade::constants::REVERSE_COMPLEMENT_SUFFIX;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
 use nextclade::io::gene_map::GeneMap;
@@ -118,8 +119,15 @@ impl<'a> NextcladeOrderedWriter<'a> {
           warnings,
           insertions,
           missing_genes,
+          is_reverse_complement,
           ..
         } = &nextclade_outputs;
+
+        let seq_name = if *is_reverse_complement {
+          format!("{seq_name}{REVERSE_COMPLEMENT_SUFFIX}")
+        } else {
+          seq_name.clone()
+        };
 
         if let Some(fasta_writer) = &mut self.fasta_writer {
           fasta_writer.write(&seq_name, &from_nuc_seq(&qry_seq_stripped))?;

--- a/packages_rs/nextclade-web/src/wasm/analyze.rs
+++ b/packages_rs/nextclade-web/src/wasm/analyze.rs
@@ -77,6 +77,9 @@ impl NextcladeParams {
 #[derive(Clone, Serialize, Deserialize, TypescriptDefinition, Debug)]
 pub struct AnalysisInput {
   #[wasm_bindgen(getter_with_clone)]
+  pub qry_index: usize,
+  
+  #[wasm_bindgen(getter_with_clone)]
   pub qry_seq_name: String,
 
   #[wasm_bindgen(getter_with_clone)]
@@ -218,6 +221,7 @@ impl Nextclade {
 
   pub fn run(&mut self, input: &AnalysisInput) -> Result<AnalysisResult, Report> {
     let AnalysisInput {
+      qry_index,
       qry_seq_name,
       qry_seq_str,
     } = input;
@@ -225,6 +229,7 @@ impl Nextclade {
     let qry_seq = &to_nuc_seq(qry_seq_str).wrap_err("When converting query sequence")?;
 
     match nextclade_run_one(
+      *qry_index,
       qry_seq_name,
       qry_seq,
       &self.ref_seq,

--- a/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
+++ b/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
@@ -90,6 +90,7 @@ async function analyze(record: FastaRecord): Promise<NextcladeResult> {
   const { index, seqName, seq } = record
 
   const input = AnalysisInput.from_js({
+    qry_index: index,
     qry_seq_name: seqName,
     qry_seq_str: seq,
   })

--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -52,7 +52,9 @@ pub fn align_nuc(
         let mut qry_seq = qry_seq.to_owned();
         reverse_complement_in_place(&mut qry_seq);
         let stripes = seed_alignment(&qry_seq, ref_seq, params).map_err(|_| report)?;
-        Ok(align_pairwise(&qry_seq, ref_seq, gap_open_close, params, &stripes))
+        let mut result = align_pairwise(&qry_seq, ref_seq, gap_open_close, params, &stripes);
+        result.is_reverse_complement = true;
+        Ok(result)
       } else {
         Err(report)
       }

--- a/packages_rs/nextclade/src/align/backtrace.rs
+++ b/packages_rs/nextclade/src/align/backtrace.rs
@@ -14,6 +14,7 @@ pub struct AlignmentOutput<T> {
   pub qry_seq: Vec<T>,
   pub ref_seq: Vec<T>,
   pub alignment_score: i32,
+  pub is_reverse_complement: bool,
 }
 
 pub fn backtrace<T: Letter<T>>(
@@ -89,6 +90,7 @@ pub fn backtrace<T: Letter<T>>(
     qry_seq: aln_qry,
     ref_seq: aln_ref,
     alignment_score: scores[(num_rows - 1, num_cols - 1)],
+    is_reverse_complement: false,
   }
 }
 
@@ -156,6 +158,7 @@ mod tests {
       qry_seq: to_nuc_seq("---CTCGCT")?,
       ref_seq: to_nuc_seq("ACGCTCGCT")?,
       alignment_score: 18,
+      is_reverse_complement: false
     };
 
     let output = backtrace(&qry_seq, &ref_seq, &scores, &paths);

--- a/packages_rs/nextclade/src/align/params.rs
+++ b/packages_rs/nextclade/src/align/params.rs
@@ -13,6 +13,7 @@ pub enum GapAlignmentSide {
 // as well as adds a method `.merge_opt(&opt)` to the original struct, which merges values from the optional counterpart
 // into self (mutably).
 
+#[allow(clippy::struct_excessive_bools)]
 #[optfield(pub AlignPairwiseParamsOptional, attrs, doc, field_attrs, field_doc, merge_fn = pub)]
 #[derive(Parser, Debug, Clone, Serialize, Deserialize)]
 pub struct AlignPairwiseParams {
@@ -70,8 +71,12 @@ pub struct AlignPairwiseParams {
   #[clap(long)]
   pub seed_spacing: i32,
 
+  /// Retry seed matching step with a reverse complement if the first attempt failed
+  #[clap(long, takes_value = false, forbid_empty_values = false, default_missing_value = "true")]
+  pub retry_reverse_complement: bool,
+
   /// If this flag is present, the amino acid sequences will be truncated at the first stop codon, if mutations or sequencing errors cause premature stop codons to be present. No amino acid mutations in the truncated region will be recorded.
-  #[clap(long)]
+  #[clap(long, takes_value = false, forbid_empty_values = false, default_missing_value = "true")]
   pub no_translate_past_stop: bool,
 
   // Internal alignment parameter
@@ -112,6 +117,7 @@ impl Default for AlignPairwiseParams {
       min_match_rate: 0.3,
       seed_spacing: 100,
       mismatches_allowed: 3,
+      retry_reverse_complement: false,
       no_translate_past_stop: false,
       left_terminal_gaps_free: true,
       right_terminal_gaps_free: true,

--- a/packages_rs/nextclade/src/constants.rs
+++ b/packages_rs/nextclade/src/constants.rs
@@ -1,0 +1,1 @@
+pub const REVERSE_COMPLEMENT_SUFFIX: &str = " |(reverse complement)";

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -86,6 +86,7 @@ static NEXTCLADE_CSV_HEADERS: &[&str] = &[
   "qc.stopCodons.totalStopCodons",
   "qc.stopCodons.score",
   "qc.stopCodons.status",
+  "isReverseComplement",
   // "failedGenes",
   // "warnings",
   "errors",
@@ -169,6 +170,7 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
       // divergence,
       qc,
       custom_node_attributes,
+      is_reverse_complement,
       ..
     } = nextclade_outputs;
 
@@ -365,6 +367,7 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
       "qc.stopCodons.status",
       qc.stop_codons.as_ref().map(|sc| sc.status.to_string()),
     )?;
+    self.add_entry("isReverseComplement", &is_reverse_complement.to_string())?;
     // self.add_entry("failedGenes", &format_failed_genes(missing_genes, ARRAY_ITEM_DELIMITER))?;
     // self.add_entry("warnings", &format_aa_warnings(translations, ARRAY_ITEM_DELIMITER))?;
     self.add_entry("errors", &"")?;

--- a/packages_rs/nextclade/src/lib.rs
+++ b/packages_rs/nextclade/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod align;
 pub mod analyze;
+pub mod constants;
 pub mod gene;
 pub mod io;
 pub mod qc;

--- a/packages_rs/nextclade/src/run/nextalign_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextalign_run_one.rs
@@ -51,12 +51,15 @@ pub fn nextalign_run_one(
         .cloned()
         .collect_vec();
 
+      let is_reverse_complement = alignment.is_reverse_complement;
+
       Ok(NextalignOutputs {
         stripped,
         alignment,
         translations,
         warnings,
         missing_genes,
+        is_reverse_complement,
       })
     }
   }

--- a/packages_rs/nextclade/src/run/nextalign_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextalign_run_one.rs
@@ -11,6 +11,8 @@ use itertools::{Either, Itertools};
 use std::collections::HashSet;
 
 pub fn nextalign_run_one(
+  index: usize,
+  seq_name: &str,
   qry_seq: &[Nuc],
   ref_seq: &[Nuc],
   ref_peptides: &TranslationMap,
@@ -19,7 +21,7 @@ pub fn nextalign_run_one(
   gap_open_close_aa: &[i32],
   params: &AlignPairwiseParams,
 ) -> Result<NextalignOutputs, Report> {
-  match align_nuc(qry_seq, ref_seq, gap_open_close_nuc, params) {
+  match align_nuc(index, seq_name, qry_seq, ref_seq, gap_open_close_nuc, params) {
     Err(report) => Err(report),
 
     Ok(alignment) => {

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -28,6 +28,7 @@ use crate::types::outputs::{NextalignOutputs, NextcladeOutputs};
 use eyre::Report;
 
 pub fn nextclade_run_one(
+  index: usize,
   seq_name: &str,
   qry_seq: &[Nuc],
   ref_seq: &[Nuc],
@@ -49,6 +50,8 @@ pub fn nextclade_run_one(
     missing_genes,
     is_reverse_complement,
   } = nextalign_run_one(
+    index,
+    seq_name,
     qry_seq,
     ref_seq,
     ref_peptides,
@@ -166,6 +169,7 @@ pub fn nextclade_run_one(
     stripped.qry_seq,
     translations,
     NextcladeOutputs {
+      index,
       seq_name,
       substitutions,
       total_substitutions,

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -12,6 +12,7 @@ use crate::analyze::nuc_changes::{find_nuc_changes, FindNucChangesOutput};
 use crate::analyze::pcr_primer_changes::get_pcr_primer_changes;
 use crate::analyze::pcr_primers::PcrPrimer;
 use crate::analyze::virus_properties::VirusProperties;
+use crate::constants::REVERSE_COMPLEMENT_SUFFIX;
 use crate::io::aa::Aa;
 use crate::io::gene_map::GeneMap;
 use crate::io::letter::Letter;
@@ -46,6 +47,7 @@ pub fn nextclade_run_one(
     translations,
     warnings,
     missing_genes,
+    is_reverse_complement,
   } = nextalign_run_one(
     qry_seq,
     ref_seq,
@@ -154,11 +156,17 @@ pub fn nextclade_run_one(
     qc_config,
   );
 
+  let seq_name = if is_reverse_complement {
+    format!("{seq_name}{REVERSE_COMPLEMENT_SUFFIX}")
+  } else {
+    seq_name.to_owned()
+  };
+
   Ok((
     stripped.qry_seq,
     translations,
     NextcladeOutputs {
-      seq_name: seq_name.to_owned(),
+      seq_name,
       substitutions,
       total_substitutions,
       deletions,
@@ -195,6 +203,7 @@ pub fn nextclade_run_one(
       qc,
       custom_node_attributes: clade_node_attrs,
       nearest_node_id,
+      is_reverse_complement,
     },
   ))
 }

--- a/packages_rs/nextclade/src/translate/translate_genes.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes.rs
@@ -176,7 +176,7 @@ pub fn translate_gene(
     &aa_params,
     band_width,
     mean_shift,
-  )?;
+  );
 
   let mut stripped = insertions_strip(&alignment.qry_seq, &alignment.ref_seq);
 

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -37,6 +37,7 @@ pub struct NextalignOutputs {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NextcladeOutputs {
+  pub index: usize,
   pub seq_name: String,
   pub substitutions: Vec<NucSubFull>,
   pub total_substitutions: usize,

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -31,6 +31,7 @@ pub struct NextalignOutputs {
   pub translations: Vec<Translation>,
   pub warnings: Vec<PeptideWarning>,
   pub missing_genes: Vec<String>,
+  pub is_reverse_complement: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,6 +76,7 @@ pub struct NextcladeOutputs {
   pub qc: QcResult,
   pub custom_node_attributes: BTreeMap<String, String>,
   pub nearest_node_id: usize,
+  pub is_reverse_complement: bool,
 }
 
 impl NextcladeOutputs {


### PR DESCRIPTION
Adds flag `--retry-reverse-complement` which enables additional attempt of seed matching when initial attempt fails. The second attempt is performed on reverse-complemented sequence.

If the flag is provided, as a consequence:
 - the output alignment, peptides and analysis results correspond to this modified sequence and not to the original
 - sequence name gets a suffix appended to it for all output files (fasta, `seqName` column, node name on the tree etc.)
 - in output files, there is a new field/column: `isReverseComplement`, which contains "true" if the corresponding sequence underwent reverse-complement transformation

This functionality is opt-in and the default behavior is unchanged: skip sequence and emit a warning.

