### PR TITLE
feat: add "download dataset and run" shortcut"

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_loop.rs
@@ -62,7 +62,7 @@ pub fn nextalign_run(run_args: NextalignRunArgs) -> Result<(), Report> {
   let gene_map = match input_gene_map {
     Some(input_gene_map) => {
       let gene_map = read_gff3_file(&input_gene_map)?;
-      filter_gene_map(Some(gene_map), genes)?
+      filter_gene_map(Some(gene_map), &genes)?
     }
     None => GeneMap::new(),
   };

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -255,6 +255,18 @@ pub struct NextcladeRunInputArgs {
   #[clap(value_hint = ValueHint::AnyPath)]
   pub input_dataset: Option<PathBuf>,
 
+  /// Name of the dataset to download and use during the run
+  ///
+  /// This is a convenience shortcut to first downloading a dataset and then immediately running with it. Providing this flag is equivalent to running 2 commands: `dataset get` followed by `run`, with the difference that the dataset files from the first command are not saved to disk and cannot be reused later. The default parameters are used for the dataset (e.g. default reference name and latest version tag).
+  ///
+  /// See `dataset get --help` and `dataset list --help` for more details.
+  ///
+  /// Note that when using this flag, the dataset will be downloaded on every run. If a new version of the dataset is released between two runs, they will use different versions of the dataset and may produce different results. For the most reproducible runs, and for more control, use the usual 2-step flow with `dataset get` followed by `run`.
+  ///
+  /// This flag is mutually exclusive with `--input_dataset`
+  #[clap(long, short = 'd')]
+  pub dataset_name: Option<String>,
+
   /// Path to a FASTA file containing reference sequence.
   ///
   /// This file should contain exactly 1 sequence.
@@ -326,6 +338,12 @@ pub struct NextcladeRunInputArgs {
   )]
   #[clap(value_hint = ValueHint::FilePath)]
   pub genes: Option<Vec<String>>,
+
+  /// Use custom dataset server
+  #[clap(long)]
+  #[clap(value_hint = ValueHint::Url)]
+  #[clap(default_value_t = Url::from_str(DATA_FULL_DOMAIN).expect("Invalid URL"))]
+  pub server: Url,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -25,7 +25,7 @@ pub fn nextclade_dataset_list(
   }: NextcladeDatasetListArgs,
 ) -> Result<(), Report> {
   let verbose = log::max_level() > LevelFilter::Info;
-  let mut http = HttpClient::new(server, proxy_config, verbose)?;
+  let mut http = HttpClient::new(&server, &proxy_config, verbose)?;
   let DatasetsIndexJson { datasets, .. } = DatasetsIndexJson::download(&mut http)?;
 
   // Parse attribute key-value pairs

--- a/packages_rs/nextclade/src/io/gene_map.rs
+++ b/packages_rs/nextclade/src/io/gene_map.rs
@@ -24,7 +24,7 @@ fn get_requested_genes_not_in_genemap(gene_map: &GeneMap, genes: &[String]) -> S
 /// |     +      |         | Take all genes                             |
 /// |            |    +    | Error                                      |
 /// |            |         | Skip translation and codon penalties       |
-pub fn filter_gene_map(gene_map: Option<GeneMap>, genes: Option<Vec<String>>) -> Result<GeneMap, Report> {
+pub fn filter_gene_map(gene_map: Option<GeneMap>, genes: &Option<Vec<String>>) -> Result<GeneMap, Report> {
   match (gene_map, genes) {
     // Both gene map and list of genes are provided. Retain only requested genes.
     (Some(gene_map), Some(genes)) => {
@@ -33,7 +33,7 @@ pub fn filter_gene_map(gene_map: Option<GeneMap>, genes: Option<Vec<String>>) ->
         .filter(|(gene_name, ..)| genes.contains(gene_name))
         .collect();
 
-      let requested_genes_not_in_genemap = get_requested_genes_not_in_genemap(&gene_map, &genes);
+      let requested_genes_not_in_genemap = get_requested_genes_not_in_genemap(&gene_map, genes);
       if !requested_genes_not_in_genemap.is_empty() {
         warn!(
           "The following genes were requested through `--genes` \


### PR DESCRIPTION
This adds `--dataset-name` (`-d`) to `run` command, which allows to download a dataset with default parameters and run with it immediately, in one command.

For example this command.

```bash
nextclade run --output-all=out --dataset-name=sars-cov-2 sequences.fasta
```

will download the latest default sars-cov-2 dataset into memory and will run analysis with these dataset files.

This is a convenience shortcut for the usual combination of `dataset get` + `run`. The dataset is not persisted on disk and downloaded on every run.

This also adds `--server` flag to the `run` command, which works exactly the same as in the `dataset get` and `dataset list` commands.
