### PR TITLE
fix: ensure parsing of large, highly-nested tree JSONs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,7 @@ dependencies = [
  "rstest_reuse",
  "serde",
  "serde_json",
+ "serde_stacker",
  "strum 0.24.1",
  "strum_macros 0.24.1",
  "tinytemplate",
@@ -1963,6 +1964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037227ef03e9c319736423e8d2e29d8695315094b473030cdca306af3ad52688"
+dependencies = [
+ "serde",
+ "stacker",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,6 +2458,19 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "statrs"

--- a/docker-dev
+++ b/docker-dev
@@ -407,6 +407,11 @@ if [ "${RUN}" == "1" ]; then
   if [ "$(is_ci)" == "1" ]; then
     PARAMS=" --locked ${PARAMS}"
   fi
+
+  if [ -z "${RELEASE}" ]; then
+    RELEASE='--profile=opt-dev'
+  fi
+
   COMMAND="cargo run -q --target-dir='${BUILD_DIR_REL}' ${RUST_TARGET} ${RELEASE} ${PARAMS}"
 elif [ "${EXAMPLE}" == "1" ]; then
   PARAMS="$(echo "${@:-}" | xargs)"

--- a/docker-dev
+++ b/docker-dev
@@ -407,11 +407,6 @@ if [ "${RUN}" == "1" ]; then
   if [ "$(is_ci)" == "1" ]; then
     PARAMS=" --locked ${PARAMS}"
   fi
-
-  if [ -z "${RELEASE}" ]; then
-    RELEASE='--profile=opt-dev'
-  fi
-
   COMMAND="cargo run -q --target-dir='${BUILD_DIR_REL}' ${RUST_TARGET} ${RELEASE} ${PARAMS}"
 elif [ "${EXAMPLE}" == "1" ]; then
   PARAMS="$(echo "${@:-}" | xargs)"

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -43,6 +43,7 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order", "indexmap", "unbounded_depth"] }
+serde_stacker = { version = "0.1.6" }
 strum = "0.24.0"
 strum_macros = "0.24.0"
 tinytemplate = "1.2.1"

--- a/packages_rs/nextclade/src/io/json.rs
+++ b/packages_rs/nextclade/src/io/json.rs
@@ -4,12 +4,18 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 pub fn json_parse<T: for<'de> Deserialize<'de>>(s: &str) -> Result<T, Report> {
-  let obj = serde_json::from_str::<T>(s).wrap_err("When parsing JSON")?;
+  let mut de = serde_json::Deserializer::from_str(s);
+  de.disable_recursion_limit();
+  let de = serde_stacker::Deserializer::new(&mut de);
+  let obj = T::deserialize(de).wrap_err("When parsing JSON")?;
   Ok(obj)
 }
 
 pub fn json_parse_bytes<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, Report> {
-  let obj = serde_json::from_slice::<T>(bytes).wrap_err("When parsing JSON")?;
+  let mut de = serde_json::Deserializer::from_slice(bytes);
+  de.disable_recursion_limit();
+  let de = serde_stacker::Deserializer::new(&mut de);
+  let obj = T::deserialize(de).wrap_err("When parsing JSON")?;
   Ok(obj)
 }
 

--- a/packages_rs/nextclade/src/io/json.rs
+++ b/packages_rs/nextclade/src/io/json.rs
@@ -1,22 +1,28 @@
 use crate::io::file::create_file;
 use eyre::{Report, WrapErr};
 use serde::{Deserialize, Serialize};
+use serde_json::{de::Read, Deserializer};
 use std::path::Path;
 
-pub fn json_parse<T: for<'de> Deserialize<'de>>(s: &str) -> Result<T, Report> {
-  let mut de = serde_json::Deserializer::from_str(s);
+/// Mitigates recursion limit error when parsing large JSONs
+/// See https://github.com/serde-rs/json/issues/334
+pub fn deserialize_without_recursion_limit<'de, R: Read<'de>, T: Deserialize<'de>>(
+  de: &mut Deserializer<R>,
+) -> Result<T, Report> {
   de.disable_recursion_limit();
-  let de = serde_stacker::Deserializer::new(&mut de);
+  let de = serde_stacker::Deserializer::new(de);
   let obj = T::deserialize(de).wrap_err("When parsing JSON")?;
   Ok(obj)
 }
 
+pub fn json_parse<T: for<'de> Deserialize<'de>>(s: &str) -> Result<T, Report> {
+  let mut de = Deserializer::from_str(s);
+  deserialize_without_recursion_limit(&mut de)
+}
+
 pub fn json_parse_bytes<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, Report> {
-  let mut de = serde_json::Deserializer::from_slice(bytes);
-  de.disable_recursion_limit();
-  let de = serde_stacker::Deserializer::new(&mut de);
-  let obj = T::deserialize(de).wrap_err("When parsing JSON")?;
-  Ok(obj)
+  let mut de = Deserializer::from_slice(bytes);
+  deserialize_without_recursion_limit(&mut de)
 }
 
 pub fn json_stringify<T: Serialize>(obj: &T) -> Result<String, Report> {


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1018

When tree JSON is sufficiently nested, `serde_json` fails to parse it into the `AuspiceTree` `struct`  with:

```
recursion limit exceeded at line <line> column <column>
```

This problem has been reported before in `serde_json` in https://github.com/serde-rs/json/issues/334, and the solution allowing to remove the recursion limit was implemented in the form of [`Deserializer::disable_recursion_limit`](https://docs.rs/serde_json/latest/serde_json/struct.Deserializer.html#method.disable_recursion_limit) traded off to the increased risk of overflowing the call stack.

So here I implemented the suggested solution, by calling the `disable_recursion_limit()` on deserializer. I am also mitigating the risk of stack overflow by using growing stack adapter from [`serde_stacker`](https://docs.rs/serde_stacker/latest/serde_stacker/).

This allows to successfully parse the large tree from https://github.com/nextstrain/nextclade/issues/1018, although probably also makes the tree parsing a bit slower. But it is not critical for overall runtime, as it is a one-off operation.

