### PR TITLE
fix(web): enable download button even if all sequences failed

### DIFF
--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -217,12 +217,6 @@ export const canDownloadAtom = selector<boolean>({
   key: 'canDownload',
   get({ get }) {
     const globalStatus = get(analysisStatusGlobalAtom)
-    const resultStatuses = get(analysisResultStatusesAtom)
-    const tree = get(treeAtom)
-    return (
-      globalStatus === AlgorithmGlobalStatus.done &&
-      resultStatuses.includes(AlgorithmSequenceStatus.done) &&
-      !isNil(tree)
-    )
+    return globalStatus === AlgorithmGlobalStatus.done
   },
 })


### PR DESCRIPTION
Currently the button stays disabled when a ran ended in no successful results. However, this prevents downloading errors.csv and other files containing errors, which might still be useful.

