### PR TITLE
feat: allow hiding custom clade columns

### DIFF
--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -215,9 +215,23 @@ export const hasTreeAtom = selector<boolean>({
   },
 })
 
-export const cladeNodeAttrDescsAtom = atom<CladeNodeAttrDesc[]>({
-  key: 'cladeNodeAttrDescs',
+const cladeNodeAttrDescsStorageAtom = atom<CladeNodeAttrDesc[]>({
+  key: 'cladeNodeAttrDescsStorage',
   default: [],
+})
+
+export const cladeNodeAttrDescsAtom = selector<CladeNodeAttrDesc[]>({
+  key: 'cladeNodeAttrDescs',
+  get({ get }): CladeNodeAttrDesc[] {
+    return get(cladeNodeAttrDescsStorageAtom).filter(({ showInWeb }) => showInWeb)
+  },
+
+  set({ set, reset }, descs: CladeNodeAttrDesc[] | DefaultValue) {
+    set(cladeNodeAttrDescsStorageAtom, descs)
+    if (!isDefaultValue(descs)) {
+      reset(cladeNodeAttrDescsStorageAtom)
+    }
+  },
 })
 
 export const cladeNodeAttrKeysAtom = selector<string[]>({

--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -223,7 +223,7 @@ const cladeNodeAttrDescsStorageAtom = atom<CladeNodeAttrDesc[]>({
 export const cladeNodeAttrDescsAtom = selector<CladeNodeAttrDesc[]>({
   key: 'cladeNodeAttrDescs',
   get({ get }): CladeNodeAttrDesc[] {
-    return get(cladeNodeAttrDescsStorageAtom).filter(({ showInWeb }) => showInWeb)
+    return get(cladeNodeAttrDescsStorageAtom).filter(({ hideInWeb }) => !hideInWeb)
   },
 
   set({ set, reset }, descs: CladeNodeAttrDesc[] | DefaultValue) {

--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -228,7 +228,7 @@ export const cladeNodeAttrDescsAtom = selector<CladeNodeAttrDesc[]>({
 
   set({ set, reset }, descs: CladeNodeAttrDesc[] | DefaultValue) {
     set(cladeNodeAttrDescsStorageAtom, descs)
-    if (!isDefaultValue(descs)) {
+    if (isDefaultValue(descs)) {
       reset(cladeNodeAttrDescsStorageAtom)
     }
   },

--- a/packages_rs/nextclade-web/src/types/auspice/index.d.ts
+++ b/packages_rs/nextclade-web/src/types/auspice/index.d.ts
@@ -203,6 +203,7 @@ declare module 'auspice' {
     name: string
     displayName: string
     description: string
+    showInWeb: boolean
   }
 
   export declare interface AuspiceMetadata {

--- a/packages_rs/nextclade-web/src/types/auspice/index.d.ts
+++ b/packages_rs/nextclade-web/src/types/auspice/index.d.ts
@@ -203,7 +203,7 @@ declare module 'auspice' {
     name: string
     displayName: string
     description: string
-    showInWeb: boolean
+    hideInWeb: boolean
   }
 
   export declare interface AuspiceMetadata {

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -167,6 +167,8 @@ pub struct CladeNodeAttrKeyDesc {
   pub name: String,
   pub display_name: String,
   pub description: String,
+  #[serde(default)]
+  pub show_in_web: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Validate, Debug)]

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -168,7 +168,7 @@ pub struct CladeNodeAttrKeyDesc {
   pub display_name: String,
   pub description: String,
   #[serde(default)]
-  pub show_in_web: bool,
+  pub hide_in_web: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Validate, Debug)]


### PR DESCRIPTION
Related: https://github.com/nextstrain/nextclade_data/issues/39

Allows hiding custom clade columns from Nextclade Web.

In order to hide a column from Nextclade Web, set `"hideInWeb": true` in `meta.extensions.nextclade.clade_node_attrs` in reference tree JSON, for example:

```json
"extensions": {
  "nextclade": {
    "clade_node_attrs": [
      {
        "name": "WHO_name",
        "displayName": "...",
        "description": "...",
        "hideInWeb": true
      }
    ]
  }
}
```

The columns/fields will still be rendered in all other outputs: TSV, CSV, JSON and NDJSON
