### PR TITLE
fix(web): ensure timely i18n initialization

### DIFF
--- a/packages_rs/nextclade-web/src/i18n/i18n.auspice.ts
+++ b/packages_rs/nextclade-web/src/i18n/i18n.auspice.ts
@@ -46,6 +46,7 @@ export function i18nAuspiceInit() {
     debug: process.env.DEV_ENABLE_I18N_DEBUG === '1',
     interpolation: { escapeValue: false },
     defaultNS: 'translation',
+    initImmediate: true,
   })
 
   // eslint-disable-next-line no-void

--- a/packages_rs/nextclade-web/src/i18n/i18n.ts
+++ b/packages_rs/nextclade-web/src/i18n/i18n.ts
@@ -165,6 +165,7 @@ export function i18nInit({ localeKey }: I18NInitParams) {
     keySeparator: false, // Disable dots as key separators as we use dots in keys
     nsSeparator: false,
     interpolation: { escapeValue: false },
+    initImmediate: true,
   })
 
   // eslint-disable-next-line no-void


### PR DESCRIPTION
Here I enable immediate mode of i18next initialization, by setting `initImmediate: true` option, forcing synchronous initialization (without `Promises`).

This allows us to use `i18n` object and `t()` function globally, for example outside of React components.

Previously there was as risk of using them before initialization completes (depending on whether initialization promise resolves by then or not). But now it is guaranteed to be correct.

See: https://www.i18next.com/overview/configuration-options#text-initimmediate

