### PR TITLE
fix: mixed up input-prc and input-virus-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# CHANGELOG
+
+## NEXT
+
+- **Fix** [[#908](https://github.com/nextstrain/nextclade/issues/908): Files passed as `--input-virus-properties` were interpreted like passed to `--input-pcr-primers` and vice versa (report: @BCArg, fix: @CorneliusRoemer)
+
 ## Nextclade 2.0.0
 
 ### Rust

--- a/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
@@ -157,8 +157,8 @@ pub fn dataset_individual_files_load(
       (_, Some(input_tree)),
       (_, Some(input_gene_map)),
       (_, Some(input_qc_config)),
-      (_, Some(input_virus_properties)),
       (_, Some(input_pcr_primers)),
+      (_, Some(input_virus_properties)),
     ] => {
       dataset_load_files(DatasetFilePaths {
         input_ref,


### PR DESCRIPTION
Resolves #908 

Positional args in Rust tripped us up here, maybe there's a less bug-prone way to do this.

I'm still wondering though: why is there no error when the default dataset is passed? Surely there must still be a file parsing problem. Do we quietly not overwrite then? That's not great. We should still throw an error if someone wants to overwrite but the file they're overwriting with is bad.