### PR TITLE
feat: add secondary clade-like values

### DIFF
--- a/packages_rs/nextclade-web/src/components/Results/ColumnCustomNodeAttr.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnCustomNodeAttr.tsx
@@ -1,9 +1,15 @@
-import React from 'react'
-
-import { get } from 'lodash'
+import React, { useCallback, useMemo, useState } from 'react'
+import { get, values } from 'lodash'
+import styled from 'styled-components'
 
 import type { AnalysisResult } from 'src/types'
 import { getSafeId } from 'src/helpers/getSafeId'
+import { TableSlimWithBorders } from 'src/components/Common/TableSlim'
+import { Tooltip } from './Tooltip'
+
+const Table = styled(TableSlimWithBorders)`
+  margin-top: 1rem;
+`
 
 export interface ColumnCustomNodeAttrProps {
   sequence: AnalysisResult
@@ -11,14 +17,34 @@ export interface ColumnCustomNodeAttrProps {
 }
 
 export function ColumnCustomNodeAttr({ sequence, attrKey }: ColumnCustomNodeAttrProps) {
-  const { index, seqName, customNodeAttributes } = sequence
-  const attrValue = get(customNodeAttributes, attrKey, '')
+  const [showTooltip, setShowTooltip] = useState(false)
+  const onMouseEnter = useCallback(() => setShowTooltip(true), [])
+  const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const id = getSafeId('col-custom-attr', { index, seqName, attrKey })
+  const { id, attrValue, secondaryValues } = useMemo(() => {
+    const { index, seqName, customNodeAttributes } = sequence
+    const attr = get(customNodeAttributes, attrKey, undefined)
+
+    const secondaryValues = values(attr?.secondaryValues ?? {}).map(({ key, value }) => (
+      <tr key={key}>
+        <td>{key}</td>
+        <td>{value}</td>
+      </tr>
+    ))
+
+    const id = getSafeId('col-custom-attr', { index, seqName, attrKey })
+
+    return { id, attrValue: attr?.value, secondaryValues }
+  }, [attrKey, sequence])
 
   return (
-    <div id={id} className="w-100">
-      {attrValue}
-    </div>
+    <>
+      <div id={id} className="w-100" onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        {attrValue}
+      </div>
+      <Tooltip isOpen={secondaryValues.length > 0 && showTooltip} target={id} wide fullWidth>
+        <Table borderless>{secondaryValues}</Table>
+      </Tooltip>
+    </>
   )
 }

--- a/packages_rs/nextclade-web/src/types.ts
+++ b/packages_rs/nextclade-web/src/types.ts
@@ -380,9 +380,20 @@ export interface AnalysisResult {
   privateAaMutations: Record<string, PrivateMutations>
   coverage: number
   qc: QcResult
-  customNodeAttributes: Record<string, string>
+  customNodeAttributes: Record<string, CustomNodeAttrValue>
   warnings: PeptideWarning[]
   missingGenes: string[]
+}
+
+export interface SecondaryCustomNodeAttrValue {
+  key: string
+  value: string
+}
+
+export interface CustomNodeAttrValue {
+  key: string
+  value: string
+  secondaryValues: Record<string, SecondaryCustomNodeAttrValue>
 }
 
 export interface AnalysisError {

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -182,7 +182,7 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
     custom_node_attributes
       .clone()
       .into_iter()
-      .try_for_each(|(key, val)| self.add_entry(&key, &val))?;
+      .try_for_each(|(key, attr)| self.add_entry(&key, &attr.value))?;
 
     self.add_entry("seqName", seq_name)?;
     self.add_entry("clade", clade)?;

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -117,7 +117,7 @@ pub fn nextclade_run_one(
   let clade = node.clade();
 
   let clade_node_attr_keys = tree.clade_node_attr_descs();
-  let clade_node_attrs = node.get_clade_node_attrs(clade_node_attr_keys);
+  let custom_node_attributes = node.get_clade_node_attrs(clade_node_attr_keys);
 
   let private_nuc_mutations = find_private_nuc_mutations(
     node,
@@ -203,7 +203,7 @@ pub fn nextclade_run_one(
       divergence,
       coverage,
       qc,
-      custom_node_attributes: clade_node_attrs,
+      custom_node_attributes,
       nearest_node_id,
       is_reverse_complement,
     },

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -2,10 +2,9 @@ use crate::io::aa::Aa;
 use crate::io::fs::read_file_to_string;
 use crate::io::json::json_parse;
 use crate::io::nuc::Nuc;
+use crate::types::outputs::{CustomNodeAttr, SecondaryCustomNodeAttrValue};
 use eyre::{Report, WrapErr};
-use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::any::Any;
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::slice::Iter;
@@ -144,21 +143,61 @@ impl AuspiceTreeNode {
     self.node_attrs.clade_membership.value.clone()
   }
 
-  /// Extracts clade-like node attributes, given a list of key descriptions
-  pub fn get_clade_node_attrs(&self, clade_node_attr_keys: &[CladeNodeAttrKeyDesc]) -> BTreeMap<String, String> {
-    clade_node_attr_keys
+  fn _extract_clade_node_attr(&self, key: &str) -> Option<String> {
+    match self.node_attrs.other.get(key) {
+      Some(attr) => attr.get("value").and_then(|value| value.as_str().map(str::to_owned)),
+      None => None,
+    }
+  }
+
+  fn _extract_clade_node_attrs(&self, meta_attr: &CladeNodeAttrKeyDesc) -> Option<(String, CustomNodeAttr)> {
+    let secondary_values: BTreeMap<String, SecondaryCustomNodeAttrValue> = meta_attr
+      .secondary_attrs
       .iter()
-      .filter_map(|attr| {
-        let key = &attr.name;
-        let attr_obj = self.node_attrs.other.get(key);
-        match attr_obj {
-          Some(attr) => attr.get("value"),
-          None => None,
-        }
-        .and_then(|val| val.as_str().map(|val| (key.clone(), val.to_owned())))
+      .filter_map(|sec_attr| {
+        self._extract_clade_node_attr(&sec_attr.name).map(|value| {
+          (
+            sec_attr.name.clone(),
+            SecondaryCustomNodeAttrValue {
+              key: sec_attr.name.clone(),
+              value,
+            },
+          )
+        })
       })
+      .collect();
+
+    let key = &meta_attr.name;
+    self._extract_clade_node_attr(key).map(|value| {
+      (
+        key.clone(),
+        CustomNodeAttr {
+          key: key.clone(),
+          value,
+          secondary_values,
+        },
+      )
+    })
+  }
+
+  /// Extracts clade-like node attribute values, given a list of key descriptions from tree meta
+  pub fn get_clade_node_attrs(
+    &self,
+    clade_node_attr_key_descs: &[CladeNodeAttrKeyDesc],
+  ) -> BTreeMap<String, CustomNodeAttr> {
+    clade_node_attr_key_descs
+      .iter()
+      .filter_map(|meta_attr| self._extract_clade_node_attrs(meta_attr))
       .collect()
   }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SecondaryCustomNodeAttr {
+  name: String,
+  display_name: String,
+  description: String,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -167,6 +206,10 @@ pub struct CladeNodeAttrKeyDesc {
   pub name: String,
   pub display_name: String,
   pub description: String,
+
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(default)]
+  pub secondary_attrs: Vec<SecondaryCustomNodeAttr>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Validate, Debug)]

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -34,6 +34,21 @@ pub struct NextalignOutputs {
   pub is_reverse_complement: bool,
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SecondaryCustomNodeAttrValue {
+  pub key: String,
+  pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomNodeAttr {
+  pub key: String,
+  pub value: String,
+  pub secondary_values: BTreeMap<String, SecondaryCustomNodeAttrValue>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NextcladeOutputs {
@@ -76,7 +91,7 @@ pub struct NextcladeOutputs {
   pub divergence: f64,
   pub coverage: f64,
   pub qc: QcResult,
-  pub custom_node_attributes: BTreeMap<String, String>,
+  pub custom_node_attributes: BTreeMap<String, CustomNodeAttr>,
   pub nearest_node_id: usize,
   pub is_reverse_complement: bool,
 }


### PR DESCRIPTION
Adds secondary (nested under primary) attributes for custom clade-like node attributes.

The secondary key-value pairs will appear in the Nextclade Web in tooltips of primary custom clade-like columns (displayed in the cells).


#### How to:

Modify reference tree as follows:

Add array of descriptions of secondary attributes under `meta.extensions.nextclade.clade_node_attrs[].secondaryAttrs[]`:


```json
{
  "meta": {
    "extensions": {
      "nextclade": {
        "clade_node_attrs": [
          {
            "name": "Nextclade_pango",
            "displayName": "Pango lineage (Nextclade)",
            "description": "...",
            "secondaryAttrs": [
              {
                "name": "foo",
                "displayName": "Foo",
                "description": "..."
              },
              {
                "name": "bar",
                "displayName": "Bar",
                "description": "..."
              }
            ]
          }
        ]
      }
    }
  }
}
```

Add values (strings) to the node attribute object with the keys matching `clade_node_attrs[].secondaryAttrs[].name`:

```json
{
  "name": "NODE_0000000",
  "node_attrs": {
    "Nextclade_pango": { "value": "B" },
    "foo": { "value": "Hello" },
  },
  "branch_attrs": {}
}
```



#### Compatibility

These changes are backwards compatible: previous versions of Nextclade don't know about `secondaryAttrs` field and will ignore it. 

These changes are forward compatible: new versions ignore secondary attributes if `secondaryAttrs` property is missing, an empty array, or (for each node) if `node_attrs` does not contain a value for a given attributive.
