### PR TITLE
Fix CLI dataset table on Windows

### DIFF
--- a/packages_rs/nextclade-cli/src/dataset/dataset_table.rs
+++ b/packages_rs/nextclade-cli/src/dataset/dataset_table.rs
@@ -5,13 +5,24 @@ use comfy_table::{ContentArrangement, Table};
 use indexmap::IndexMap;
 use itertools::Itertools;
 
-pub fn format_dataset_table(filtered: &[Dataset]) -> String {
+pub fn get_table() -> Table {
+  #[allow(unused_mut)]
   let mut table = Table::new();
+
+  #[cfg(unix)]
+  {
+    table
+      .load_preset(UTF8_FULL)
+      .apply_modifier(UTF8_ROUND_CORNERS)
+      .apply_modifier(UTF8_SOLID_INNER_BORDERS)
+      .set_content_arrangement(ContentArrangement::Dynamic);
+  }
+
   table
-    .load_preset(UTF8_FULL)
-    .apply_modifier(UTF8_ROUND_CORNERS)
-    .apply_modifier(UTF8_SOLID_INNER_BORDERS)
-    .set_content_arrangement(ContentArrangement::Dynamic);
+}
+
+pub fn format_dataset_table(filtered: &[Dataset]) -> String {
+  let mut table = get_table();
 
   table.set_header([
     "name".to_owned(),


### PR DESCRIPTION
Here I attempt to fix https://github.com/nextstrain/nextclade/issues/903

No luck so far. Disabling `Utf8` profile and other niceties leads to ASCII-formatted table, which is equally unreadable, just with ASCII borders, instead of nice UTF-8 lines.

So the lines might not be the problem here.

Needs more work.

