### PR TITLE
perf: use default memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,15 +1289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,15 +1352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1486,7 +1468,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
- "mimalloc",
  "num",
  "num-traits",
  "num_cpus",
@@ -1531,7 +1512,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
- "mimalloc",
  "nextclade",
  "num_cpus",
  "owo-colors",

--- a/packages_rs/nextclade-cli/Cargo.toml
+++ b/packages_rs/nextclade-cli/Cargo.toml
@@ -40,9 +40,6 @@ strum_macros = "0.24"
 url = { version = "2.2.2", features = ["serde"] }
 zip = { version = "0.6.2", default-features = false, features = ["aes-crypto", "bzip2", "deflate", "time"] }
 
-[target.'cfg(all(target_os="linux", target_arch="x86_64"))'.dependencies]
-mimalloc = { version = "0.1.28", default-features = false, optional = true }
-
 [dev-dependencies]
 assert2 = "0.3.6"
 criterion = { version = "0.3.5", features = ["html_reports"] }

--- a/packages_rs/nextclade-cli/src/bin/nextalign.rs
+++ b/packages_rs/nextclade-cli/src/bin/nextalign.rs
@@ -3,10 +3,6 @@ use eyre::Report;
 use nextclade::utils::global_init::global_init;
 use nextclade_cli::cli::nextalign_cli::nextalign_handle_cli_args;
 
-#[cfg(all(target_family = "linux", target_arch = "x86_64"))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[ctor]
 fn init() {
   global_init();

--- a/packages_rs/nextclade-cli/src/bin/nextclade.rs
+++ b/packages_rs/nextclade-cli/src/bin/nextclade.rs
@@ -3,10 +3,6 @@ use eyre::Report;
 use nextclade::utils::global_init::global_init;
 use nextclade_cli::cli::nextclade_cli::nextclade_parse_cli_args;
 
-#[cfg(all(target_family = "linux", target_arch = "x86_64"))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[ctor]
 fn init() {
   global_init();

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -51,9 +51,6 @@ traversal = "0.1.2"
 validator = { version = "0.14.0", features = ["derive"] }
 zip = { version = "0.6.2", default-features = false, features = ["aes-crypto", "deflate", "time"] }
 
-[target.'cfg(all(target_family = "linux", target_arch = "x86_64"))'.dependencies]
-mimalloc = { version = "0.1.28", default-features = false, optional = true }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 atty = "0.2.14"
 bzip2 = "0.4.3"


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1027

Here I remove Mimalloc, because  was not configured correctly, due to a mistake in `cfg` conditional, and even when set up correctly does not make Nextclade any faster (see the linked issue for benchmarks).
