### PR TITLE
feat(web): format tooltip text

### DIFF
--- a/packages_rs/nextclade-web/src/components/Common/FormattedText.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/FormattedText.tsx
@@ -1,0 +1,6 @@
+import React, { useMemo } from 'react'
+
+export function FormattedText({ text }: { text: string }) {
+  const paragraphs = useMemo(() => text.split('\n').map((line) => <p key={line}>{line}</p>), [text])
+  return <section>{paragraphs}</section>
+}

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
@@ -23,6 +23,7 @@ import {
   sortAnalysisResultsAtom,
   sortAnalysisResultsByKeyAtom,
 } from 'src/state/results.state'
+import { FormattedText } from 'src/components/Common/FormattedText'
 import type { TableRowDatum } from './ResultsTableRow'
 import { ResultsTableRow } from './ResultsTableRow'
 import {
@@ -205,7 +206,7 @@ export function ResultsTable() {
           </TableHeaderCellContent>
           <ButtonHelpStyled identifier={`btn-help-col-phenotype-${name}`} tooltipWidth="600px">
             <h5>{`Column: ${nameFriendly}`}</h5>
-            <p>{description}</p>
+            <FormattedText text={description} />
           </ButtonHelpStyled>
         </TableHeaderCell>
       )


### PR DESCRIPTION
Format text of custom phenotype columns. This text comes from a JSON string, so formatting capabilities are very limited. Here I split the incoming string on `\n` and create paragraphs (`<p>`)  from each fragment.


![01](https://user-images.githubusercontent.com/9403403/192856479-3d76cc0a-ae5e-4e2c-aee3-fb4f56ac17d7.png)
