### PR TITLE
fix(cli): prevent truncation of  components if basename contains dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
-## NEXT
+## Nextclade CLI 2.0.1
+
+- **Fix** [[#907]]](https://github.com/nextstrain/nextclade/issues/907): If `--ouput-basename` contains dots, the last component is no longer omitted
 
 - **Fix** [[#908](https://github.com/nextstrain/nextclade/issues/908): Files passed as `--input-virus-properties` were interpreted like passed to `--input-pcr-primers` and vice versa (report: @BCArg, fix: @CorneliusRoemer)
 

--- a/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_cli.rs
@@ -7,6 +7,7 @@ use eyre::{eyre, ContextCompat, Report, WrapErr};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use nextclade::align::params::AlignPairwiseParamsOptional;
+use nextclade::io::fs::add_extension;
 use nextclade::make_error;
 use nextclade::utils::global_init::setup_logger;
 use std::fmt::Debug;
@@ -346,23 +347,23 @@ pub fn nextalign_get_output_filenames(run_args: &mut NextalignRunArgs) -> Result
     // to set default output filenames only if they are not provided.
 
     if output_selection.contains(&NextalignOutputSelection::Fasta) {
-      output_fasta.get_or_insert(default_output_file_path.with_extension("aligned.fasta"));
+      output_fasta.get_or_insert(add_extension(&default_output_file_path, "aligned.fasta"));
     }
 
     if output_selection.contains(&NextalignOutputSelection::Insertions) {
       let output_insertions =
-        output_insertions.get_or_insert(default_output_file_path.with_extension("insertions.csv"));
+        output_insertions.get_or_insert(add_extension(&default_output_file_path, "insertions.csv"));
     }
 
     if output_selection.contains(&NextalignOutputSelection::Errors) {
-      let output_errors = output_errors.get_or_insert(default_output_file_path.with_extension("errors.csv"));
+      let output_errors = output_errors.get_or_insert(add_extension(&default_output_file_path, "errors.csv"));
     }
 
     if output_selection.contains(&NextalignOutputSelection::Translations) {
       let output_translations = {
-        let output_translations_path = default_output_file_path
-          .with_file_name(format!("{output_basename}_gene_{{gene}}"))
-          .with_extension("translation.fasta");
+        let output_translations_path =
+          default_output_file_path.with_file_name(format!("{output_basename}_gene_{{gene}}"));
+        let output_translations_path = add_extension(&output_translations_path, "translation.fasta");
 
         let output_translations_template = output_translations_path
           .to_str()

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -10,6 +10,7 @@ use eyre::{eyre, ContextCompat, Report, WrapErr};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use nextclade::align::params::AlignPairwiseParamsOptional;
+use nextclade::io::fs::add_extension;
 use nextclade::utils::global_init::setup_logger;
 use nextclade::{getenv, make_error};
 use std::fmt::Debug;
@@ -628,21 +629,21 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
     // to set default output filenames only if they are not provided.
 
     if output_selection.contains(&NextcladeOutputSelection::Fasta) {
-      output_fasta.get_or_insert(default_output_file_path.with_extension("aligned.fasta"));
+      output_fasta.get_or_insert(add_extension(&default_output_file_path, "aligned.fasta"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Insertions) {
-      output_insertions.get_or_insert(default_output_file_path.with_extension("insertions.csv"));
+      output_insertions.get_or_insert(add_extension(&default_output_file_path, "insertions.csv"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Errors) {
-      output_errors.get_or_insert(default_output_file_path.with_extension("errors.csv"));
+      output_errors.get_or_insert(add_extension(&default_output_file_path, "errors.csv"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Translations) {
-      let output_translations_path = default_output_file_path
-        .with_file_name(format!("{output_basename}_gene_{{gene}}"))
-        .with_extension("translation.fasta");
+      let output_translations_path =
+        default_output_file_path.with_file_name(format!("{output_basename}_gene_{{gene}}"));
+      let output_translations_path = add_extension(&output_translations_path, "translation.fasta");
 
       let output_translations_template = output_translations_path
         .to_str()
@@ -653,23 +654,23 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Ndjson) {
-      output_ndjson.get_or_insert(default_output_file_path.with_extension("ndjson"));
+      output_ndjson.get_or_insert(add_extension(&default_output_file_path, "ndjson"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Json) {
-      output_json.get_or_insert(default_output_file_path.with_extension("json"));
+      output_json.get_or_insert(add_extension(&default_output_file_path, "json"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Csv) {
-      output_csv.get_or_insert(default_output_file_path.with_extension("csv"));
+      output_csv.get_or_insert(add_extension(&default_output_file_path, "csv"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Tsv) {
-      output_tsv.get_or_insert(default_output_file_path.with_extension("tsv"));
+      output_tsv.get_or_insert(add_extension(&default_output_file_path, "tsv"));
     }
 
     if output_selection.contains(&NextcladeOutputSelection::Tree) {
-      output_tree.get_or_insert(default_output_file_path.with_extension("auspice.json"));
+      output_tree.get_or_insert(add_extension(&default_output_file_path, "auspice.json"));
     }
   }
 

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -1,5 +1,5 @@
 use eyre::{eyre, Report, WrapErr};
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -46,6 +46,27 @@ pub fn extension(filepath: impl AsRef<Path>) -> Option<String> {
 
 pub fn has_extension(filepath: impl AsRef<Path>, ext: impl AsRef<str>) -> bool {
   extension(filepath.as_ref()).map_or(false, |fext| fext.eq_ignore_ascii_case(ext.as_ref()))
+}
+
+pub fn add_extension(filepath: impl AsRef<Path>, extension: impl AsRef<OsStr>) -> PathBuf {
+  let filepath = filepath.as_ref();
+  let extension = extension.as_ref();
+
+  if filepath.file_name().is_none() {
+    return filepath.to_owned();
+  }
+
+  let mut stem = match filepath.file_name() {
+    Some(stem) => stem.to_os_string(),
+    None => OsString::new(),
+  };
+
+  if !extension.is_empty() {
+    stem.push(".");
+    stem.push(extension);
+  }
+
+  filepath.to_owned().with_file_name(&stem)
 }
 
 /// Reads entire file into a string.


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/907

This rolls an in-house version of `add_extension()` function which always adds an extension to a `PathBuf`.  This is different from `PathBuf::with_extension()` which may replace or add extension depending on what the path is.

This solves a problem with basenames containing dots, as described in the issue: `PathBuf::with_extension()` thought that they are extensions and replaced the last one. But we always want to add, not replace.

