### PR TITLE
fix: write failed sequence results (errors) to into outputs

### DIFF
--- a/docs/user/output-files.md
+++ b/docs/user/output-files.md
@@ -105,6 +105,8 @@ Every row in tabular output corresponds to 1 input sequence. The meaning of colu
 | qc.stopCodons.status                            | Status for "Stop codons" QC rule                                                                           |
 | isReverseComplement                             | Whether query sequences were transformed using reverse complement operation before alignment               | 
 | errors                                          | List of errors during processing                                                                           |
+| warnings                                        | List of warnings during processing                                                                         |
+| failedGenes                                     | List of genes that failed translation                                                                      |
 
 The table can contain additional columns for every clade-like attributes defined in reference tree in `meta.extensions.clade_node_attrs` and in the node attributes. For example, the default SARS-CoV-2 datasets define `Nextclade_pango` attribute which signifies a PANGO lineage assigned by Nextclade (see [Nextclade as pango lineage classifier: Methods and Validation](algorithm/nextclade-pango)).
 
@@ -145,3 +147,19 @@ The file contains the following columns (delimited by commas):
 Nextclade CLI flag: `--output-errors`
 
 A table that, for each sequence, contains a list of warnings, errors as well as a list of genes affected by error. The genes listed in this table are omitted from translation, analysis and FASTA outputs.
+
+## Outputs for failed sequences
+
+When processing of a sequence fails for various reasons, not all output files will contain the corresponding entry (due to limitations of file formats):
+
+| Output file                  | CLI arg                 | Failed entries?  |
+|------------------------------|:------------------------|:-----------------|
+| Aligned nucleotide sequences | `--output-fasta`        | no               |
+| Aligned peptides             | `--output-translations` | no               |
+| Auspice tree JSON            | `--output-tree`         | no               |
+| Analysis results CSV         | `--output-csv`          | yes              |
+| Analysis results TSV         | `--output-tsv`          | yes              |
+| Analysis results NDJSON      | `--output-ndjson`       | yes              |
+| Analysis results JSON        | `--output-json`         | yes              |
+| Insertions CSV               | `--output-insertions`   | yes              |
+| Errors CSV                   | `--output-errors`       | yes              |

--- a/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
@@ -114,6 +114,9 @@ impl<'a> NextalignOrderedWriter<'a> {
           "In sequence #{index} '{seq_name}': {cause}. Note that this sequence will not be included in the results."
         );
         warn!("{message}");
+        if let Some(insertions_csv_writer) = &mut self.insertions_csv_writer {
+          insertions_csv_writer.write(seq_name, &[], &[])?;
+        }
         if let Some(errors_csv_writer) = &mut self.errors_csv_writer {
           errors_csv_writer.write_nuc_error(seq_name, &message)?;
         }

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -162,6 +162,9 @@ impl<'a> NextcladeOrderedWriter<'a> {
           "In sequence #{index} '{seq_name}': {cause}. Note that this sequence will not be included in the results."
         );
         warn!("{message}");
+        if let Some(insertions_csv_writer) = &mut self.insertions_csv_writer {
+          insertions_csv_writer.write(&seq_name, &[], &[])?;
+        }
         if let Some(errors_csv_writer) = &mut self.errors_csv_writer {
           errors_csv_writer.write_nuc_error(&seq_name, &message)?;
         }

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -165,6 +165,12 @@ impl<'a> NextcladeOrderedWriter<'a> {
         if let Some(errors_csv_writer) = &mut self.errors_csv_writer {
           errors_csv_writer.write_nuc_error(&seq_name, &message)?;
         }
+        if let Some(output_csv_writer) = &mut self.output_csv_writer {
+          output_csv_writer.write_nuc_error(&seq_name, &message)?;
+        }
+        if let Some(output_tsv_writer) = &mut self.output_tsv_writer {
+          output_tsv_writer.write_nuc_error(&seq_name, &message)?;
+        }
       }
     }
 

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -158,27 +158,26 @@ impl<'a> NextcladeOrderedWriter<'a> {
       }
       Err(report) => {
         let cause = report_to_string(&report);
-        let message = format!(
+        warn!(
           "In sequence #{index} '{seq_name}': {cause}. Note that this sequence will not be included in the results."
         );
-        warn!("{message}");
         if let Some(insertions_csv_writer) = &mut self.insertions_csv_writer {
           insertions_csv_writer.write(&seq_name, &[], &[])?;
         }
         if let Some(errors_csv_writer) = &mut self.errors_csv_writer {
-          errors_csv_writer.write_nuc_error(&seq_name, &message)?;
+          errors_csv_writer.write_nuc_error(&seq_name, &cause)?;
         }
         if let Some(output_csv_writer) = &mut self.output_csv_writer {
-          output_csv_writer.write_nuc_error(&seq_name, &message)?;
+          output_csv_writer.write_nuc_error(&seq_name, &cause)?;
         }
         if let Some(output_tsv_writer) = &mut self.output_tsv_writer {
-          output_tsv_writer.write_nuc_error(&seq_name, &message)?;
+          output_tsv_writer.write_nuc_error(&seq_name, &cause)?;
         }
         if let Some(output_ndjson_writer) = &mut self.output_ndjson_writer {
-          output_ndjson_writer.write_nuc_error(index, &seq_name, &message)?;
+          output_ndjson_writer.write_nuc_error(index, &seq_name, &[cause.clone()])?;
         }
         if let Some(output_json_writer) = &mut self.output_json_writer {
-          output_json_writer.write_nuc_error(index, &seq_name, &message);
+          output_json_writer.write_nuc_error(index, &seq_name, &[cause]);
         }
       }
     }

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -171,6 +171,12 @@ impl<'a> NextcladeOrderedWriter<'a> {
         if let Some(output_tsv_writer) = &mut self.output_tsv_writer {
           output_tsv_writer.write_nuc_error(&seq_name, &message)?;
         }
+        if let Some(output_ndjson_writer) = &mut self.output_ndjson_writer {
+          output_ndjson_writer.write_nuc_error(index, &seq_name, &message)?;
+        }
+        if let Some(output_json_writer) = &mut self.output_json_writer {
+          output_json_writer.write_nuc_error(index, &seq_name, &message);
+        }
       }
     }
 

