### PR TITLE
feat: remove reverse complement suffix from outputs except nuc fasta

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
@@ -1,7 +1,6 @@
 use crate::cli::nextalign_loop::NextalignRecord;
 use eyre::{Report, WrapErr};
 use log::warn;
-use nextclade::constants::REVERSE_COMPLEMENT_SUFFIX;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
 use nextclade::io::gene_map::GeneMap;
@@ -59,7 +58,7 @@ impl<'a> NextalignOrderedWriter<'a> {
     let FastaRecord { seq_name, seq, .. } = &ref_record;
 
     if let Some(fasta_writer) = &mut self.fasta_writer {
-      fasta_writer.write(seq_name, seq)?;
+      fasta_writer.write(seq_name, seq, false)?;
     }
 
     ref_peptides.iter().try_for_each(|(_, peptide)| {
@@ -91,14 +90,8 @@ impl<'a> NextalignOrderedWriter<'a> {
           is_reverse_complement,
         } = output;
 
-        let seq_name = if *is_reverse_complement {
-          format!("{seq_name}{REVERSE_COMPLEMENT_SUFFIX}")
-        } else {
-          seq_name.clone()
-        };
-
         if let Some(fasta_writer) = &mut self.fasta_writer {
-          fasta_writer.write(&seq_name, &from_nuc_seq(&stripped.qry_seq))?;
+          fasta_writer.write(&seq_name, &from_nuc_seq(&stripped.qry_seq), *is_reverse_complement)?;
         }
 
         if let Some(fasta_peptide_writer) = &mut self.fasta_peptide_writer {

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -2,7 +2,6 @@ use crate::cli::nextclade_loop::NextcladeRecord;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::warn;
-use nextclade::constants::REVERSE_COMPLEMENT_SUFFIX;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
 use nextclade::io::gene_map::GeneMap;
@@ -92,7 +91,7 @@ impl<'a> NextcladeOrderedWriter<'a> {
     let FastaRecord { seq_name, seq, .. } = &ref_record;
 
     if let Some(fasta_writer) = &mut self.fasta_writer {
-      fasta_writer.write(seq_name, seq)?;
+      fasta_writer.write(seq_name, seq, false)?;
     }
 
     ref_peptides.iter().try_for_each(|(_, peptide)| {
@@ -123,14 +122,8 @@ impl<'a> NextcladeOrderedWriter<'a> {
           ..
         } = &nextclade_outputs;
 
-        let seq_name = if *is_reverse_complement {
-          format!("{seq_name}{REVERSE_COMPLEMENT_SUFFIX}")
-        } else {
-          seq_name.clone()
-        };
-
         if let Some(fasta_writer) = &mut self.fasta_writer {
-          fasta_writer.write(&seq_name, &from_nuc_seq(&qry_seq_stripped))?;
+          fasta_writer.write(&seq_name, &from_nuc_seq(&qry_seq_stripped), *is_reverse_complement)?;
         }
 
         if let Some(fasta_peptide_writer) = &mut self.fasta_peptide_writer {

--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -56,7 +56,7 @@ pub fn align_nuc(
         let stripes = seed_alignment(&qry_seq, ref_seq, params).map_err(|_| report)?;
         let mut result = align_pairwise(&qry_seq, ref_seq, gap_open_close, params, &stripes);
         result.is_reverse_complement = true;
-        warn!("When processing sequence #{index} '{seq_name}': Sequence is reverse-complemented: Seed matching failed for the original sequence, but succeeded for its reverse complement. Outputs will be derived from the reverse complement and 'reverse complement' suffix will be added to sequence ID.");
+        warn!("When processing sequence #{index} '{seq_name}': Sequence is reverse-complemented: Seed matching failed for the original sequence, but succeeded for its reverse complement. Outputs will be derived from the reverse complement and 'reverse complement' suffix will be added to the fasta header in the nucleotide alignment.");
         Ok(result)
       } else {
         Err(report)

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -1,3 +1,4 @@
+use crate::constants::REVERSE_COMPLEMENT_SUFFIX;
 use crate::io::aa::from_aa_seq;
 use crate::io::compression::Decompressor;
 use crate::io::concat::concat;
@@ -188,8 +189,14 @@ impl FastaWriter {
     Ok(Self::new(create_file(filepath)?))
   }
 
-  pub fn write(&mut self, name: &str, seq: &str) -> Result<(), Report> {
-    write!(self.writer, ">{name}\n{seq}\n")?;
+  pub fn write(&mut self, seq_name: &str, seq: &str, is_reverse_complement: bool) -> Result<(), Report> {
+    let seq_name = if is_reverse_complement {
+      format!("{seq_name}{REVERSE_COMPLEMENT_SUFFIX}")
+    } else {
+      seq_name.to_owned()
+    };
+
+    write!(self.writer, ">{seq_name}\n{seq}\n")?;
     Ok(())
   }
 
@@ -239,7 +246,7 @@ impl FastaPeptideWriter {
   pub fn write(&mut self, seq_name: &str, translation: &Translation) -> Result<(), Report> {
     match self.writers.get_mut(&translation.gene_name) {
       None => make_internal_error!("Fasta file writer not found for gene '{}'", &translation.gene_name),
-      Some(writer) => writer.write(seq_name, &from_aa_seq(&translation.seq)),
+      Some(writer) => writer.write(seq_name, &from_aa_seq(&translation.seq), false),
     }
   }
 }

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -12,7 +12,6 @@ use crate::analyze::nuc_changes::{find_nuc_changes, FindNucChangesOutput};
 use crate::analyze::pcr_primer_changes::get_pcr_primer_changes;
 use crate::analyze::pcr_primers::PcrPrimer;
 use crate::analyze::virus_properties::VirusProperties;
-use crate::constants::REVERSE_COMPLEMENT_SUFFIX;
 use crate::io::aa::Aa;
 use crate::io::gene_map::GeneMap;
 use crate::io::letter::Letter;
@@ -159,18 +158,12 @@ pub fn nextclade_run_one(
     qc_config,
   );
 
-  let seq_name = if is_reverse_complement {
-    format!("{seq_name}{REVERSE_COMPLEMENT_SUFFIX}")
-  } else {
-    seq_name.to_owned()
-  };
-
   Ok((
     stripped.qry_seq,
     translations,
     NextcladeOutputs {
       index,
-      seq_name,
+      seq_name: seq_name.to_owned(),
       substitutions,
       total_substitutions,
       deletions,


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/887

We reconsidered: we will only append suffix to sequence names in aligned fasta output. So this removes the suffix from all other places (incl. translation fastas).

