### PR TITLE
fix: use indices to identify sequences uniquely

### DIFF
--- a/packages_rs/nextclade-web/src/algorithms/types.ts
+++ b/packages_rs/nextclade-web/src/algorithms/types.ts
@@ -345,6 +345,7 @@ export function convertPrivateMutations(privateNucMutations: PrivateMutations) {
 }
 
 export interface AnalysisResult {
+  index: number
   seqName: string
   substitutions: NucleotideSubstitution[]
   totalSubstitutions: number

--- a/packages_rs/nextclade-web/src/components/Common/SeqNameHeading.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/SeqNameHeading.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export const SeqNameHeading = styled.h6`
+  overflow-wrap: anywhere;
+  word-wrap: anywhere;
+  word-break: break-all;
+`

--- a/packages_rs/nextclade-web/src/components/Results/ColumnClade.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnClade.tsx
@@ -13,8 +13,8 @@ export function ColumnClade({ analysisResult }: ColumnCladeProps) {
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
 
-  const { clade, seqName } = analysisResult
-  const id = getSafeId('col-clade', { seqName })
+  const { clade, seqName, index } = analysisResult
+  const id = getSafeId('col-clade', { index, seqName })
   const cladeText = clade ?? t('Pending...')
 
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])

--- a/packages_rs/nextclade-web/src/components/Results/ColumnCustomNodeAttr.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnCustomNodeAttr.tsx
@@ -11,10 +11,10 @@ export interface ColumnCustomNodeAttrProps {
 }
 
 export function ColumnCustomNodeAttr({ sequence, attrKey }: ColumnCustomNodeAttrProps) {
-  const { seqName, customNodeAttributes } = sequence
+  const { index, seqName, customNodeAttributes } = sequence
   const attrValue = get(customNodeAttributes, attrKey, '')
 
-  const id = getSafeId('col-custom-attr', { seqName, attrKey })
+  const id = getSafeId('col-custom-attr', { index, seqName, attrKey })
 
   return (
     <div id={id} className="w-100">

--- a/packages_rs/nextclade-web/src/components/Results/ColumnFrameShifts.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnFrameShifts.tsx
@@ -10,13 +10,13 @@ export function ColumnFrameShifts({ analysisResult }: ColumnCladeProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { seqName, qc } = analysisResult
+  const { index, seqName, qc } = analysisResult
 
   if (!qc.frameShifts) {
     return null
   }
 
-  const id = getSafeId('frame-shifts-label', { seqName })
+  const id = getSafeId('frame-shifts-label', { index, seqName })
 
   const { totalFrameShifts, totalFrameShiftsIgnored } = qc.frameShifts
   const grandTotal = totalFrameShiftsIgnored + totalFrameShifts

--- a/packages_rs/nextclade-web/src/components/Results/ColumnGaps.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnGaps.tsx
@@ -18,8 +18,8 @@ export function ColumnGaps({ analysisResult }: ColumnGapsProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { deletions, aaDeletions, seqName } = analysisResult
-  const id = getSafeId('col-gaps', { seqName })
+  const { index, deletions, aaDeletions, seqName } = analysisResult
+  const id = getSafeId('col-gaps', { index, seqName })
 
   const totalGaps = deletions.reduce((acc, curr) => acc + curr.length, 0)
 

--- a/packages_rs/nextclade-web/src/components/Results/ColumnInsertions.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnInsertions.tsx
@@ -17,8 +17,8 @@ export function ColumnInsertions({ analysisResult }: ColumnInsertionsProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { seqName, insertions, totalInsertions, aaInsertions, totalAminoacidInsertions } = analysisResult
-  const id = getSafeId('col-insertions', { seqName, insertions })
+  const { index, seqName, insertions, totalInsertions, aaInsertions, totalAminoacidInsertions } = analysisResult
+  const id = getSafeId('col-insertions', { index, seqName, insertions })
 
   const nucTitle = useMemo(() => t('Nucleotide insertions ({{n}})', { n: insertions.length }), [insertions.length, t])
   const aaTitle = useMemo(() => t('Aminoacid insertions ({{n}})', { n: aaInsertions.length }), [aaInsertions.length, t])

--- a/packages_rs/nextclade-web/src/components/Results/ColumnMissing.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnMissing.tsx
@@ -14,8 +14,8 @@ export function ColumnMissing({ analysisResult }: ColumnMissingProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { missing, seqName, totalMissing } = analysisResult
-  const id = getSafeId('col-missing', { seqName })
+  const { index, missing, seqName, totalMissing } = analysisResult
+  const id = getSafeId('col-missing', { index, seqName })
 
   return (
     <div id={id} className="w-100" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>

--- a/packages_rs/nextclade-web/src/components/Results/ColumnMutations.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnMutations.tsx
@@ -16,8 +16,8 @@ export function ColumnMutations({ analysisResult }: ColumnCladeProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { seqName, substitutions, aaSubstitutions, privateNucMutations } = analysisResult
-  const id = getSafeId('mutations-label', { seqName })
+  const { index, seqName, substitutions, aaSubstitutions, privateNucMutations } = analysisResult
+  const id = getSafeId('mutations-label', { index, seqName })
 
   const privateNucMutationsInternal = useMemo(() => convertPrivateMutations(privateNucMutations), [privateNucMutations])
 

--- a/packages_rs/nextclade-web/src/components/Results/ColumnName.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnName.tsx
@@ -16,16 +16,17 @@ export const SequenceName = styled.div`
 `
 
 export interface ColumnNameProps {
+  index: number
   seqName: string
 }
 
-export function ColumnName({ seqName }: ColumnNameProps) {
+export function ColumnName({ index, seqName }: ColumnNameProps) {
   const { t } = useTranslationSafe()
-  const { result, error } = useRecoilValue(analysisResultAtom(seqName))
+  const { result, error } = useRecoilValue(analysisResultAtom(index))
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
-  const id = useMemo(() => getSafeId('sequence-label', { seqName }), [seqName])
+  const id = useMemo(() => getSafeId('sequence-label', { index }), [index])
 
   const { StatusIcon } = useMemo(
     () =>
@@ -41,17 +42,17 @@ export function ColumnName({ seqName }: ColumnNameProps) {
     if (error) {
       return (
         <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
-          <ColumnNameErrorTooltip seqName={seqName} error={error} />
+          <ColumnNameErrorTooltip index={index} seqName={seqName} error={error} />
         </Tooltip>
       )
     }
 
     return (
       <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
-        <ColumnNameTooltip seqName={seqName} />
+        <ColumnNameTooltip index={index} />
       </Tooltip>
     )
-  }, [error, id, seqName, showTooltip])
+  }, [error, id, index, seqName, showTooltip])
 
   return (
     <SequenceName id={id} className="w-100" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>

--- a/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
@@ -10,6 +10,7 @@ import { formatRange } from 'src/helpers/formatRange'
 import { ListOfPcrPrimerChanges } from 'src/components/SequenceView/ListOfPcrPrimerChanges'
 import { ErrorIcon, getStatusIconAndText, WarningIcon } from 'src/components/Results/getStatusIconAndText'
 import { TableSlim as TableSlimBase } from 'src/components/Common/TableSlim'
+import { SeqNameHeading } from 'src/components/Common/SeqNameHeading'
 
 const Alert = styled(ReactstrapAlert)`
   box-shadow: ${(props) => props.theme.shadows.slight};
@@ -21,12 +22,12 @@ const TableSlim = styled(TableSlimBase)`
 `
 
 export interface ColumnNameTooltipProps {
-  seqName: string
+  index: number
 }
 
-export function ColumnNameTooltip({ seqName }: ColumnNameTooltipProps) {
+export function ColumnNameTooltip({ index }: ColumnNameTooltipProps) {
   const { t } = useTranslationSafe()
-  const { result, error } = useRecoilValue(analysisResultAtom(seqName))
+  const { result, error } = useRecoilValue(analysisResultAtom(index))
 
   const { StatusIcon, statusText } = useMemo(
     () =>
@@ -51,7 +52,7 @@ export function ColumnNameTooltip({ seqName }: ColumnNameTooltipProps) {
     return null
   }
 
-  const { clade, alignmentStart, alignmentEnd, alignmentScore, pcrPrimerChanges, totalPcrPrimerChanges } =
+  const { seqName, clade, alignmentStart, alignmentEnd, alignmentScore, pcrPrimerChanges, totalPcrPrimerChanges } =
     result.analysisResult
 
   return (
@@ -60,8 +61,13 @@ export function ColumnNameTooltip({ seqName }: ColumnNameTooltipProps) {
       <tbody>
         <tr>
           <td colSpan={2}>
-            <h5 className="mb-2">{seqName}</h5>
+            <SeqNameHeading className="mb-2">{seqName}</SeqNameHeading>
           </td>
+        </tr>
+
+        <tr className="mb-2">
+          <td>{t('Sequence index')} </td>
+          <td>{index}</td>
         </tr>
 
         <tr>
@@ -106,11 +112,12 @@ export function ColumnNameTooltip({ seqName }: ColumnNameTooltipProps) {
 }
 
 export interface ColumnNameErrorTooltipProps {
+  index: number
   seqName: string
   error: string
 }
 
-export function ColumnNameErrorTooltip({ seqName, error }: ColumnNameErrorTooltipProps) {
+export function ColumnNameErrorTooltip({ index, seqName, error }: ColumnNameErrorTooltipProps) {
   const { t } = useTranslationSafe()
 
   return (
@@ -119,8 +126,13 @@ export function ColumnNameErrorTooltip({ seqName, error }: ColumnNameErrorToolti
       <tbody>
         <tr>
           <td colSpan={2}>
-            <h5 className="mb-2">{seqName}</h5>
+            <SeqNameHeading className="mb-2">{seqName}</SeqNameHeading>
           </td>
+        </tr>
+
+        <tr className="mb-2">
+          <td>{t('Sequence index')} </td>
+          <td>{index}</td>
         </tr>
 
         <tr>

--- a/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
@@ -65,11 +65,6 @@ export function ColumnNameTooltip({ index }: ColumnNameTooltipProps) {
           </td>
         </tr>
 
-        <tr className="mb-2">
-          <td>{t('Sequence index')} </td>
-          <td>{index}</td>
-        </tr>
-
         <tr>
           <td>{t('Analysis status')}</td>
           <td>

--- a/packages_rs/nextclade-web/src/components/Results/ColumnNonACGTNs.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnNonACGTNs.tsx
@@ -14,8 +14,8 @@ export function ColumnNonACGTNs({ analysisResult }: ColumnNonACGTNsProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { seqName, nonACGTNs, totalNonACGTNs } = analysisResult
-  const id = getSafeId('col-nonacgtn', { seqName })
+  const { index, seqName, nonACGTNs, totalNonACGTNs } = analysisResult
+  const id = getSafeId('col-nonacgtn', { index, seqName })
 
   return (
     <div id={id} className="w-100" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>

--- a/packages_rs/nextclade-web/src/components/Results/ColumnQCStatus.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnQCStatus.tsx
@@ -16,10 +16,10 @@ export function ColumnQCStatus({ analysisResult }: ColumnQCStatusProps) {
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { seqName, qc } = analysisResult
+  const { index, seqName, qc } = analysisResult
   const { missingData, privateMutations, mixedSites, snpClusters, frameShifts, stopCodons } = qc
 
-  const id = getSafeId('qc-label', { seqName })
+  const id = getSafeId('qc-label', { index, seqName })
 
   const rules = [
     { value: missingData, name: 'N' },

--- a/packages_rs/nextclade-web/src/components/Results/ColumnStopCodons.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnStopCodons.tsx
@@ -11,6 +11,7 @@ export function ColumnStopCodons({ analysisResult }: ColumnCladeProps) {
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
   const {
+    index,
     seqName,
     qc: { stopCodons },
   } = analysisResult
@@ -19,7 +20,7 @@ export function ColumnStopCodons({ analysisResult }: ColumnCladeProps) {
     return null
   }
 
-  const id = getSafeId('stop-codons-label', { seqName })
+  const id = getSafeId('stop-codons-label', { index, seqName })
 
   const { totalStopCodons, totalStopCodonsIgnored } = stopCodons
   const grandTotal = totalStopCodons + totalStopCodonsIgnored

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
@@ -16,7 +16,7 @@ import {
 import {
   cladeNodeAttrDescsAtom,
   cladeNodeAttrKeysAtom,
-  seqNamesFilteredAtom,
+  seqIndicesFilteredAtom,
   sortAnalysisResultsAtom,
   sortAnalysisResultsByKeyAtom,
 } from 'src/state/results.state'
@@ -58,8 +58,8 @@ export const FixedSizeList = styled(FixedSizeListBase)<FixedSizeListProps>`
 export function ResultsTable() {
   const { t } = useTranslation()
 
-  const seqNamesImmediate = useRecoilValue(seqNamesFilteredAtom)
-  const seqNames = useDeferredValue(seqNamesImmediate)
+  const seqIndicesImmediate = useRecoilValue(seqIndicesFilteredAtom)
+  const seqIndices = useDeferredValue(seqIndicesImmediate)
 
   const columnWidthsPx = useRecoilValue(resultsTableColumnWidthsPxAtom)
   const dynamicColumnWidthPx = useRecoilValue(resultsTableDynamicColumnWidthPxAtom)
@@ -69,14 +69,14 @@ export function ResultsTable() {
   const viewedGene = useRecoilValue(viewedGeneAtom)
 
   const rowData: TableRowDatum[] = useMemo(() => {
-    return seqNames.map((seqName) => ({
-      seqName,
+    return seqIndices.map((seqIndex) => ({
+      seqIndex,
       viewedGene,
       columnWidthsPx,
       dynamicColumnWidthPx,
       cladeNodeAttrKeys,
     }))
-  }, [cladeNodeAttrKeys, columnWidthsPx, dynamicColumnWidthPx, seqNames, viewedGene])
+  }, [cladeNodeAttrKeys, columnWidthsPx, dynamicColumnWidthPx, seqIndices, viewedGene])
 
   // TODO: we could use a map (object) and refer to filters by name,
   // in order to reduce code duplication in the state, callbacks and components being rendered

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRow.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRow.tsx
@@ -9,7 +9,7 @@ import { ResultsTableRowPending } from './ResultsTableRowPending'
 import { ResultsTableRowResult } from './ResultsTableRowResult'
 
 export interface TableRowDatum {
-  seqName: string
+  seqIndex: number
   viewedGene: string
   columnWidthsPx: Record<keyof typeof COLUMN_WIDTHS, string>
   dynamicColumnWidthPx: string
@@ -23,22 +23,22 @@ export interface RowProps extends ListChildComponentProps {
 export const ResultsTableRow = memo(ResultsTableRowUnmemoed, areEqual)
 
 function ResultsTableRowUnmemoed({ index, data, ...restProps }: RowProps) {
-  const { seqName, viewedGene, columnWidthsPx, dynamicColumnWidthPx, cladeNodeAttrKeys } = useMemo(
+  const { seqIndex, viewedGene, columnWidthsPx, dynamicColumnWidthPx, cladeNodeAttrKeys } = useMemo(
     () => data[index],
     [data, index],
   )
 
-  const { result, error } = useRecoilValue(analysisResultAtom(seqName))
+  const { result, error } = useRecoilValue(analysisResultAtom(seqIndex))
 
   if (error) {
-    return <ResultsTableRowError {...restProps} seqName={seqName} columnWidthsPx={columnWidthsPx} />
+    return <ResultsTableRowError {...restProps} index={seqIndex} columnWidthsPx={columnWidthsPx} />
   }
 
   if (result) {
     return (
       <ResultsTableRowResult
         {...restProps}
-        seqName={seqName}
+        index={seqIndex}
         columnWidthsPx={columnWidthsPx}
         dynamicColumnWidthPx={dynamicColumnWidthPx}
         cladeNodeAttrKeys={cladeNodeAttrKeys}
@@ -47,5 +47,5 @@ function ResultsTableRowUnmemoed({ index, data, ...restProps }: RowProps) {
     )
   }
 
-  return <ResultsTableRowPending seqName={seqName} columnWidthsPx={columnWidthsPx} />
+  return <ResultsTableRowPending index={seqIndex} columnWidthsPx={columnWidthsPx} />
 }

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRowError.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRowError.tsx
@@ -12,12 +12,12 @@ import {
 import { analysisResultAtom } from 'src/state/results.state'
 
 export interface ResultsTableRowErrorProps {
-  seqName: string
+  index: number
   columnWidthsPx: Record<keyof typeof COLUMN_WIDTHS, string>
 }
 
-export function ResultsTableRowError({ seqName, columnWidthsPx, ...restProps }: ResultsTableRowErrorProps) {
-  const { index, error } = useRecoilValue(analysisResultAtom(seqName))
+export function ResultsTableRowError({ index, columnWidthsPx, ...restProps }: ResultsTableRowErrorProps) {
+  const { seqName, error } = useRecoilValue(analysisResultAtom(index))
 
   return (
     <TableRowError {...restProps}>
@@ -26,7 +26,7 @@ export function ResultsTableRowError({ seqName, columnWidthsPx, ...restProps }: 
       </TableCell>
 
       <TableCellName basis={columnWidthsPx.seqName} shrink={0}>
-        <ColumnName seqName={seqName} />
+        <ColumnName index={index} seqName={seqName} />
       </TableCellName>
 
       <TableCell basis={columnWidthsPx.sequenceView} grow={1} shrink={0}>

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRowPending.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRowPending.tsx
@@ -13,14 +13,14 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { analysisResultAtom } from 'src/state/results.state'
 
 export interface ResultsTableRowPendingProps {
-  seqName: string
+  index: number
   columnWidthsPx: Record<keyof typeof COLUMN_WIDTHS, string>
 }
 
-export function ResultsTableRowPending({ seqName, columnWidthsPx, ...restProps }: ResultsTableRowPendingProps) {
+export function ResultsTableRowPending({ index, columnWidthsPx, ...restProps }: ResultsTableRowPendingProps) {
   const { t } = useTranslationSafe()
   const text = useMemo(() => t('Analyzing...'), [t])
-  const { index } = useRecoilValue(analysisResultAtom(seqName))
+  const { seqName } = useRecoilValue(analysisResultAtom(index))
 
   return (
     <TableRowPending {...restProps}>
@@ -29,7 +29,7 @@ export function ResultsTableRowPending({ seqName, columnWidthsPx, ...restProps }
       </TableCell>
 
       <TableCellName basis={columnWidthsPx.seqName} shrink={0}>
-        <ColumnName seqName={seqName} />
+        <ColumnName index={index} seqName={seqName} />
       </TableCellName>
 
       <TableCell basis={columnWidthsPx.sequenceView} grow={1} shrink={0}>

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
@@ -28,7 +28,7 @@ import { GENE_OPTION_NUC_SEQUENCE } from 'src/constants'
 import { analysisResultAtom } from 'src/state/results.state'
 
 export interface ResultsTableRowResultProps {
-  seqName: string
+  index: number
   viewedGene: string
   cladeNodeAttrKeys: string[]
   columnWidthsPx: Record<keyof typeof COLUMN_WIDTHS, string>
@@ -69,14 +69,14 @@ export function TableRowColored({
 }
 
 export function ResultsTableRowResult({
-  seqName,
+  index,
   viewedGene,
   cladeNodeAttrKeys,
   columnWidthsPx,
   dynamicColumnWidthPx,
   ...restProps
 }: ResultsTableRowResultProps) {
-  const { index, result } = useRecoilValue(analysisResultAtom(seqName))
+  const { seqName, result } = useRecoilValue(analysisResultAtom(index))
 
   if (!result) {
     return null
@@ -92,7 +92,7 @@ export function ResultsTableRowResult({
       </TableCell>
 
       <TableCellName basis={columnWidthsPx.seqName} shrink={0}>
-        <ColumnName seqName={seqName} />
+        <ColumnName index={index} seqName={seqName} />
       </TableCellName>
 
       <TableCell basis={columnWidthsPx.qc} grow={0} shrink={0}>

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
@@ -14,19 +14,26 @@ const frameShiftColor = '#eb0d2a'
 const frameShiftBorderColor = '#ffff00'
 
 export interface PeptideMarkerFrameShiftProps extends SVGProps<SVGRectElement> {
+  index: number
   seqName: string
   frameShift: FrameShift
   pixelsPerAa: number
 }
 
-function PeptideMarkerFrameShiftUnmemoed({ seqName, frameShift, pixelsPerAa, ...rest }: PeptideMarkerFrameShiftProps) {
+function PeptideMarkerFrameShiftUnmemoed({
+  index,
+  seqName,
+  frameShift,
+  pixelsPerAa,
+  ...rest
+}: PeptideMarkerFrameShiftProps) {
   const { t } = useTranslationSafe()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
   const { geneName, nucAbs, codon, gapsLeading, gapsTrailing } = frameShift
-  const id = getSafeId('frame-shift-aa-marker', { seqName, ...frameShift })
+  const id = getSafeId('frame-shift-aa-marker', { index, seqName, ...frameShift })
 
   const geneMap = useRecoilValue(geneMapAtom)
 

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerInsertion.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerInsertion.tsx
@@ -9,12 +9,13 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { ListOfInsertionsAa } from 'src/components/Results/ListOfInsertions'
 
 export interface MissingViewProps extends SVGProps<SVGPolygonElement> {
+  index: number
   seqName: string
   insertion: AminoacidInsertion
   pixelsPerAa: number
 }
 
-function PeptideMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerAa, ...rest }: MissingViewProps) {
+function PeptideMarkerInsertionUnmemoed({ index, seqName, insertion, pixelsPerAa, ...rest }: MissingViewProps) {
   const {
     seqView: {
       markers: {
@@ -28,7 +29,7 @@ function PeptideMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerAa, ...re
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
 
-  const id = getSafeId('insertion-marker', { seqName, ...insertion })
+  const id = getSafeId('insertion-marker', { index, seqName, ...insertion })
 
   const { pos } = insertion
   const halfNuc = Math.max(pixelsPerAa, AA_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
@@ -123,11 +123,6 @@ function PeptideMarkerMutationGroupUnmemoed({
                   </td>
                 </tr>
 
-                <tr className="mb-2">
-                  <td>{t('Sequence index')}</td>
-                  <td>{index}</td>
-                </tr>
-
                 <TableRowSpacer />
 
                 <tr className="mb-2">

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerMutationGroup.tsx
@@ -9,9 +9,10 @@ import { formatRange } from 'src/helpers/formatRange'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { AminoacidMutationBadge, NucleotideMutationBadge } from 'src/components/Common/MutationBadge'
-import { TableSlim } from 'src/components/Common/TableSlim'
+import { TableRowSpacer, TableSlim } from 'src/components/Common/TableSlim'
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { geneAtom } from 'src/state/results.state'
+import { SeqNameHeading } from 'src/components/Common/SeqNameHeading'
 import { PeptideContext } from './PeptideContext'
 
 export interface PeptideMarkerMutationProps {
@@ -32,12 +33,14 @@ export function PeptideMarkerMutation({ change, parentGroup, pixelsPerAa, ...res
 }
 
 export interface PeptideMarkerMutationGroupProps extends SVGProps<SVGSVGElement> {
+  index: number
   seqName: string
   group: AminoacidChangesGroup
   pixelsPerAa: number
 }
 
 function PeptideMarkerMutationGroupUnmemoed({
+  index,
   seqName,
   group,
   pixelsPerAa,
@@ -77,7 +80,7 @@ function PeptideMarkerMutationGroupUnmemoed({
     return null
   }, [gene?.strand, t])
 
-  const id = getSafeId('aa-mutation-group-marker', { seqName, geneName, begin: codonAaRange.begin })
+  const id = getSafeId('aa-mutation-group-marker', { index, seqName, geneName, begin: codonAaRange.begin })
   const minWidth = (AA_MIN_WIDTH_PX * 6) / (5 + changes.length)
   const pixelsPerAaAdjusted = Math.max(minWidth, pixelsPerAa)
   const width = changes.length * Math.max(pixelsPerAaAdjusted, pixelsPerAa)
@@ -116,9 +119,16 @@ function PeptideMarkerMutationGroupUnmemoed({
               <tbody>
                 <tr>
                   <td colSpan={2}>
-                    <h5>{seqName}</h5>
+                    <SeqNameHeading>{seqName}</SeqNameHeading>
                   </td>
                 </tr>
+
+                <tr className="mb-2">
+                  <td>{t('Sequence index')}</td>
+                  <td>{index}</td>
+                </tr>
+
+                <TableRowSpacer />
 
                 <tr className="mb-2">
                   <td colSpan={2}>

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerUnknown.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerUnknown.tsx
@@ -13,12 +13,19 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 const unknownAaColor = getAminoacidColor(AMINOACID_UNKNOWN)
 
 export interface PeptideMarkerUnknownProps extends SVGProps<SVGRectElement> {
+  index: number
   seqName: string
   range: AminoacidRange
   pixelsPerAa: number
 }
 
-export function PeptideMarkerUnknownUnmemoed({ seqName, range, pixelsPerAa, ...rest }: PeptideMarkerUnknownProps) {
+export function PeptideMarkerUnknownUnmemoed({
+  index,
+  seqName,
+  range,
+  pixelsPerAa,
+  ...rest
+}: PeptideMarkerUnknownProps) {
   const { t } = useTranslationSafe()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
@@ -26,7 +33,7 @@ export function PeptideMarkerUnknownUnmemoed({ seqName, range, pixelsPerAa, ...r
 
   const { begin, end } = range // prettier-ignore
 
-  const id = getSafeId('unknown-marker', { seqName, ...range })
+  const id = getSafeId('unknown-marker', { index, seqName, ...range })
   let width = (end - begin) * pixelsPerAa
   width = Math.max(width, AA_MIN_WIDTH_PX)
   const halfAa = Math.max(pixelsPerAa, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first AA

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
@@ -96,7 +96,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
     )
   }
 
-  const { seqName, unknownAaRanges, frameShifts, aaChangesGroups, aaInsertions } = sequence
+  const { index, seqName, unknownAaRanges, frameShifts, aaChangesGroups, aaInsertions } = sequence
   const geneLength = gene.end - gene.start
   const pixelsPerAa = width / Math.round(geneLength / 3)
   const groups = aaChangesGroups.filter((group) => group.gene === viewedGene)
@@ -108,6 +108,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
     .map((frameShift) => (
       <PeptideMarkerFrameShift
         key={`${frameShift.geneName}_${frameShift.nucAbs.begin}`}
+        index={index}
         seqName={seqName}
         frameShift={frameShift}
         pixelsPerAa={pixelsPerAa}
@@ -118,7 +119,13 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
     .filter((ins) => ins.gene === viewedGene)
     .map((insertion) => {
       return (
-        <PeptideMarkerInsertion key={insertion.pos} seqName={seqName} insertion={insertion} pixelsPerAa={pixelsPerAa} />
+        <PeptideMarkerInsertion
+          key={insertion.pos}
+          index={index}
+          seqName={seqName}
+          insertion={insertion}
+          pixelsPerAa={pixelsPerAa}
+        />
       )
     })
 
@@ -129,13 +136,20 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
 
         {unknownAaRangesForGene &&
           unknownAaRangesForGene.ranges.map((range) => (
-            <PeptideMarkerUnknown key={range.begin} seqName={seqName} range={range} pixelsPerAa={pixelsPerAa} />
+            <PeptideMarkerUnknown
+              key={range.begin}
+              index={index}
+              seqName={seqName}
+              range={range}
+              pixelsPerAa={pixelsPerAa}
+            />
           ))}
 
         {groups.map((group) => {
           return (
             <PeptideMarkerMutationGroup
               key={group.codonAaRange.begin}
+              index={index}
               seqName={seqName}
               group={group}
               pixelsPerAa={pixelsPerAa}

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -15,12 +15,13 @@ const frameShiftColor = '#eb0d2a'
 const frameShiftBorderColor = '#ffff00'
 
 export interface MissingViewProps extends SVGProps<SVGRectElement> {
+  index: number
   seqName: string
   frameShift: FrameShift
   pixelsPerBase: number
 }
 
-function SequenceMarkerFrameShiftUnmemoed({ seqName, frameShift, pixelsPerBase, ...rest }: MissingViewProps) {
+function SequenceMarkerFrameShiftUnmemoed({ index, seqName, frameShift, pixelsPerBase, ...rest }: MissingViewProps) {
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
@@ -35,7 +36,7 @@ function SequenceMarkerFrameShiftUnmemoed({ seqName, frameShift, pixelsPerBase, 
   }
 
   const { geneName, nucAbs, codon, gapsTrailing, gapsLeading } = frameShift
-  const id = getSafeId('frame-shift-nuc-marker', { seqName, ...frameShift })
+  const id = getSafeId('frame-shift-nuc-marker', { index, seqName, ...frameShift })
 
   const gene = geneMap.find((gene) => geneName === gene.geneName)
   if (!gene) {

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerGap.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerGap.tsx
@@ -15,12 +15,13 @@ import { ListOfAaChangesFlatTruncated } from 'src/components/SequenceView/ListOf
 const gapColor = getNucleotideColor(GAP)
 
 export interface MissingViewProps extends SVGProps<SVGRectElement> {
+  index: number
   seqName: string
   deletion: NucleotideDeletion
   pixelsPerBase: number
 }
 
-function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }: MissingViewProps) {
+function SequenceMarkerGapUnmemoed({ index, seqName, deletion, pixelsPerBase, ...rest }: MissingViewProps) {
   const { t } = useTranslationSafe()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
@@ -32,7 +33,7 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
   const { start: begin, length, aaSubstitutions, aaDeletions } = deletion
   const end = begin + length
 
-  const id = getSafeId('gap-marker', { seqName, ...deletion })
+  const id = getSafeId('gap-marker', { index, seqName, ...deletion })
 
   let width = (end - begin) * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
@@ -77,7 +78,15 @@ function SequenceMarkerGapUnmemoed({ seqName, deletion, pixelsPerBase, ...rest }
               </tr>
             )}
 
-            <ListOfAaChangesFlatTruncated aaSubstitutions={aaSubstitutions} aaDeletions={aaDeletions} maxRows={10} />
+            <tr>
+              <td colSpan={2}>
+                <ListOfAaChangesFlatTruncated
+                  aaSubstitutions={aaSubstitutions}
+                  aaDeletions={aaDeletions}
+                  maxRows={10}
+                />
+              </td>
+            </tr>
           </tbody>
         </TableSlim>
       </Tooltip>

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerInsertion.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerInsertion.tsx
@@ -9,12 +9,13 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { ListOfInsertionsNuc } from 'src/components/Results/ListOfInsertions'
 
 export interface MissingViewProps extends SVGProps<SVGPolygonElement> {
+  index: number
   seqName: string
   insertion: NucleotideInsertion
   pixelsPerBase: number
 }
 
-function SequenceMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerBase, ...rest }: MissingViewProps) {
+function SequenceMarkerInsertionUnmemoed({ index, seqName, insertion, pixelsPerBase, ...rest }: MissingViewProps) {
   const {
     seqView: {
       markers: {
@@ -28,7 +29,7 @@ function SequenceMarkerInsertionUnmemoed({ seqName, insertion, pixelsPerBase, ..
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
 
-  const id = getSafeId('insertion-marker', { seqName, ...insertion })
+  const id = getSafeId('insertion-marker', { index, seqName, ...insertion })
 
   const { pos } = insertion
   const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMissing.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMissing.tsx
@@ -18,12 +18,13 @@ import {
 const missingColor = getNucleotideColor(N)
 
 export interface MissingViewProps extends SVGProps<SVGRectElement> {
+  index: number
   seqName: string
   missing: NucleotideMissing
   pixelsPerBase: number
 }
 
-export function SequenceMarkerMissingUnmemoed({ seqName, missing, pixelsPerBase, ...rest }: MissingViewProps) {
+export function SequenceMarkerMissingUnmemoed({ index, seqName, missing, pixelsPerBase, ...rest }: MissingViewProps) {
   const { t } = useTranslation()
   const [showTooltip, setShowTooltip] = useState(false)
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
@@ -38,7 +39,7 @@ export function SequenceMarkerMissingUnmemoed({ seqName, missing, pixelsPerBase,
 
   const { begin, end } = missing // prettier-ignore
 
-  const id = getSafeId('missing-marker', { seqName, ...missing })
+  const id = getSafeId('missing-marker', { index, seqName, ...missing })
   let width = (end - begin) * pixelsPerBase
   width = Math.max(width, BASE_MIN_WIDTH_PX)
   const halfNuc = Math.max(pixelsPerBase, BASE_MIN_WIDTH_PX) / 2 // Anchor on the center of the first nuc

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMutation.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerMutation.tsx
@@ -16,12 +16,14 @@ import {
 } from 'src/state/seqViewSettings.state'
 
 export interface SequenceMarkerMutationProps extends SVGProps<SVGRectElement> {
+  index: number
   seqName: string
   substitution: NucleotideSubstitution
   pixelsPerBase: number
 }
 
 function SequenceMarkerMutationUnmemoed({
+  index,
   seqName,
   substitution,
   pixelsPerBase,
@@ -40,7 +42,7 @@ function SequenceMarkerMutationUnmemoed({
   }
 
   const { pos, queryNuc, aaSubstitutions, aaDeletions } = substitution
-  const id = getSafeId('mutation-marker', { seqName, ...substitution })
+  const id = getSafeId('mutation-marker', { index, seqName, ...substitution })
 
   const fill = getNucleotideColor(queryNuc)
   const width = Math.max(BASE_MIN_WIDTH_PX, pixelsPerBase)

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerUnsequenced.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerUnsequenced.tsx
@@ -76,6 +76,7 @@ export const SequenceMarker = memo(function SequenceMarkerImpl({
 })
 
 export interface SequenceMarkerUnsequencedStartProps {
+  index: number
   seqName: string
   alignmentStart: number
   pixelsPerBase: number
@@ -83,10 +84,10 @@ export interface SequenceMarkerUnsequencedStartProps {
 
 // eslint-disable-next-line react/display-name
 export const SequenceMarkerUnsequencedStart = memo(
-  ({ seqName, alignmentStart, pixelsPerBase }: SequenceMarkerUnsequencedStartProps) => {
+  ({ index, seqName, alignmentStart, pixelsPerBase }: SequenceMarkerUnsequencedStartProps) => {
     const { t } = useTranslation()
 
-    const id = getSafeId('sequence-marker-unsequenced-start', { seqName, alignmentStart })
+    const id = getSafeId('sequence-marker-unsequenced-start', { index, seqName, alignmentStart })
 
     const begin = 0
     const end = begin + alignmentStart
@@ -104,6 +105,7 @@ export const SequenceMarkerUnsequencedStart = memo(
 )
 
 export interface SequenceMarkerUnsequencedEndProps {
+  index: number
   seqName: string
   genomeSize: number
   alignmentEnd: number
@@ -112,10 +114,10 @@ export interface SequenceMarkerUnsequencedEndProps {
 
 // eslint-disable-next-line react/display-name
 export const SequenceMarkerUnsequencedEnd = memo(
-  ({ seqName, genomeSize, alignmentEnd, pixelsPerBase }: SequenceMarkerUnsequencedEndProps) => {
+  ({ index, seqName, genomeSize, alignmentEnd, pixelsPerBase }: SequenceMarkerUnsequencedEndProps) => {
     const { t } = useTranslation()
 
-    const id = getSafeId('sequence-marker-unsequenced-end', { seqName, alignmentEnd })
+    const id = getSafeId('sequence-marker-unsequenced-end', { index, seqName, alignmentEnd })
 
     const begin = alignmentEnd
     const length = genomeSize - alignmentEnd

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
@@ -39,7 +39,8 @@ export interface SequenceViewProps extends ReactResizeDetectorDimensions {
 }
 
 export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
-  const { seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd, frameShifts, insertions } = sequence
+  const { index, seqName, substitutions, missing, deletions, alignmentStart, alignmentEnd, frameShifts, insertions } =
+    sequence
 
   const { t } = useTranslationSafe()
   const maxNucMarkers = useRecoilValue(maxNucMarkersAtom)
@@ -60,6 +61,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     return (
       <SequenceMarkerMutation
         key={substitution.pos}
+        index={index}
         seqName={seqName}
         substitution={substitution}
         pixelsPerBase={pixelsPerBase}
@@ -71,6 +73,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     return (
       <SequenceMarkerMissing
         key={oneMissing.begin}
+        index={index}
         seqName={seqName}
         missing={oneMissing}
         pixelsPerBase={pixelsPerBase}
@@ -80,7 +83,13 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
 
   const deletionViews = deletions.map((deletion) => {
     return (
-      <SequenceMarkerGap key={deletion.start} seqName={seqName} deletion={deletion} pixelsPerBase={pixelsPerBase} />
+      <SequenceMarkerGap
+        key={deletion.start}
+        index={index}
+        seqName={seqName}
+        deletion={deletion}
+        pixelsPerBase={pixelsPerBase}
+      />
     )
   })
 
@@ -88,6 +97,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
     return (
       <SequenceMarkerInsertion
         key={insertion.pos}
+        index={index}
         seqName={seqName}
         insertion={insertion}
         pixelsPerBase={pixelsPerBase}
@@ -98,6 +108,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
   const frameShiftMarkers = frameShifts.map((frameShift) => (
     <SequenceMarkerFrameShift
       key={`${frameShift.geneName}_${frameShift.nucAbs.begin}`}
+      index={index}
       seqName={seqName}
       frameShift={frameShift}
       pixelsPerBase={pixelsPerBase}
@@ -128,6 +139,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
       <SequenceViewSVG viewBox={`0 0 ${width} 10`}>
         <rect fill="transparent" x={0} y={-10} width={genomeSize} height="30" />
         <SequenceMarkerUnsequencedStart
+          index={index}
           seqName={seqName}
           alignmentStart={alignmentStart}
           pixelsPerBase={pixelsPerBase}
@@ -137,6 +149,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
         {deletionViews}
         {insertionViews}
         <SequenceMarkerUnsequencedEnd
+          index={index}
           seqName={seqName}
           genomeSize={genomeSize}
           alignmentEnd={alignmentEnd}

--- a/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -72,7 +72,7 @@ export function useRunAnalysis() {
             // set(analysisResultsAtom(record.seqName), { index: record.index, seqName: record.seqName })
           },
           onAnalysisResult(result) {
-            set(analysisResultAtom(result.seqName), result)
+            set(analysisResultAtom(result.index), result)
           },
           onError(error) {
             set(globalErrorAtom, error)


### PR DESCRIPTION
Nextclade is using sequence names to uniquely identify sequences. However, sequence names come from user inputs and cannot be trusted to be unique. Neither it seems there is a consensus on uniqueness of sequence names in the bioinformatics community as a whole.

This causes various problems where sequence names are used as identifiers, and when for example there are multiple sequences with the same name. In particular, when Nextclade Web stores analysis results, they are effectively stored in an associative container, where sequence name acts as a key. This leads to newer results overwriting older results as they arrive during analysis. Additionally, some of the HTML `id` properties used sequence names to add uniqueness. This was leading to incorrect HTML being produces, with multiple elements having the same `id` property.

In this PR I:
 - change internal storage to use sequence indices in the input file(s) as keys
 - add sequence index into HTML `id`s
 - display "Sequence index" in places where only sequence name was displayed previously

This should ensure correct handling of duplicated names.

This affects only web application. In the algorithmic and CLI parts, sequence names are not used - results are stored in the form of an array, and no HTML is involved.