### PR TITLE
fix: make filtering code safer

### DIFF
--- a/packages_rs/nextclade-web/src/filtering/filterByAminoacidChanges.ts
+++ b/packages_rs/nextclade-web/src/filtering/filterByAminoacidChanges.ts
@@ -6,7 +6,7 @@ import { notUndefined } from 'src/helpers/notUndefined'
 import type { AminoacidSubstitution, NextcladeResult } from 'src/algorithms/types'
 import { splitFilterString } from './splitFilterString'
 
-export function aminoacidChangesAreEqual(filter: Partial<AminoacidSubstitution>, actual: AminoacidSubstitution) {
+export function aminoacidChangesAreEqual(actual: AminoacidSubstitution, filter: Partial<AminoacidSubstitution>) {
   const geneMatch = isNil(filter.gene) || (filter.gene ?? '').toLowerCase() === actual.gene.toLowerCase()
   const posMatch = isNil(filter.codon) || (filter.codon ?? -1) === actual.codon
   const refNucMatch = isNil(filter.refAA) || (filter.refAA ?? '').toLowerCase() === (actual.refAA ?? '').toLowerCase()
@@ -33,6 +33,6 @@ export function filterByAminoacidChanges(aaFilter: string) {
     // We want to search for both, the substitutions and deletions
     const aaChanges = [...aaSubstitutions, ...aaDeletionsLikeSubstitutions]
 
-    return intersectionWith(aaFilters, aaChanges, aminoacidChangesAreEqual).length > 0
+    return intersectionWith(aaChanges, aaFilters, aminoacidChangesAreEqual).length > 0
   }
 }

--- a/packages_rs/nextclade-web/src/filtering/filterByAminoacidChanges.ts
+++ b/packages_rs/nextclade-web/src/filtering/filterByAminoacidChanges.ts
@@ -1,4 +1,4 @@
-import { intersectionWith } from 'lodash'
+import { intersectionWith, isNil } from 'lodash'
 
 import { AMINOACID_GAP } from 'src/constants'
 import { parseAminoacidChange } from 'src/helpers/parseAminoacidChange'
@@ -7,13 +7,11 @@ import type { AminoacidSubstitution, NextcladeResult } from 'src/algorithms/type
 import { splitFilterString } from './splitFilterString'
 
 export function aminoacidChangesAreEqual(filter: Partial<AminoacidSubstitution>, actual: AminoacidSubstitution) {
-  const geneMatch = filter.gene === undefined || filter.gene.toLowerCase() === actual.gene.toLowerCase()
-  const posMatch = filter.codon === undefined || filter.codon === actual.codon
-  const refNucMatch =
-    filter.refAA === undefined || (filter.refAA as string).toLowerCase() === (actual.refAA as string).toLowerCase()
+  const geneMatch = isNil(filter.gene) || (filter.gene ?? '').toLowerCase() === actual.gene.toLowerCase()
+  const posMatch = isNil(filter.codon) || (filter.codon ?? -1) === actual.codon
+  const refNucMatch = isNil(filter.refAA) || (filter.refAA ?? '').toLowerCase() === (actual.refAA ?? '').toLowerCase()
   const queryNucMatch =
-    filter.queryAA === undefined ||
-    (filter.queryAA as string).toLowerCase() === (actual.queryAA as string).toLowerCase()
+    isNil(filter.queryAA) || (filter.queryAA ?? '').toLowerCase() === (actual.queryAA ?? '').toLowerCase()
   return geneMatch && posMatch && refNucMatch && queryNucMatch
 }
 

--- a/packages_rs/nextclade-web/src/filtering/filterByNucleotideMutations.ts
+++ b/packages_rs/nextclade-web/src/filtering/filterByNucleotideMutations.ts
@@ -1,4 +1,4 @@
-import { intersectionWith } from 'lodash'
+import { intersectionWith, isNil } from 'lodash'
 
 import type { NextcladeResult } from 'src/algorithms/types'
 import { parseMutation } from 'src/helpers/parseMutation'
@@ -8,9 +8,10 @@ import { NucleotideSubstitution } from 'src/algorithms/types'
 import { splitFilterString } from './splitFilterString'
 
 export function mutationsAreEqual(filter: Partial<NucleotideSubstitution>, actual: NucleotideSubstitution) {
-  const posMatch = filter.pos === undefined || filter.pos === actual.pos
-  const refNucMatch = filter.refNuc === undefined || filter.refNuc.toLowerCase() === actual.refNuc.toLowerCase()
-  const queryNucMatch = filter.queryNuc === undefined || filter.queryNuc.toLowerCase() === actual.queryNuc.toLowerCase()
+  const posMatch = isNil(filter.pos) || (filter.pos ?? -1) === actual.pos
+  const refNucMatch = isNil(filter.refNuc) || (filter.refNuc ?? '').toLowerCase() === actual.refNuc.toLowerCase()
+  const queryNucMatch =
+    isNil(filter.queryNuc) || (filter.queryNuc ?? '').toLowerCase() === actual.queryNuc.toLowerCase()
   return posMatch && refNucMatch && queryNucMatch
 }
 


### PR DESCRIPTION
Related to: https://github.com/nextstrain/nextclade/issues/961

This removes casts in amino acid and nucleotide filtering code which have a potential to cause crashes in certain cases. I made `undefined`-comparison more lax, such that now it also checks for `null` and added default values to anything that can be nil.

Even though I cannot reproduce the issue, this hopefully should fix it.

