### PR TITLE
fix(web): read dataset name from URL, even when fasta is not provided

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/ButtonCustomize.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/ButtonCustomize.tsx
@@ -6,6 +6,8 @@ import styled, { useTheme } from 'styled-components'
 
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
+import { inputCustomizationCounterAtom } from 'src/state/inputs.state'
+import { useRecoilValue } from 'recoil'
 
 export const CustomizeButton = styled(ButtonTransparent)`
   display: flex;
@@ -19,14 +21,33 @@ export const CustomizeButton = styled(ButtonTransparent)`
   text-decoration: none;
 `
 
+export const DatasetCustomizationIndicator = styled.span<{ size: number }>`
+  color: ${(props) => props.theme.gray200};
+  background-color: ${(props) => props.theme.danger};
+  width: ${(props) => props.size}px;
+  height: ${(props) => props.size}px;
+  border-radius: ${(props) => props.size}px;
+  margin-left: 0.5rem;
+`
+
 export interface ButtonCustomizeProps extends ButtonProps {
   isOpen: boolean
+
   onClick(): void
 }
 
 export function ButtonCustomize({ isOpen, onClick, ...props }: PropsWithChildren<ButtonCustomizeProps>) {
   const { t } = useTranslationSafe()
   const theme = useTheme()
+
+  const inputCustomizationCounter = useRecoilValue(inputCustomizationCounterAtom)
+
+  const inputCustomizationCounterComponent = useMemo(() => {
+    if (inputCustomizationCounter === 0) {
+      return null
+    }
+    return <DatasetCustomizationIndicator size={23}>{inputCustomizationCounter}</DatasetCustomizationIndicator>
+  }, [inputCustomizationCounter])
 
   const iconClassName = useMemo(() => classNames('my-auto mr-1', isOpen ? 'icon-rotate-0' : 'icon-rotate-90'), [isOpen])
 
@@ -38,7 +59,8 @@ export function ButtonCustomize({ isOpen, onClick, ...props }: PropsWithChildren
   return (
     <CustomizeButton type="button" color="link" onClick={onClick} {...props}>
       <IoIosArrowDropdownCircle color={theme.gray650} size={25} className={iconClassName} />
-      {customizeButtonText}
+      <span>{customizeButtonText}</span>
+      {inputCustomizationCounterComponent}
     </CustomizeButton>
   )
 }

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -5,22 +5,11 @@ import { fetchDatasetsIndex, findDataset, getLatestCompatibleEnabledDatasets } f
 import { getQueryParamMaybe } from 'src/io/getQueryParamMaybe'
 
 export async function getDatasetFromUrlParams(urlQuery: ParsedUrlQuery, datasets: Dataset[]) {
-  const inputFastaUrl = getQueryParamMaybe(urlQuery, 'input-fasta')
-
-  // If there are no input sequences, we are not going to run, so skip the rest
-  if (!inputFastaUrl) {
-    return undefined
-  }
-
   // Retrieve dataset-related URL params and try to find a dataset based on these params
   const datasetName = getQueryParamMaybe(urlQuery, 'dataset-name')
 
   if (!datasetName) {
-    throw new Error(
-      "Incorrect URL parameters: 'input-fasta' is set, but 'dataset-name' is not. " +
-        "Nextclade won't run to avoid producing incorrect results. " +
-        "Please set 'dataset-name' explicitly in the URL parameters",
-    )
+    return undefined
   }
 
   const datasetRef = getQueryParamMaybe(urlQuery, 'dataset-reference')

--- a/packages_rs/nextclade-web/src/state/inputs.state.ts
+++ b/packages_rs/nextclade-web/src/state/inputs.state.ts
@@ -2,6 +2,7 @@ import { isEmpty } from 'lodash'
 import { useCallback } from 'react'
 import { atom, selector, useRecoilState, useResetRecoilState } from 'recoil'
 import { AlgorithmInput } from 'src/types'
+import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 
 export const qrySeqInputsStorageAtom = atom<AlgorithmInput[]>({
   key: 'qrySeqInputsStorage',
@@ -63,6 +64,21 @@ export const hasRequiredInputsAtom = selector({
   key: 'hasRequiredInputs',
   get({ get }) {
     return !isEmpty(get(qrySeqInputsStorageAtom))
+  },
+})
+
+/** Counts how many custom inputs are set */
+export const inputCustomizationCounterAtom = selector<number>({
+  key: 'inputCustomizationCounterAtom',
+  get: ({ get }) => {
+    return [
+      get(refSeqInputAtom),
+      get(geneMapInputAtom),
+      get(refTreeInputAtom),
+      get(qcConfigInputAtom),
+      get(virusPropertiesInputAtom),
+      get(primersCsvInputAtom),
+    ].filter(notUndefinedOrNull).length
   },
 })
 


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/998

Now when `dataset-name` is present in the URL params, Nextclade will try to find and set this dataset as current, regardless of whether the `input-fasta` is also provided. This allows to set a dataset and customize its files using URL params, with intent to then load fasta manually.

Normally, when navigation happened from such URL, there is no obvious sign that dataset files were changed. I added a little indicator with a counter to make it more obvious when dataset files are customized.

Example: 

https://nextclade-git-feat-web-url-read-dataset-witho-0511cb-nextstrain.vercel.app/?dataset-name=sars-cov-2-21L&input-tree=https%3A%2F%2Fapi.codetabs.com%2Fv1%2Fproxy%3Fquest%3Dhttps%3A%2F%2Fnextstrain.org%2Fcharon%2FgetDataset%3Fprefix%3Dstaging%2Fnextclade%2Fsars-cov-2%2F21L


