### PR TITLE
fix(cli): avoid errors when certain subcommands are invoked

### DIFF
--- a/packages_rs/nextclade-cli/src/bin/nextalign.rs
+++ b/packages_rs/nextclade-cli/src/bin/nextalign.rs
@@ -1,9 +1,7 @@
 use ctor::ctor;
 use eyre::Report;
-use nextclade::make_internal_error;
 use nextclade::utils::global_init::global_init;
-use nextclade_cli::cli::nextalign_cli::{nextalign_parse_cli_args, NextalignCommands};
-use nextclade_cli::cli::nextalign_loop::nextalign_run;
+use nextclade_cli::cli::nextalign_cli::nextalign_handle_cli_args;
 
 #[cfg(all(target_family = "linux", target_arch = "x86_64"))]
 #[global_allocator]
@@ -15,11 +13,5 @@ fn init() {
 }
 
 fn main() -> Result<(), Report> {
-  let args = nextalign_parse_cli_args()?;
-
-  if let NextalignCommands::Run { 0: run_args } = args.command {
-    nextalign_run(*run_args)
-  } else {
-    make_internal_error!("Unhandled CLI subcommand. Subcommand handling must be exhaustive")
-  }
+  nextalign_handle_cli_args()
 }

--- a/packages_rs/nextclade-cli/src/bin/nextclade.rs
+++ b/packages_rs/nextclade-cli/src/bin/nextclade.rs
@@ -1,11 +1,7 @@
 use ctor::ctor;
 use eyre::Report;
-use nextclade::make_internal_error;
 use nextclade::utils::global_init::global_init;
-use nextclade_cli::cli::nextclade_cli::{nextclade_parse_cli_args, NextcladeCommands, NextcladeDatasetCommands};
-use nextclade_cli::cli::nextclade_dataset_get::nextclade_dataset_get;
-use nextclade_cli::cli::nextclade_dataset_list::nextclade_dataset_list;
-use nextclade_cli::cli::nextclade_loop::nextclade_run;
+use nextclade_cli::cli::nextclade_cli::nextclade_parse_cli_args;
 
 #[cfg(all(target_family = "linux", target_arch = "x86_64"))]
 #[global_allocator]
@@ -17,14 +13,5 @@ fn init() {
 }
 
 fn main() -> Result<(), Report> {
-  let args = nextclade_parse_cli_args()?;
-
-  match args.command {
-    NextcladeCommands::Run(run_args) => nextclade_run(run_args),
-    NextcladeCommands::Dataset(dataset_command) => match dataset_command.command {
-      NextcladeDatasetCommands::List(dataset_list_args) => nextclade_dataset_list(dataset_list_args),
-      NextcladeDatasetCommands::Get(dataset_get_args) => nextclade_dataset_get(dataset_get_args),
-    },
-    _ => make_internal_error!("Unhandled CLI subcommand. Subcommand handling must be exhaustive"),
-  }
+  nextclade_parse_cli_args()
 }

--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -1,3 +1,4 @@
+use crate::cli::nextalign_loop::nextalign_run;
 use crate::cli::verbosity::{Verbosity, WarnLevel};
 use clap::{AppSettings, ArgEnum, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Generator, Shell};
@@ -453,20 +454,19 @@ pub fn nextalign_check_removed_args(run_args: &mut NextalignRunArgs) -> Result<(
   Ok(())
 }
 
-pub fn nextalign_parse_cli_args() -> Result<NextalignArgs, Report> {
-  let mut args = NextalignArgs::parse();
+pub fn nextalign_handle_cli_args() -> Result<(), Report> {
+  let args = NextalignArgs::parse();
 
   setup_logger(args.verbosity.get_filter_level());
 
-  match &mut args.command {
+  match args.command {
     NextalignCommands::Completions { shell } => {
-      generate_completions(shell).wrap_err_with(|| format!("When generating completions for shell '{shell}'"))?;
+      generate_completions(&shell).wrap_err_with(|| format!("When generating completions for shell '{shell}'"))
     }
-    NextalignCommands::Run(ref mut run_args) => {
-      nextalign_check_removed_args(run_args)?;
-      nextalign_get_output_filenames(run_args).wrap_err("When deducing output filenames")?;
+    NextalignCommands::Run(mut run_args) => {
+      nextalign_check_removed_args(&mut run_args)?;
+      nextalign_get_output_filenames(&mut run_args).wrap_err("When deducing output filenames")?;
+      nextalign_run(*run_args)
     }
   }
-
-  Ok(args)
 }


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/899

This consolidates subcommand handling on one place and prevents inconsistencies when certain subommands need to be handled in 2 places but it's not done, causing a crash.

