### PR TITLE
feat(cli): improve file io logic

### DIFF
--- a/packages_rs/nextclade/src/io/csv.rs
+++ b/packages_rs/nextclade/src/io/csv.rs
@@ -1,4 +1,4 @@
-use crate::io::file::create_file;
+use crate::io::file::create_file_or_stdout;
 use crate::io::fs::read_file_to_string;
 use crate::utils::error::to_eyre_error;
 use csv::{ReaderBuilder as CsvReaderBuilder, Writer as CsvWriterImpl, WriterBuilder as CsvWriterBuilder};
@@ -33,7 +33,7 @@ pub struct CsvStructFileWriter {
 impl CsvStructFileWriter {
   pub fn new(filepath: impl AsRef<Path>, delimiter: u8) -> Result<Self, Report> {
     let filepath = filepath.as_ref();
-    let file = create_file(filepath)?;
+    let file = create_file_or_stdout(filepath)?;
     let writer = CsvStructWriter::new(file, delimiter)?;
     Ok(Self {
       filepath: filepath.to_owned(),
@@ -85,7 +85,7 @@ pub struct CsvVecFileWriter {
 impl CsvVecFileWriter {
   pub fn new(filepath: impl AsRef<Path>, delimiter: u8, headers: &[String]) -> Result<Self, Report> {
     let filepath = filepath.as_ref();
-    let file = create_file(filepath)?;
+    let file = create_file_or_stdout(filepath)?;
     let writer = CsvVecWriter::new(file, delimiter, headers)?;
     Ok(Self {
       filepath: filepath.to_owned(),

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -2,7 +2,7 @@ use crate::constants::REVERSE_COMPLEMENT_SUFFIX;
 use crate::io::aa::from_aa_seq;
 use crate::io::compression::Decompressor;
 use crate::io::concat::concat;
-use crate::io::file::{create_file, open_file_or_stdin, open_stdin};
+use crate::io::file::{create_file_or_stdout, open_file_or_stdin, open_stdin};
 use crate::io::gene_map::GeneMap;
 use crate::translate::translate_genes::Translation;
 use crate::{make_error, make_internal_error};
@@ -176,7 +176,7 @@ impl FastaWriter {
   }
 
   pub fn from_path(filepath: impl AsRef<Path>) -> Result<Self, Report> {
-    Ok(Self::new(create_file(filepath)?))
+    Ok(Self::new(create_file_or_stdout(filepath)?))
   }
 
   pub fn write(&mut self, seq_name: &str, seq: &str, is_reverse_complement: bool) -> Result<(), Report> {

--- a/packages_rs/nextclade/src/io/file.rs
+++ b/packages_rs/nextclade/src/io/file.rs
@@ -1,28 +1,81 @@
-use crate::io::compression::Compressor;
 use crate::io::fs::ensure_dir;
 use eyre::{Report, WrapErr};
-use log::info;
+use log::{info, warn};
 use std::fmt::Debug;
 use std::fs::File;
-use std::io::{stdout, BufWriter, Write};
+use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
+use crate::io::compression::{Compressor, Decompressor};
+#[cfg(not(target_arch = "wasm32"))]
+use atty::{is as is_tty, Stream};
+
+const TTY_WARNING: &str = r#"Reading from standard input which is a TTY (e.g. an interactive terminal). This is likely not what you meant. Instead:
+
+ - if you want to read fasta from the output of another program, try:
+
+    cat /path/to/file | nextclade <your other flags>
+
+ - if you want to read from file(s), don't forget to provide a path:
+
+    nextclade /path/to/file
+"#;
+
+/// Open stdin
+pub fn open_stdin() -> Result<Box<dyn BufRead>, Report> {
+  info!("Reading from standard input");
+
+  #[cfg(not(target_arch = "wasm32"))]
+  if is_tty(Stream::Stdin) {
+    warn!("{TTY_WARNING}");
+  }
+
+  Ok(Box::new(BufReader::new(stdin())))
+}
+
+/// Open file for reading given a filepath. If the filepath is None, then read from stdin.
+pub fn open_file_or_stdin<P: AsRef<Path>>(filepath: &Option<P>) -> Result<Box<dyn BufRead>, Report> {
+  match filepath {
+    Some(filepath) => {
+      let filepath = filepath.as_ref();
+      if is_path_stdin(filepath) {
+        open_stdin()
+      } else {
+        let file = File::open(filepath).wrap_err_with(|| format!("When opening file '{filepath:?}'"))?;
+        let buf_file = BufReader::with_capacity(32 * 1024, file);
+        let decompressor = Decompressor::from_path(buf_file, filepath)?;
+        let buf_decompressor = BufReader::with_capacity(32 * 1024, decompressor);
+        Ok(Box::new(buf_decompressor))
+      }
+    }
+    None => open_stdin(),
+  }
+}
+
+/// Open file for writing. If the path does not exist it will be created recursively.
 pub fn create_file(filepath: impl AsRef<Path>) -> Result<Box<dyn Write + Send>, Report> {
   let filepath = filepath.as_ref();
 
-  let file: Box<dyn Write + Sync + Send> = if filepath == PathBuf::from("-") {
-    info!("File path is '-', writing to standard output");
-    Box::new(stdout())
+  let file: Box<dyn Write + Sync + Send> = if is_path_stdout(filepath) {
+    info!("File path is {filepath:?}. Writing to standard output.");
+    Box::new(BufWriter::with_capacity(32 * 1024, stdout()))
   } else {
     ensure_dir(&filepath)?;
-    Box::new(File::create(&filepath).wrap_err_with(|| format!("When creating file: {filepath:?}"))?)
+    Box::new(File::create(&filepath).wrap_err_with(|| format!("When creating file: '{filepath:?}'"))?)
   };
 
   let buf_file = BufWriter::with_capacity(32 * 1024, file);
-
   let compressor = Compressor::from_path(buf_file, filepath)?;
+  let buf_compressor = BufWriter::with_capacity(32 * 1024, compressor);
+  Ok(Box::new(buf_compressor))
+}
 
-  let writer = BufWriter::with_capacity(32 * 1024, compressor);
+pub fn is_path_stdin(filepath: impl AsRef<Path>) -> bool {
+  let filepath = filepath.as_ref();
+  filepath == PathBuf::from("-") || filepath == PathBuf::from("/dev/stdin")
+}
 
-  Ok(Box::new(writer))
+pub fn is_path_stdout(filepath: impl AsRef<Path>) -> bool {
+  let filepath = filepath.as_ref();
+  filepath == PathBuf::from("-") || filepath == PathBuf::from("/dev/stdout")
 }

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -1,6 +1,6 @@
+use crate::io::file::open_file_or_stdin;
 use eyre::{eyre, Report, WrapErr};
 use std::ffi::{OsStr, OsString};
-use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
@@ -72,17 +72,21 @@ pub fn add_extension(filepath: impl AsRef<Path>, extension: impl AsRef<OsStr>) -
 /// Reads entire file into a string.
 /// Compared to `std::fs::read_to_string` uses buffered reader
 pub fn read_file_to_string(filepath: impl AsRef<Path>) -> Result<String, Report> {
-  const BUF_SIZE: usize = 2 * 1024 * 1024;
-
   let filepath = filepath.as_ref();
-
-  let file = File::open(&filepath).wrap_err_with(|| format!("When opening file: {filepath:#?}"))?;
-  let mut reader = BufReader::with_capacity(BUF_SIZE, file);
-
+  let mut file = open_file_or_stdin(&Some(filepath))?;
   let mut data = String::new();
-  reader
+  file
     .read_to_string(&mut data)
     .wrap_err_with(|| format!("When reading file: {filepath:#?}"))?;
+  Ok(data)
+}
 
+/// Reads entire reader into a string.
+/// Compared to `std::fs::read_to_string` uses buffered reader
+pub fn read_reader_to_string(reader: impl Read) -> Result<String, Report> {
+  const BUF_SIZE: usize = 2 * 1024 * 1024;
+  let mut reader = BufReader::with_capacity(BUF_SIZE, reader);
+  let mut data = String::new();
+  reader.read_to_string(&mut data)?;
   Ok(data)
 }

--- a/packages_rs/nextclade/src/io/fs.rs
+++ b/packages_rs/nextclade/src/io/fs.rs
@@ -1,4 +1,4 @@
-use crate::io::file::open_file_or_stdin;
+use crate::io::file::{open_file_or_stdin, DEFAULT_FILE_BUF_SIZE};
 use eyre::{eyre, Report, WrapErr};
 use std::ffi::{OsStr, OsString};
 use std::io::{BufReader, Read};
@@ -84,8 +84,7 @@ pub fn read_file_to_string(filepath: impl AsRef<Path>) -> Result<String, Report>
 /// Reads entire reader into a string.
 /// Compared to `std::fs::read_to_string` uses buffered reader
 pub fn read_reader_to_string(reader: impl Read) -> Result<String, Report> {
-  const BUF_SIZE: usize = 2 * 1024 * 1024;
-  let mut reader = BufReader::with_capacity(BUF_SIZE, reader);
+  let mut reader = BufReader::with_capacity(DEFAULT_FILE_BUF_SIZE, reader);
   let mut data = String::new();
   reader.read_to_string(&mut data)?;
   Ok(data)

--- a/packages_rs/nextclade/src/io/json.rs
+++ b/packages_rs/nextclade/src/io/json.rs
@@ -1,4 +1,4 @@
-use crate::io::file::create_file;
+use crate::io::file::create_file_or_stdout;
 use eyre::{Report, WrapErr};
 use serde::{Deserialize, Serialize};
 use serde_json::{de::Read, Deserializer};
@@ -31,6 +31,6 @@ pub fn json_stringify<T: Serialize>(obj: &T) -> Result<String, Report> {
 
 pub fn json_write<T: Serialize>(filepath: impl AsRef<Path>, obj: &T) -> Result<(), Report> {
   let filepath = filepath.as_ref();
-  let file = create_file(filepath)?;
+  let file = create_file_or_stdout(filepath)?;
   serde_json::to_writer_pretty(file, &obj).wrap_err("When writing JSON to file: {filepath:#?}")
 }

--- a/packages_rs/nextclade/src/io/ndjson.rs
+++ b/packages_rs/nextclade/src/io/ndjson.rs
@@ -1,4 +1,4 @@
-use crate::io::file::create_file;
+use crate::io::file::create_file_or_stdout;
 use crate::types::outputs::NextcladeErrorOutputs;
 use eyre::{Report, WrapErr};
 use std::fmt::Debug;
@@ -38,7 +38,7 @@ pub struct NdjsonFileWriter {
 impl NdjsonFileWriter {
   pub fn new(filepath: impl AsRef<Path>) -> Result<Self, Report> {
     let filepath = filepath.as_ref();
-    let file = create_file(filepath)?;
+    let file = create_file_or_stdout(filepath)?;
     let line_writer = NdjsonWriter::new(file)?;
     Ok(Self {
       filepath: filepath.to_owned(),


### PR DESCRIPTION
Here I refactor file I/O code in Nextclade CLI.

I am introducing and then reusing the function `open_file_or_stdin()` in all places where a file needs to be read (except for when reading a zip archive, where it needs a seekable stream, so stdin won't work), and the function `create_file_or_stdout()` for all places where a  file needs to be written.

This reduces code duplication (of compression and buffering code specifically) and also introduces consistent buffering and compression support to all the input and output files (except the zip mentioned above).
