### PR TITLE
fix: remove unused data from outputs

### DIFF
--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -175,8 +175,6 @@ pub fn nextclade_run_one(
         Some(PhenotypeValue {
           name: name.clone(),
           gene: gene.clone(),
-          name_friendly: name_friendly.clone(),
-          description: description.clone(),
           value: phenotype,
         })
       })

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -39,8 +39,6 @@ pub struct NextalignOutputs {
 pub struct PhenotypeValue {
   pub name: String,
   pub gene: String,
-  pub name_friendly: String,
-  pub description: String,
   pub value: f64,
 }
 


### PR DESCRIPTION
Removes `results[].phenotypeValues.nameFriendly` and `results[].phenotypeValues.description` from output JSON and NDJSON. These fields were not intended to be used, are repeated and increase file size needlessly.