--- a/packages_rs/nextclade-web/src/algorithms/types.ts
+++ b/packages_rs/nextclade-web/src/algorithms/types.ts
@@ -386,7 +386,7 @@ export interface AnalysisResult {
 export interface AnalysisError {
   index: number
   seqName: string
-  message: string
+  errors: string[]
 }
 
 export interface ErrorsFromWeb {

--- a/packages_rs/nextclade-web/src/algorithms/types.ts
+++ b/packages_rs/nextclade-web/src/algorithms/types.ts
@@ -383,6 +383,12 @@ export interface AnalysisResult {
   missingGenes: string[]
 }
 
+export interface AnalysisError {
+  index: number
+  seqName: string
+  message: string
+}
+
 export interface ErrorsFromWeb {
   seqName: string
   errors: string

--- a/packages_rs/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages_rs/nextclade-web/src/hooks/useExportResults.ts
@@ -151,7 +151,8 @@ export function useExportTree() {
 
 async function prepareInsertionsCsv(snapshot: Snapshot, worker: ExportWorker) {
   const results = await mapGoodResults(snapshot, (result) => result.analysisResult)
-  return worker.serializeInsertionsCsv(results)
+  const errors = await mapErrors(snapshot, (err) => err)
+  return worker.serializeInsertionsCsv(results, errors)
 }
 
 export function useExportInsertionsCsv() {

--- a/packages_rs/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages_rs/nextclade-web/src/hooks/useExportResults.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-void,unicorn/no-await-expression-member,no-loops/no-loops,sonarjs/no-duplicate-string */
 import { Snapshot, useRecoilCallback } from 'recoil'
 
-import type { AnalysisOutput, ErrorsFromWeb } from 'src/algorithms/types'
+import type { AnalysisError, AnalysisOutput, ErrorsFromWeb } from 'src/algorithms/types'
 import type { ExportParams } from 'src/components/Results/ExportDialogButton'
 import { ErrorInternal } from 'src/helpers/ErrorInternal'
 import { notUndefined } from 'src/helpers/notUndefined'
@@ -58,6 +58,19 @@ async function mapGoodResults<T>(snapshot: Snapshot, mapFn: (result: AnalysisOut
     })
 }
 
+async function mapErrors<T>(snapshot: Snapshot, mapFn: (result: AnalysisError) => T) {
+  const results = await snapshot.getPromise(analysisResultsAtom)
+
+  return results
+    .filter((result) => notUndefined(result.error))
+    .map(({ error, seqName, index }) => {
+      if (!error) {
+        throw new ErrorInternal('When preparing analysis errors for export: expected error to be non-nil')
+      }
+      return mapFn({ index, seqName, message: error })
+    })
+}
+
 async function prepareOutputFasta(snapshot: Snapshot) {
   let fastaStr = (
     await mapGoodResults(snapshot, (result) => `>${result.analysisResult.seqName}\n${result.query}`)
@@ -75,8 +88,9 @@ export function useExportFasta() {
 
 async function prepareResultsCsv(snapshot: Snapshot, worker: ExportWorker, delimiter: string) {
   const results = await mapGoodResults(snapshot, (result) => result.analysisResult)
+  const errors = await mapErrors(snapshot, (err) => err)
   const cladeNodeAttrDescs = await snapshot.getPromise(cladeNodeAttrDescsAtom)
-  return worker.serializeResultsCsv(results, cladeNodeAttrDescs, delimiter)
+  return worker.serializeResultsCsv(results, errors, cladeNodeAttrDescs, delimiter)
 }
 
 export function useExportCsv() {
@@ -95,8 +109,9 @@ export function useExportTsv() {
 
 async function prepareResultsJson(snapshot: Snapshot, worker: ExportWorker) {
   const results = await mapGoodResults(snapshot, (result) => result.analysisResult)
+  const errors = await mapErrors(snapshot, (err) => err)
   const cladeNodeAttrDescs = await snapshot.getPromise(cladeNodeAttrDescsAtom)
-  return worker.serializeResultsJson(results, cladeNodeAttrDescs, PACKAGE_VERSION)
+  return worker.serializeResultsJson(results, errors, cladeNodeAttrDescs, PACKAGE_VERSION)
 }
 
 export function useExportJson() {
@@ -108,7 +123,8 @@ export function useExportJson() {
 
 async function prepareResultsNdjson(snapshot: Snapshot, worker: ExportWorker) {
   const results = await mapGoodResults(snapshot, (result) => result.analysisResult)
-  return worker.serializeResultsNdjson(results)
+  const errors = await mapErrors(snapshot, (err) => err)
+  return worker.serializeResultsNdjson(results, errors)
 }
 
 export function useExportNdjson() {

--- a/packages_rs/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages_rs/nextclade-web/src/hooks/useExportResults.ts
@@ -67,7 +67,7 @@ async function mapErrors<T>(snapshot: Snapshot, mapFn: (result: AnalysisError) =
       if (!error) {
         throw new ErrorInternal('When preparing analysis errors for export: expected error to be non-nil')
       }
-      return mapFn({ index, seqName, message: error })
+      return mapFn({ index, seqName, errors: [error] })
     })
 }
 

--- a/packages_rs/nextclade-web/src/wasm/main.rs
+++ b/packages_rs/nextclade-web/src/wasm/main.rs
@@ -147,8 +147,7 @@ impl NextcladeWasm {
     )?;
 
     let errors: Vec<NextcladeErrorOutputs> = jserr(
-      json_parse(errors_json_str)
-        .wrap_err("When serializing results into NDJSON: When parsing errors JSON internally"),
+      json_parse(errors_json_str).wrap_err("When serializing results into NDJSON: When parsing errors JSON internally"),
     )?;
 
     jserr(results_to_ndjson_string(&outputs, &errors))
@@ -183,13 +182,17 @@ impl NextcladeWasm {
     ))
   }
 
-  pub fn serialize_insertions_csv(outputs_json_str: &str) -> Result<String, JsError> {
+  pub fn serialize_insertions_csv(outputs_json_str: &str, errors_json_str: &str) -> Result<String, JsError> {
     let outputs: Vec<NextcladeOutputs> = jserr(
       json_parse(outputs_json_str)
         .wrap_err("When serializing insertions into CSV: When parsing outputs JSON internally"),
     )?;
 
-    jserr(insertions_to_csv_string(&outputs))
+    let errors: Vec<NextcladeErrorOutputs> = jserr(
+      json_parse(errors_json_str).wrap_err("When serializing results into CSV: When parsing errors JSON internally"),
+    )?;
+
+    jserr(insertions_to_csv_string(&outputs, &errors))
   }
 
   pub fn serialize_errors_csv(errors_json_str: &str) -> Result<String, JsError> {

--- a/packages_rs/nextclade-web/src/wasm/main.rs
+++ b/packages_rs/nextclade-web/src/wasm/main.rs
@@ -12,7 +12,7 @@ use nextclade::io::nextclade_csv::results_to_csv_string;
 use nextclade::io::results_json::{results_to_json_string, results_to_ndjson_string};
 use nextclade::qc::qc_config::QcConfig;
 use nextclade::tree::tree::{AuspiceTree, CladeNodeAttrKeyDesc};
-use nextclade::types::outputs::NextcladeOutputs;
+use nextclade::types::outputs::{NextcladeErrorOutputs, NextcladeOutputs};
 use nextclade::utils::error::report_to_string;
 use std::io::Read;
 use std::str::FromStr;
@@ -117,37 +117,55 @@ impl NextcladeWasm {
   #[allow(clippy::needless_pass_by_value)]
   pub fn serialize_results_json(
     outputs_json_str: &str,
+    errors_json_str: &str,
     clade_node_attrs_json_str: &str,
     nextclade_web_version: Option<String>,
   ) -> Result<String, JsError> {
     let outputs: Vec<NextcladeOutputs> = jserr(
       json_parse(outputs_json_str).wrap_err("When serializing results into JSON: When parsing outputs JSON internally"),
     )?;
+
+    let errors: Vec<NextcladeErrorOutputs> = jserr(
+      json_parse(errors_json_str).wrap_err("When serializing results into JSON: When parsing errors JSON internally"),
+    )?;
+
     let clade_node_attrs: Vec<CladeNodeAttrKeyDesc> = jserr(
       json_parse(clade_node_attrs_json_str)
         .wrap_err("When serializing results JSON: When parsing clade node attrs JSON internally"),
     )?;
+
     jserr(
-      results_to_json_string(&outputs, &clade_node_attrs, &nextclade_web_version)
+      results_to_json_string(&outputs, &errors, &clade_node_attrs, &nextclade_web_version)
         .wrap_err("When serializing results JSON"),
     )
   }
 
-  pub fn serialize_results_ndjson(outputs_json_str: &str) -> Result<String, JsError> {
+  pub fn serialize_results_ndjson(outputs_json_str: &str, errors_json_str: &str) -> Result<String, JsError> {
     let outputs: Vec<NextcladeOutputs> = jserr(
       json_parse(outputs_json_str)
         .wrap_err("When serializing results into NDJSON: When parsing outputs JSON internally"),
     )?;
-    jserr(results_to_ndjson_string(&outputs))
+
+    let errors: Vec<NextcladeErrorOutputs> = jserr(
+      json_parse(errors_json_str)
+        .wrap_err("When serializing results into NDJSON: When parsing errors JSON internally"),
+    )?;
+
+    jserr(results_to_ndjson_string(&outputs, &errors))
   }
 
   pub fn serialize_results_csv(
     outputs_json_str: &str,
+    errors_json_str: &str,
     clade_node_attrs_json_str: &str,
     delimiter: char,
   ) -> Result<String, JsError> {
     let outputs: Vec<NextcladeOutputs> = jserr(
       json_parse(outputs_json_str).wrap_err("When serializing results into CSV: When parsing outputs JSON internally"),
+    )?;
+
+    let errors: Vec<NextcladeErrorOutputs> = jserr(
+      json_parse(errors_json_str).wrap_err("When serializing results into CSV: When parsing errors JSON internally"),
     )?;
 
     let clade_node_attrs: Vec<CladeNodeAttrKeyDesc> = jserr(
@@ -157,7 +175,12 @@ impl NextcladeWasm {
 
     let clade_node_attr_keys = clade_node_attrs.into_iter().map(|attr| attr.name).collect_vec();
 
-    jserr(results_to_csv_string(&outputs, &clade_node_attr_keys, delimiter as u8))
+    jserr(results_to_csv_string(
+      &outputs,
+      &errors,
+      &clade_node_attr_keys,
+      delimiter as u8,
+    ))
   }
 
   pub fn serialize_insertions_csv(outputs_json_str: &str) -> Result<String, JsError> {

--- a/packages_rs/nextclade-web/src/workers/ExportThread.ts
+++ b/packages_rs/nextclade-web/src/workers/ExportThread.ts
@@ -1,5 +1,5 @@
 import { CladeNodeAttrDesc } from 'auspice'
-import type { AnalysisResult, ErrorsFromWeb } from 'src/algorithms/types'
+import type { AnalysisError, AnalysisResult, ErrorsFromWeb } from 'src/algorithms/types'
 import type { NextcladeWasmWorker } from 'src/workers/nextcladeWasm.worker'
 import { spawn } from 'src/workers/spawn'
 
@@ -25,22 +25,24 @@ export class ExportWorker {
 
   public async serializeResultsJson(
     outputs: AnalysisResult[],
+    errors: AnalysisError[],
     cladeNodeAttrsJson: CladeNodeAttrDesc[],
     nextcladeWebVersion: string,
   ): Promise<string> {
-    return this.thread.serializeResultsJson(outputs, cladeNodeAttrsJson, nextcladeWebVersion)
+    return this.thread.serializeResultsJson(outputs, errors, cladeNodeAttrsJson, nextcladeWebVersion)
   }
 
   public async serializeResultsCsv(
     results: AnalysisResult[],
+    errors: AnalysisError[],
     cladeNodeAttrsJson: CladeNodeAttrDesc[],
     delimiter: string,
   ) {
-    return this.thread.serializeResultsCsv(results, cladeNodeAttrsJson, delimiter)
+    return this.thread.serializeResultsCsv(results, errors, cladeNodeAttrsJson, delimiter)
   }
 
-  public async serializeResultsNdjson(results: AnalysisResult[]) {
-    return this.thread.serializeResultsNdjson(results)
+  public async serializeResultsNdjson(results: AnalysisResult[], errors: AnalysisError[]) {
+    return this.thread.serializeResultsNdjson(results, errors)
   }
 
   public async serializeInsertionsCsv(results: AnalysisResult[]) {

--- a/packages_rs/nextclade-web/src/workers/ExportThread.ts
+++ b/packages_rs/nextclade-web/src/workers/ExportThread.ts
@@ -45,8 +45,8 @@ export class ExportWorker {
     return this.thread.serializeResultsNdjson(results, errors)
   }
 
-  public async serializeInsertionsCsv(results: AnalysisResult[]) {
-    return this.thread.serializeInsertionsCsv(results)
+  public async serializeInsertionsCsv(results: AnalysisResult[], errors: AnalysisError[]) {
+    return this.thread.serializeInsertionsCsv(results, errors)
   }
 
   public async serializeErrorsCsv(errors: ErrorsFromWeb[]) {

--- a/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
+++ b/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
@@ -220,8 +220,8 @@ export async function serializeResultsCsv(
   )
 }
 
-async function serializeInsertionsCsv(results: AnalysisResult[]) {
-  return NextcladeWasm.serialize_insertions_csv(JSON.stringify(results))
+async function serializeInsertionsCsv(results: AnalysisResult[], errors: AnalysisError[]) {
+  return NextcladeWasm.serialize_insertions_csv(JSON.stringify(results), JSON.stringify(errors))
 }
 
 async function serializeErrorsCsv(errors: ErrorsFromWeb[]) {

--- a/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
+++ b/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
@@ -6,7 +6,14 @@ import type { Thread } from 'threads'
 import { expose } from 'threads/worker'
 import { Observable as ThreadsObservable, Subject } from 'threads/observable'
 
-import type { AnalysisResult, ErrorsFromWeb, FastaRecord, NextcladeResult, Translation } from 'src/algorithms/types'
+import type {
+  AnalysisError,
+  AnalysisResult,
+  ErrorsFromWeb,
+  FastaRecord,
+  NextcladeResult,
+  Translation,
+} from 'src/algorithms/types'
 import type { LaunchAnalysisInitialData } from 'src/workers/launchAnalysis'
 import type { NextcladeParamsPojo, AnalysisOutputPojo } from 'src/gen/nextclade-wasm'
 import { NextcladeWasm, NextcladeParams, AnalysisInput } from 'src/gen/nextclade-wasm'
@@ -183,26 +190,34 @@ export async function parseVirusJsonString(virusJsonStr: string) {
 
 export async function serializeResultsJson(
   outputs: AnalysisResult[],
+  errors: AnalysisError[],
   cladeNodeAttrsJson: CladeNodeAttrDesc[],
   nextcladeWebVersion: string,
 ) {
   return NextcladeWasm.serialize_results_json(
     JSON.stringify(outputs),
+    JSON.stringify(errors),
     JSON.stringify(cladeNodeAttrsJson),
     nextcladeWebVersion,
   )
 }
 
-export async function serializeResultsNdjson(results: AnalysisResult[]) {
-  return NextcladeWasm.serialize_results_ndjson(JSON.stringify(results))
+export async function serializeResultsNdjson(results: AnalysisResult[], errors: AnalysisError[]) {
+  return NextcladeWasm.serialize_results_ndjson(JSON.stringify(results), JSON.stringify(errors))
 }
 
 export async function serializeResultsCsv(
   results: AnalysisResult[],
+  errors: AnalysisError[],
   cladeNodeAttrsJson: CladeNodeAttrDesc[],
   delimiter: string,
 ) {
-  return NextcladeWasm.serialize_results_csv(JSON.stringify(results), JSON.stringify(cladeNodeAttrsJson), delimiter)
+  return NextcladeWasm.serialize_results_csv(
+    JSON.stringify(results),
+    JSON.stringify(errors),
+    JSON.stringify(cladeNodeAttrsJson),
+    delimiter,
+  )
 }
 
 async function serializeInsertionsCsv(results: AnalysisResult[]) {

--- a/packages_rs/nextclade/src/io/insertions_csv.rs
+++ b/packages_rs/nextclade/src/io/insertions_csv.rs
@@ -3,7 +3,9 @@ use crate::io::csv::{CsvStructFileWriter, CsvStructWriter};
 use crate::io::nextclade_csv::{format_aa_insertions, format_aa_insertions_from_translations, format_nuc_insertions};
 use crate::io::nuc::Nuc;
 use crate::translate::translate_genes::Translation;
-use crate::types::outputs::NextcladeOutputs;
+use crate::types::outputs::{
+  combine_outputs_and_errors_sorted, NextcladeErrorOutputs, NextcladeOutputOrError, NextcladeOutputs,
+};
 use eyre::Report;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -43,17 +45,33 @@ impl InsertionsCsvWriter {
   }
 }
 
-pub fn insertions_to_csv_string(outputs: &[NextcladeOutputs]) -> Result<String, Report> {
+pub fn insertions_to_csv_string(
+  outputs: &[NextcladeOutputs],
+  errors: &[NextcladeErrorOutputs],
+) -> Result<String, Report> {
   let mut buf = Vec::<u8>::new();
   {
     let mut writer = CsvStructWriter::new(&mut buf, b',')?;
 
-    for output in outputs {
-      writer.write(&InsertionCsvEntry {
-        seq_name: &output.seq_name,
-        insertions: format_nuc_insertions(&output.insertions, ";"),
-        aa_insertions: format_aa_insertions(&output.aa_insertions, ";"),
-      })?;
+    let outputs_or_errors = combine_outputs_and_errors_sorted(outputs, errors);
+
+    for (_, output_or_error) in outputs_or_errors {
+      match output_or_error {
+        NextcladeOutputOrError::Outputs(output) => {
+          writer.write(&InsertionCsvEntry {
+            seq_name: &output.seq_name,
+            insertions: format_nuc_insertions(&output.insertions, ";"),
+            aa_insertions: format_aa_insertions(&output.aa_insertions, ";"),
+          })?;
+        }
+        NextcladeOutputOrError::Error(error) => {
+          writer.write(&InsertionCsvEntry {
+            seq_name: &error.seq_name,
+            insertions: "".to_owned(),
+            aa_insertions: "".to_owned(),
+          })?;
+        }
+      }
     }
   }
   Ok(String::from_utf8(buf)?)

--- a/packages_rs/nextclade/src/io/ndjson.rs
+++ b/packages_rs/nextclade/src/io/ndjson.rs
@@ -1,4 +1,5 @@
 use crate::io::file::create_file;
+use crate::types::outputs::NextcladeErrorOutputs;
 use eyre::{Report, WrapErr};
 use std::fmt::Debug;
 use std::io::{LineWriter, Write};
@@ -42,5 +43,13 @@ impl NdjsonFileWriter {
       .ndjson_writer
       .write(entry)
       .wrap_err_with(|| format!("When writing ndjson entry to file {:#?}", &self.filepath))
+  }
+
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) -> Result<(), Report> {
+    self.write(&NextcladeErrorOutputs {
+      index,
+      seq_name: seq_name.to_owned(),
+      message: message.to_owned(),
+    })
   }
 }

--- a/packages_rs/nextclade/src/io/ndjson.rs
+++ b/packages_rs/nextclade/src/io/ndjson.rs
@@ -20,6 +20,14 @@ impl<W: Write + Send> NdjsonWriter<W> {
     self.line_writer.write_all(b"\n")?;
     Ok(())
   }
+
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) -> Result<(), Report> {
+    self.write(&NextcladeErrorOutputs {
+      index,
+      seq_name: seq_name.to_owned(),
+      message: message.to_owned(),
+    })
+  }
 }
 
 pub struct NdjsonFileWriter {
@@ -42,14 +50,13 @@ impl NdjsonFileWriter {
     self
       .ndjson_writer
       .write(entry)
-      .wrap_err_with(|| format!("When writing ndjson entry to file {:#?}", &self.filepath))
+      .wrap_err_with(|| format!("When writing ndjson output entry to file {:#?}", &self.filepath))
   }
 
   pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) -> Result<(), Report> {
-    self.write(&NextcladeErrorOutputs {
-      index,
-      seq_name: seq_name.to_owned(),
-      message: message.to_owned(),
-    })
+    self
+      .ndjson_writer
+      .write_nuc_error(index, seq_name, message)
+      .wrap_err_with(|| format!("When writing ndjson error entry to file {:#?}", &self.filepath))
   }
 }

--- a/packages_rs/nextclade/src/io/ndjson.rs
+++ b/packages_rs/nextclade/src/io/ndjson.rs
@@ -21,11 +21,11 @@ impl<W: Write + Send> NdjsonWriter<W> {
     Ok(())
   }
 
-  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) -> Result<(), Report> {
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, errors: &[String]) -> Result<(), Report> {
     self.write(&NextcladeErrorOutputs {
       index,
       seq_name: seq_name.to_owned(),
-      message: message.to_owned(),
+      errors: errors.to_vec(),
     })
   }
 }
@@ -53,10 +53,10 @@ impl NdjsonFileWriter {
       .wrap_err_with(|| format!("When writing ndjson output entry to file {:#?}", &self.filepath))
   }
 
-  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) -> Result<(), Report> {
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, errors: &[String]) -> Result<(), Report> {
     self
       .ndjson_writer
-      .write_nuc_error(index, seq_name, message)
+      .write_nuc_error(index, seq_name, errors)
       .wrap_err_with(|| format!("When writing ndjson error entry to file {:#?}", &self.filepath))
   }
 }

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -645,7 +645,7 @@ pub fn results_to_csv_string(
     for (_, output_or_error) in outputs_or_errors {
       match output_or_error {
         NextcladeOutputOrError::Outputs(output) => writer.write(&output)?,
-        NextcladeOutputOrError::Error(error) => writer.write_nuc_error(&error.seq_name, &error.message)?,
+        NextcladeOutputOrError::Error(error) => writer.write_nuc_error(&error.seq_name, &error.errors.join(";"))?,
       };
     }
   }

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -12,7 +12,7 @@ use crate::qc::qc_config::StopCodonLocation;
 use crate::qc::qc_rule_snp_clusters::ClusteredSnp;
 use crate::translate::frame_shifts_translate::FrameShift;
 use crate::translate::translate_genes::Translation;
-use crate::types::outputs::NextcladeOutputs;
+use crate::types::outputs::{NextcladeOutputs, PeptideWarning};
 use crate::utils::error::report_to_string;
 use crate::utils::num::is_int;
 use crate::utils::range::Range;
@@ -87,8 +87,8 @@ static NEXTCLADE_CSV_HEADERS: &[&str] = &[
   "qc.stopCodons.score",
   "qc.stopCodons.status",
   "isReverseComplement",
-  // "failedGenes",
-  // "warnings",
+  "failedGenes",
+  "warnings",
   "errors",
 ];
 
@@ -171,6 +171,7 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
       qc,
       custom_node_attributes,
       is_reverse_complement,
+      warnings,
       ..
     } = nextclade_outputs;
 
@@ -368,8 +369,14 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
       qc.stop_codons.as_ref().map(|sc| sc.status.to_string()),
     )?;
     self.add_entry("isReverseComplement", &is_reverse_complement.to_string())?;
-    // self.add_entry("failedGenes", &format_failed_genes(missing_genes, ARRAY_ITEM_DELIMITER))?;
-    // self.add_entry("warnings", &format_aa_warnings(translations, ARRAY_ITEM_DELIMITER))?;
+    self.add_entry("failedGenes", &format_failed_genes(missing_genes, ARRAY_ITEM_DELIMITER))?;
+    self.add_entry(
+      "warnings",
+      &warnings
+        .iter()
+        .map(|PeptideWarning { warning, .. }| warning)
+        .join(";"),
+    )?;
     self.add_entry("errors", &"")?;
 
     self.write_row()?;

--- a/packages_rs/nextclade/src/io/results_json.rs
+++ b/packages_rs/nextclade/src/io/results_json.rs
@@ -1,7 +1,7 @@
 use crate::io::json::{json_stringify, json_write};
 use crate::io::ndjson::NdjsonWriter;
 use crate::tree::tree::CladeNodeAttrKeyDesc;
-use crate::types::outputs::NextcladeOutputs;
+use crate::types::outputs::{NextcladeErrorOutputs, NextcladeOutputs};
 use crate::utils::datetime::date_iso_now;
 use eyre::Report;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,8 @@ pub struct ResultsJson {
   pub clade_node_attr_keys: Vec<CladeNodeAttrKeyDesc>,
 
   pub results: Vec<NextcladeOutputs>,
+
+  pub errors: Vec<NextcladeErrorOutputs>,
 }
 
 impl ResultsJson {
@@ -35,6 +37,7 @@ impl ResultsJson {
       created_at: date_iso_now(),
       clade_node_attr_keys: Vec::<CladeNodeAttrKeyDesc>::from(clade_node_attrs),
       results: vec![],
+      errors: vec![],
     }
   }
 
@@ -65,6 +68,14 @@ impl ResultsJsonWriter {
 
   pub fn write(&mut self, entry: NextcladeOutputs) {
     self.result.results.push(entry);
+  }
+
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) {
+    self.result.errors.push(NextcladeErrorOutputs {
+      index,
+      seq_name: seq_name.to_owned(),
+      message: message.to_owned(),
+    });
   }
 
   pub fn finish(&self) -> Result<(), Report> {

--- a/packages_rs/nextclade/src/io/results_json.rs
+++ b/packages_rs/nextclade/src/io/results_json.rs
@@ -1,7 +1,9 @@
 use crate::io::json::{json_stringify, json_write};
 use crate::io::ndjson::NdjsonWriter;
 use crate::tree::tree::CladeNodeAttrKeyDesc;
-use crate::types::outputs::{NextcladeErrorOutputs, NextcladeOutputs};
+use crate::types::outputs::{
+  combine_outputs_and_errors_sorted, NextcladeErrorOutputs, NextcladeOutputOrError, NextcladeOutputs,
+};
 use crate::utils::datetime::date_iso_now;
 use eyre::Report;
 use serde::{Deserialize, Serialize};
@@ -43,11 +45,13 @@ impl ResultsJson {
 
   pub fn from_outputs(
     outputs: &[NextcladeOutputs],
+    errors: &[NextcladeErrorOutputs],
     clade_node_attrs: &[CladeNodeAttrKeyDesc],
     nextclade_web_version: &Option<String>,
   ) -> Self {
     let mut this = Self::new(clade_node_attrs);
     this.results = outputs.to_vec();
+    this.errors = errors.to_vec();
     this.nextclade_web_version = nextclade_web_version.clone();
     this
   }
@@ -92,19 +96,29 @@ impl Drop for ResultsJsonWriter {
 
 pub fn results_to_json_string(
   outputs: &[NextcladeOutputs],
+  errors: &[NextcladeErrorOutputs],
   clade_node_attrs: &[CladeNodeAttrKeyDesc],
   nextclade_web_version: &Option<String>,
 ) -> Result<String, Report> {
-  let results_json = ResultsJson::from_outputs(outputs, clade_node_attrs, nextclade_web_version);
+  let results_json = ResultsJson::from_outputs(outputs, errors, clade_node_attrs, nextclade_web_version);
   json_stringify(&results_json)
 }
 
-pub fn results_to_ndjson_string(outputs: &[NextcladeOutputs]) -> Result<String, Report> {
+pub fn results_to_ndjson_string(
+  outputs: &[NextcladeOutputs],
+  errors: &[NextcladeErrorOutputs],
+) -> Result<String, Report> {
   let mut buf = Vec::<u8>::new();
   {
     let mut writer = NdjsonWriter::new(&mut buf)?;
-    for output in outputs {
-      writer.write(output)?;
+
+    let output_or_errors = combine_outputs_and_errors_sorted(outputs, errors);
+
+    for (i, output_or_error) in output_or_errors {
+      match output_or_error {
+        NextcladeOutputOrError::Outputs(output) => writer.write(&output),
+        NextcladeOutputOrError::Error(error) => writer.write_nuc_error(error.index, &error.seq_name, &error.message),
+      }?;
     }
   }
   Ok(String::from_utf8(buf)?)

--- a/packages_rs/nextclade/src/io/results_json.rs
+++ b/packages_rs/nextclade/src/io/results_json.rs
@@ -74,11 +74,11 @@ impl ResultsJsonWriter {
     self.result.results.push(entry);
   }
 
-  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, message: &str) {
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, errors: &[String]) {
     self.result.errors.push(NextcladeErrorOutputs {
       index,
       seq_name: seq_name.to_owned(),
-      message: message.to_owned(),
+      errors: errors.to_vec(),
     });
   }
 
@@ -117,7 +117,7 @@ pub fn results_to_ndjson_string(
     for (i, output_or_error) in output_or_errors {
       match output_or_error {
         NextcladeOutputOrError::Outputs(output) => writer.write(&output),
-        NextcladeOutputOrError::Error(error) => writer.write_nuc_error(error.index, &error.seq_name, &error.message),
+        NextcladeOutputOrError::Error(error) => writer.write_nuc_error(error.index, &error.seq_name, &error.errors),
       }?;
     }
   }

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -95,7 +95,7 @@ impl NextcladeOutputs {
 pub struct NextcladeErrorOutputs {
   pub index: usize,
   pub seq_name: String,
-  pub message: String,
+  pub errors: Vec<String>,
 }
 
 pub enum NextcladeOutputOrError {

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -89,3 +89,11 @@ impl NextcladeOutputs {
     json_parse(s)
   }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NextcladeErrorOutputs {
+  pub index: usize,
+  pub seq_name: String,
+  pub message: String,
+}

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -97,3 +97,29 @@ pub struct NextcladeErrorOutputs {
   pub seq_name: String,
   pub message: String,
 }
+
+pub enum NextcladeOutputOrError {
+  Outputs(Box<NextcladeOutputs>),
+  Error(NextcladeErrorOutputs),
+}
+
+/// Merges an array of outputs with an array of errors into an array of variants
+/// and sorts them by output/error index
+pub fn combine_outputs_and_errors_sorted(
+  outputs: &[NextcladeOutputs],
+  errors: &[NextcladeErrorOutputs],
+) -> Vec<(usize, NextcladeOutputOrError)> {
+  let mut outputs_or_errors = Vec::<(usize, NextcladeOutputOrError)>::new();
+
+  for output in outputs {
+    outputs_or_errors.push((output.index, NextcladeOutputOrError::Outputs(Box::new(output.clone()))));
+  }
+
+  for error in errors {
+    outputs_or_errors.push((error.index, NextcladeOutputOrError::Error(error.clone())));
+  }
+
+  outputs_or_errors.sort_by_key(|o| o.0);
+
+  outputs_or_errors
+}


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/921

It was reported by @tseemann that in Nextclade v2 CSV and TSV rows are not written for failed sequences. While in v1 they were. This was unintended.

In this PR:
  - CSV, TSV, NDJSON rows for failed entries are now also written (only `errors` column is populated)
  - JSON output now has a separate `errors` filed at the root of the object, with all failed entries
  - NDJSON rows are also written for failed entries. They only contain `index`, `seqName` and `errors` fields.
  - new columns are written into CSV and TSV outputs: `warnings` and `failedGenes`, which include any warnings emitted for a sequence as well as a list of genes that failed translation. Now all columns of the "errors.csv" file are also in the CSV and TSV results files.

