### PR TITLE
fix: link to release dataset changelog

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
@@ -102,7 +102,7 @@ export function DatasetCurrent() {
               </ChangeButton>
               <LinkExternal
                 className="ml-auto mt-auto"
-                href="https://github.com/nextstrain/nextclade_data/blob/master/CHANGELOG.md"
+                href="https://github.com/nextstrain/nextclade_data/blob/release/CHANGELOG.md"
               >
                 <small>{t('Recent dataset updates')}</small>
               </LinkExternal>

--- a/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
@@ -125,7 +125,7 @@ export function DatasetSelector({ searchTerm, setSearchTerm }: DatasetSelectorPr
 
       <Row noGutters>
         <Col className="py-1">
-          <LinkExternal href="https://github.com/nextstrain/nextclade_data/blob/master/CHANGELOG.md">
+          <LinkExternal href="https://github.com/nextstrain/nextclade_data/blob/release/CHANGELOG.md">
             <small>{t('Recent dataset updates')}</small>
           </LinkExternal>
         </Col>


### PR DESCRIPTION
Currently release users see master dataset changelog. Here I change the link such that they see dataset changelog on release branch, i.e. only released dataset changes.

