### PR TITLE
fix: correctly reset duplicate sequence name map on new runs

### DIFF
--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -56,6 +56,8 @@ export const analysisResultAtom = selectorFamily<NextcladeResult, number>({
     (index) =>
     ({ get, set, reset }, result: NextcladeResult | DefaultValue) => {
       if (isDefaultValue(result)) {
+        const result = get(analysisResultInternalAtom(index))
+        reset(seqNameDuplicatesAtom(result.seqName))
         reset(analysisResultInternalAtom(index))
         reset(seqIndicesAtom)
       } else {


### PR DESCRIPTION
Currently duplicate sequence name data persists across unrelated runs of Nextclade Web. This causes incorrect reporting of duplicates.

This PR ensures that duplicate sequence name data does not persist across runs.

