### PR TITLE
fix: avoid off-by-one array overrun in frame shift masking

### DIFF
--- a/packages_rs/nextclade/src/utils/range.rs
+++ b/packages_rs/nextclade/src/utils/range.rs
@@ -1,4 +1,5 @@
 use auto_ops::impl_op_ex;
+use num_traits::clamp;
 use serde::{Deserialize, Serialize};
 use std::ops::Range as StdRange;
 
@@ -17,6 +18,20 @@ impl Range {
   #[inline]
   pub const fn contains(&self, x: usize) -> bool {
     x >= self.begin && x < self.end
+  }
+
+  #[inline]
+  pub fn clamp(&mut self, from: usize, to: usize) {
+    self.begin = clamp(self.begin, from, to);
+    self.end = clamp(self.end, self.begin, to);
+  }
+
+  #[must_use]
+  #[inline]
+  pub fn clamped(&self, from: usize, to: usize) -> Range {
+    let mut result = self.clone();
+    result.clamp(from, to);
+    result
   }
 }
 


### PR DESCRIPTION
### Problem

When running with the new RSV dataset (shared privately [on Slack](https://neherlab.slack.com/archives/C015PFP5V44/p1666013358556229?thread_ts=1666006804.144509&cid=C015PFP5V44)), Nextclade is crashing due to illegal memory access into protein sequence, past its end:

https://github.com/nextstrain/nextclade/blob/d677b950dc85e21bd5a4c10ebed664fc67a24a71/packages_rs/nextclade/src/translate/translate_genes.rs#L107

when filling frame shift codons with aminoacid `X`: https://github.com/nextstrain/nextclade/blob/d677b950dc85e21bd5a4c10ebed664fc67a24a71/packages_rs/nextclade/src/translate/translate_genes.rs#L118


### Cause
 
My current hypothesis is that this might be due to modulo-3 logic when converting position coordinate systems: https://github.com/nextstrain/nextclade/blob/d677b950dc85e21bd5a4c10ebed664fc67a24a71/packages_rs/nextclade/src/gene/gene.rs#L84-L89

However, I cannot rule out that the issue is more complex. For example, coordinate conversion might be wrong due to coordinate maps being wrong, which can happen if reference sequence and/or gene map have defects or do not correspond to each other. We haven't explored these scenarios previously, but as we grow new datasets, these issues may occur more often.

### Attempted solution

In this PR I restricted frame shift and mask ranges to gene boundary to avoid array overrun. A scientific review of this change is needed to make sure there are no undesired side-effects.

