### PR TITLE
docs: Install nextstrain.sphinx.theme extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,8 @@ extensions = [
     'sphinx_markdown_tables',
     'sphinxarg.ext',
     'sphinx.ext.autodoc',
-    'sphinx_tabs.tabs'
+    'sphinx_tabs.tabs',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sphinx
   - pip
   - pip:
-    - nextstrain-sphinx-theme>=2020.2
+    - nextstrain-sphinx-theme>=2022.5
     - sphinx-markdown-tables
     - sphinx-argparse
     - sphinx-tabs


### PR DESCRIPTION
## Description of proposed changes

The new extension has sphinx_copybutton pre-installed and configured. This change enables it here.
This also makes it easier to configure other extensions across multiple docs projects.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [ ] copy button works on RTD preview build