### PR TITLE
fix: add descriptions for phenotype attributes to outputs

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use log::info;
 use nextclade::align::gap_open::{get_gap_open_close_scores_codon_aware, get_gap_open_close_scores_flat};
 use nextclade::align::params::AlignPairwiseParams;
-use nextclade::analyze::phenotype::get_phenotype_attr_keys;
+use nextclade::analyze::phenotype::get_phenotype_attr_descs;
 use nextclade::io::fasta::{FastaReader, FastaRecord};
 use nextclade::io::fs::has_extension;
 use nextclade::io::json::json_write;
@@ -130,7 +130,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
   let should_keep_outputs = output_tree.is_some();
   let mut outputs = Vec::<NextcladeOutputs>::new();
 
-  let phenotype_attr_keys = get_phenotype_attr_keys(&virus_properties);
+  let phenotype_attrs = &get_phenotype_attr_descs(&virus_properties);
 
   std::thread::scope(|s| {
     const CHANNEL_SIZE: usize = 128;
@@ -223,7 +223,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
       let mut output_writer = NextcladeOrderedWriter::new(
         gene_map,
         clade_node_attrs,
-        &phenotype_attr_keys,
+        phenotype_attrs,
         &output_fasta,
         &output_json,
         &output_ndjson,

--- a/packages_rs/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages_rs/nextclade-web/src/hooks/useExportResults.ts
@@ -112,7 +112,8 @@ async function prepareResultsJson(snapshot: Snapshot, worker: ExportWorker) {
   const results = await mapGoodResults(snapshot, (result) => result.analysisResult)
   const errors = await mapErrors(snapshot, (err) => err)
   const cladeNodeAttrDescs = await snapshot.getPromise(cladeNodeAttrDescsAtom)
-  return worker.serializeResultsJson(results, errors, cladeNodeAttrDescs, PACKAGE_VERSION)
+  const phenotypeAttrDescs = await snapshot.getPromise(phenotypeAttrDescsAtom)
+  return worker.serializeResultsJson(results, errors, cladeNodeAttrDescs, phenotypeAttrDescs, PACKAGE_VERSION)
 }
 
 export function useExportJson() {

--- a/packages_rs/nextclade-web/src/wasm/main.rs
+++ b/packages_rs/nextclade-web/src/wasm/main.rs
@@ -119,6 +119,7 @@ impl NextcladeWasm {
     outputs_json_str: &str,
     errors_json_str: &str,
     clade_node_attrs_json_str: &str,
+    phenotype_attrs_json_str: &str,
     nextclade_web_version: Option<String>,
   ) -> Result<String, JsError> {
     let outputs: Vec<NextcladeOutputs> = jserr(
@@ -134,9 +135,20 @@ impl NextcladeWasm {
         .wrap_err("When serializing results JSON: When parsing clade node attrs JSON internally"),
     )?;
 
+    let phenotype_attrs: Vec<PhenotypeAttrDesc> = jserr(
+      json_parse(phenotype_attrs_json_str)
+        .wrap_err("When serializing results JSON: When parsing phenotypes attr keys JSON internally"),
+    )?;
+
     jserr(
-      results_to_json_string(&outputs, &errors, &clade_node_attrs, &nextclade_web_version)
-        .wrap_err("When serializing results JSON"),
+      results_to_json_string(
+        &outputs,
+        &errors,
+        &clade_node_attrs,
+        &phenotype_attrs,
+        &nextclade_web_version,
+      )
+      .wrap_err("When serializing results JSON"),
     )
   }
 

--- a/packages_rs/nextclade-web/src/workers/ExportThread.ts
+++ b/packages_rs/nextclade-web/src/workers/ExportThread.ts
@@ -27,9 +27,16 @@ export class ExportWorker {
     outputs: AnalysisResult[],
     errors: AnalysisError[],
     cladeNodeAttrsJson: CladeNodeAttrDesc[],
+    phenotypeAttrsJson: PhenotypeAttrDesc[],
     nextcladeWebVersion: string,
   ): Promise<string> {
-    return this.thread.serializeResultsJson(outputs, errors, cladeNodeAttrsJson, nextcladeWebVersion)
+    return this.thread.serializeResultsJson(
+      outputs,
+      errors,
+      cladeNodeAttrsJson,
+      phenotypeAttrsJson,
+      nextcladeWebVersion,
+    )
   }
 
   public async serializeResultsCsv(

--- a/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
+++ b/packages_rs/nextclade-web/src/workers/nextcladeWasm.worker.ts
@@ -194,12 +194,14 @@ export async function serializeResultsJson(
   outputs: AnalysisResult[],
   errors: AnalysisError[],
   cladeNodeAttrsJson: CladeNodeAttrDesc[],
+  phenotypeAttrsJson: PhenotypeAttrDesc[],
   nextcladeWebVersion: string,
 ) {
   return NextcladeWasm.serialize_results_json(
     JSON.stringify(outputs),
     JSON.stringify(errors),
     JSON.stringify(cladeNodeAttrsJson),
+    JSON.stringify(phenotypeAttrsJson),
     nextcladeWebVersion,
   )
 }


### PR DESCRIPTION
Adds descriptions of phenotype attributes to `.phenotypeAttrKeys` of JSON output. This is for symmetry with the similarly implemented `.cladeNodeAttrKeys` attributes.

