### PR TITLE
feat(web): dynamically set dataset server root using a URL param

### DIFF
--- a/docs/user/nextclade-web.md
+++ b/docs/user/nextclade-web.md
@@ -163,6 +163,7 @@ All parameters are optional.
 | dataset-name           | Safe name of the dataset to use. Examples: `sars-cov-2`, `flu_h3n2_ha`                              |
 | dataset-reference      | Accession of the reference sequence of the dataset to use: Examples: `MN908947`, `CY034116`.        |
 | dataset-tag            | Version tag of the dataset to use.                                                                  |
+| dataset-server         | URL to the custom dataset server (to the path where `index_v2.json` is, without filename).          |
 
 For example, the file with input sequences hosted at `https://example.com/sequences.fasta` can be specified with:
 
@@ -202,6 +203,19 @@ https://clades.nextstrain.org
     &dataset-reference=CY034116
     &input-fasta=https://example.com/flu_sequences.fasta
 ```
+
+A custom dataset server can be specified using `dataset-server` param. In this case the dataset list (index) will be downloaded from this server instead of the default. Example:
+
+```url
+https://clades.nextstrain.org?dataset-server=http://example.com
+```
+
+Local URLs should also work:
+
+```url
+https://clades.nextstrain.org?dataset-server=http://localhost:27722
+```
+
 
 > 💡 Nextclade is a client-side-only, single-page web application, hosted on a static server. We do not set any usage limits for the analyses triggered. Note that all the computation will happen on the end-user machine.
 

--- a/packages_rs/nextclade-web/infra/lambda-at-edge/modifyOutgoingHeadersForApi.lambda.js
+++ b/packages_rs/nextclade-web/infra/lambda-at-edge/modifyOutgoingHeadersForApi.lambda.js
@@ -1,0 +1,63 @@
+// Adds additional headers to the response, including CORS.
+// Suited for serving files and APIs.
+//
+// Usage: Create an AWS Lambda@Edge function and attach it to "Viewer Response" event of a Cloudfront distribution
+
+const NEW_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Content-Security-Policy': `default-src 'none'; frame-ancestors 'none'`,
+  'Strict-Transport-Security': 'max-age=15768000; includeSubDomains; preload',
+  'X-Content-Type-Options': 'nosniff',
+  'X-DNS-Prefetch-Control': 'off',
+  'X-Download-Options': 'noopen',
+  'X-Frame-Options': 'Deny',
+  'X-XSS-Protection': '1; mode=block',
+}
+
+function addHeaders(headersObject) {
+  return Object.entries(headersObject).reduce(
+    (result, [header, value]) => ({
+      ...result,
+      [header.toLowerCase()]: [{ key: header, value }],
+    }),
+    {},
+  )
+}
+
+const HEADERS_TO_REMOVE = new Set(['server', 'via'])
+
+function filterHeaders(headers) {
+  return Object.entries(headers).reduce((result, [key, value]) => {
+    if (HEADERS_TO_REMOVE.has(key.toLowerCase())) {
+      return result
+    }
+
+    if (key.toLowerCase().includes('powered-by')) {
+      return result
+    }
+
+    return { ...result, [key.toLowerCase()]: value }
+  }, {})
+}
+
+function modifyHeaders({ request, response }) {
+  let newHeaders = addHeaders(NEW_HEADERS)
+
+  newHeaders = {
+    ...response.headers,
+    ...newHeaders,
+  }
+
+  newHeaders = filterHeaders(newHeaders)
+
+  return newHeaders
+}
+
+exports.handler = (event, context, callback) => {
+  const { request, response } = event.Records[0].cf
+  response.headers = modifyHeaders({ request, response })
+  callback(null, response)
+}
+
+exports.modifyHeaders = modifyHeaders

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -27,11 +27,15 @@ export async function getDatasetFromUrlParams(urlQuery: ParsedUrlQuery, datasets
   return dataset
 }
 
-export async function initializeDatasets(urlQuery: ParsedUrlQuery) {
-  const datasetsIndexJson = await fetchDatasetsIndex()
+export async function initializeDatasets(urlQuery: ParsedUrlQuery, datasetServerUrlDefault: string) {
+  const datasetServerUrl = getQueryParamMaybe(urlQuery, 'dataset-server') ?? datasetServerUrlDefault
 
-  const { datasets, defaultDatasetName, defaultDatasetNameFriendly } =
-    getLatestCompatibleEnabledDatasets(datasetsIndexJson)
+  const datasetsIndexJson = await fetchDatasetsIndex(datasetServerUrl)
+
+  const { datasets, defaultDatasetName, defaultDatasetNameFriendly } = getLatestCompatibleEnabledDatasets(
+    datasetServerUrl,
+    datasetsIndexJson,
+  )
 
   // Check if URL params specify dataset params and try to find the corresponding dataset
   const currentDataset = await getDatasetFromUrlParams(urlQuery, datasets)

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -49,7 +49,7 @@ import { SEO } from 'src/components/Common/SEO'
 import { Plausible } from 'src/components/Common/Plausible'
 import i18n, { changeLocale, getLocaleWithKey } from 'src/i18n/i18n'
 import { theme } from 'src/theme'
-import { datasetCurrentNameAtom, datasetsAtom } from 'src/state/dataset.state'
+import { datasetCurrentNameAtom, datasetsAtom, datasetServerUrlAtom } from 'src/state/dataset.state'
 import { ErrorBoundary } from 'src/components/Error/ErrorBoundary'
 import { PreviewWarning } from 'src/components/Common/PreviewWarning'
 
@@ -105,8 +105,9 @@ export function RecoilStateInitializer() {
         await changeAuspiceLocale(i18nAuspice, locale.key)
         set(localeAtom, locale.key)
       })
-      .then(() => {
-        return initializeDatasets(urlQuery)
+      .then(async () => {
+        const datasetServerUrlDefault = await getPromise(datasetServerUrlAtom)
+        return initializeDatasets(urlQuery, datasetServerUrlDefault)
       })
       .catch((error) => {
         // Dataset error is fatal and we want error to be handled in the ErrorBoundary

--- a/packages_rs/nextclade-web/src/state/dataset.state.ts
+++ b/packages_rs/nextclade-web/src/state/dataset.state.ts
@@ -1,5 +1,6 @@
 import { isNil } from 'lodash'
 import { atom, DefaultValue, selector } from 'recoil'
+import urljoin from 'url-join'
 
 import type { Dataset } from 'src/types'
 import { GENE_OPTION_NUC_SEQUENCE } from 'src/constants'
@@ -7,6 +8,20 @@ import { inputResetAtom } from 'src/state/inputs.state'
 import { persistAtom } from 'src/state/persist/localStorage'
 import { viewedGeneAtom } from 'src/state/seqViewSettings.state'
 import { isDefaultValue } from 'src/state/utils/isDefaultValue'
+
+export function getDefaultDatasetServer(): string {
+  let datasetServerUrl = process.env.DATA_FULL_DOMAIN ?? '/'
+  // Add HTTP Origin if datasetServerUrl is a relative path (start with '/')
+  if (typeof window !== 'undefined' && datasetServerUrl.slice(0) === '/') {
+    datasetServerUrl = urljoin(window.location.origin, datasetServerUrl)
+  }
+  return datasetServerUrl
+}
+
+export const datasetServerUrlAtom = atom<string>({
+  key: 'datasetServerUrl',
+  default: getDefaultDatasetServer(),
+})
 
 export interface Datasets {
   datasets: Dataset[]


### PR DESCRIPTION
Allows to dynamically set dataset server root URL in Nextclade Web on runtime.

It is sufficient to add URL parameter `dataset-server` with the value containing URL to the root of the dataset file server (containing `index_v2.json`), and Nextclade Web will fetch dataset index and all dataset files from this server instead of the default:

```url
?dataset-server=http://example.com
```

The localhost URLs should also work:
```url
?dataset-server=http://localhost:27722
```

This is equivalent to `--server` flag in Nextclade CLI. 

This should facilitate testing of custom datasets in Nextclade Web.