### PR TITLE
feat(web): report duplicate sequence names

### DIFF
--- a/packages_rs/nextclade-web/src/components/Results/ColumnName.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnName.tsx
@@ -3,10 +3,10 @@ import { useRecoilValue } from 'recoil'
 import { isEmpty, isNil } from 'lodash'
 import styled from 'styled-components'
 
-import { analysisResultAtom } from 'src/state/results.state'
+import { analysisResultAtom, seqNameDuplicatesAtom } from 'src/state/results.state'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { ColumnNameErrorTooltip, ColumnNameTooltip } from 'src/components/Results/ColumnNameTooltip'
+import { ColumnNameErrorTooltip, ColumnNameTooltip, DuplicateIcon } from 'src/components/Results/ColumnNameTooltip'
 import { Tooltip } from 'src/components/Results/Tooltip'
 import { getStatusIconAndText } from 'src/components/Results/getStatusIconAndText'
 
@@ -28,6 +28,15 @@ export function ColumnName({ index, seqName }: ColumnNameProps) {
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
   const id = useMemo(() => getSafeId('sequence-label', { index }), [index])
 
+  const duplicateIndices = useRecoilValue(seqNameDuplicatesAtom(seqName))
+  const duplicateIcon = useMemo(() => {
+    const hasDuplicates = duplicateIndices.length > 1
+    if (hasDuplicates) {
+      return <DuplicateIcon />
+    }
+    return undefined
+  }, [duplicateIndices.length])
+
   const { StatusIcon } = useMemo(
     () =>
       getStatusIconAndText({
@@ -40,25 +49,19 @@ export function ColumnName({ index, seqName }: ColumnNameProps) {
 
   const tooltip = useMemo(() => {
     if (error) {
-      return (
-        <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
-          <ColumnNameErrorTooltip index={index} seqName={seqName} error={error} />
-        </Tooltip>
-      )
+      return <ColumnNameErrorTooltip index={index} seqName={seqName} error={error} />
     }
-
-    return (
-      <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
-        <ColumnNameTooltip index={index} />
-      </Tooltip>
-    )
-  }, [error, id, index, seqName, showTooltip])
+    return <ColumnNameTooltip index={index} />
+  }, [error, index, seqName])
 
   return (
     <SequenceName id={id} className="w-100" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       <StatusIcon />
+      {duplicateIcon}
       {seqName}
-      {tooltip}
+      <Tooltip wide fullWidth target={id} isOpen={showTooltip} placement="right-start">
+        {tooltip}
+      </Tooltip>
     </SequenceName>
   )
 }

--- a/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
@@ -1,10 +1,11 @@
 import { isEmpty, isNil } from 'lodash'
 import React, { useMemo } from 'react'
+import { IoDuplicateSharp } from 'react-icons/io5'
 import { Alert as ReactstrapAlert } from 'reactstrap'
 import { useRecoilValue } from 'recoil'
 import styled from 'styled-components'
 
-import { analysisResultAtom } from 'src/state/results.state'
+import { analysisResultAtom, seqNameDuplicatesAtom } from 'src/state/results.state'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { formatRange } from 'src/helpers/formatRange'
 import { ListOfPcrPrimerChanges } from 'src/components/SequenceView/ListOfPcrPrimerChanges'
@@ -19,6 +20,14 @@ const Alert = styled(ReactstrapAlert)`
 
 const TableSlim = styled(TableSlimBase)`
   width: 400px;
+`
+
+export const DuplicateIcon = styled(IoDuplicateSharp)`
+  width: 1rem;
+  height: 1rem;
+  color: ${(props) => props.theme.warning};
+  padding-right: 2px;
+  filter: drop-shadow(2px 1px 2px rgba(0, 0, 0, 0.2));
 `
 
 export interface ColumnNameTooltipProps {
@@ -38,6 +47,24 @@ export function ColumnNameTooltip({ index }: ColumnNameTooltipProps) {
       }),
     [error, result?.analysisResult.warnings, t],
   )
+
+  const duplicateIndices = useRecoilValue(seqNameDuplicatesAtom(result?.analysisResult.seqName ?? ''))
+  const duplicatedNamesRow = useMemo(() => {
+    const hasDuplicates = duplicateIndices.length > 1
+    if (hasDuplicates) {
+      const indices = duplicateIndices.join(', ')
+      return (
+        <tr>
+          <td>{t('Duplicate sequence names')}</td>
+          <td>
+            <DuplicateIcon />
+            {`sequences # ${indices}`}
+          </td>
+        </tr>
+      )
+    }
+    return undefined
+  }, [duplicateIndices, t])
 
   const warningComponents = useMemo(() => {
     return (result?.analysisResult?.warnings ?? []).map((warning) => (
@@ -72,6 +99,8 @@ export function ColumnNameTooltip({ index }: ColumnNameTooltipProps) {
             {statusText}
           </td>
         </tr>
+
+        {duplicatedNamesRow}
 
         <tr>
           <td>{t('Clade')}</td>


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/946

This adds little yellow icons in the "Sequence name" column when a sequence has the same name as other sequences in the same run. Indices of these sequences are additionally listed in the tooltip.

![01](https://user-images.githubusercontent.com/9403403/181414142-a8a51d82-d0e1-45ce-9491-2242f0f9bf36.png)

