### PR TITLE
feat(web): reduce default number of threads to speedup initialization

### DIFF
--- a/packages_rs/nextclade-web/src/helpers/getNumThreads.ts
+++ b/packages_rs/nextclade-web/src/helpers/getNumThreads.ts
@@ -1,9 +1,9 @@
 import { clamp } from 'lodash'
 import { useEffect, useState } from 'react'
 
-export const DEFAULT_NUM_THREADS = 4
-export const MINIMUM_NUM_THREADS = 2
-export const MAXIMUM_NUM_THREADS = 8
+export const DEFAULT_NUM_THREADS = 2
+export const MINIMUM_NUM_THREADS = 1
+export const MAXIMUM_NUM_THREADS = 3
 export const MEMORY_BYTES_PER_THREAD_MINIMUM = 200 * 1024 * 1024
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
Despite "thread" (actually webworker) initialization is supposed to be concurrent, there seem to be a clear trend of increased initialization time as number of threads increased. This is likely due to data transfer overhead between workers.

Here I reduce number of threads that can be initialized with default settings.

But these settings can always be altered in the "Settings" dialog.

