### PR TITLE
fix: underflow when mutation in gene close to start

### DIFF
--- a/packages_rs/nextclade/src/analyze/aa_changes.rs
+++ b/packages_rs/nextclade/src/analyze/aa_changes.rs
@@ -16,7 +16,7 @@ use crate::utils::error::keep_ok;
 use crate::utils::range::Range;
 use eyre::Report;
 use itertools::{assert_equal, merge, Itertools};
-use num::clamp;
+use num_traits::{clamp_max, clamp_min};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
@@ -316,8 +316,9 @@ fn find_aa_changes_for_gene(
     }
 
     // Provide surrounding context in nucleotide sequences: 1 codon to the left and 1 codon to the right
-    let context_begin = clamp(codon_begin - 3, 0, num_nucs);
-    let context_end = clamp(codon_end + 3, 0, num_nucs);
+    // Avoid underflow bug when codon_begin <=2
+    let context_begin = clamp_min(codon_begin, 3) - 3;
+    let context_end = clamp_max(codon_end + 3, num_nucs);
     let mut ref_context = (&ref_seq[context_begin..context_end]).to_vec();
     let mut query_context = (&qry_seq[context_begin..context_end]).to_vec();
     if gene.strand == GeneStrand::Reverse {


### PR DESCRIPTION
When the first gene is very close to the start of the sequence, as in flu_yam_ha, and a mutation happens in the first codon, and underflow would happen inside a clamp.

So while nothing would go wrong logic wise, Rust was oversensitive here, panicking.

It would still be good to check that context behaves as expected in this edge case - as this seems to not occur commonly - outside of yam.

This PR needs to be merged in order for yam dataset to work again - bit tricky - we should exclude the range 2.0.0 to 2.3.0 for flu_yam_ha, what should we set as min version? Maybe 2.3.1 therefore not giving a new dataset to v1 users? I think that's OK as yam hardly changes.