### PR TITLE
feat(web): enable more locales in auspice

### DIFF
--- a/packages_rs/nextclade-web/src/i18n/i18n.auspice.ts
+++ b/packages_rs/nextclade-web/src/i18n/i18n.auspice.ts
@@ -3,43 +3,43 @@ import { initReactI18next } from 'react-i18next'
 
 import { DEFAULT_LOCALE_KEY, localeKeys } from 'src/i18n/i18n'
 
-import enSidebar from 'auspice/src/locales/en/sidebar.json'
 import arSidebar from 'auspice/src/locales/ar/sidebar.json'
 import deSidebar from 'auspice/src/locales/de/sidebar.json'
+import enSidebar from 'auspice/src/locales/en/sidebar.json'
 import esSidebar from 'auspice/src/locales/es/sidebar.json'
 import frSidebar from 'auspice/src/locales/fr/sidebar.json'
-// import itSidebar from 'auspice/src/locales/it/sidebar.json'
-// import koSidebar from 'auspice/src/locales/ko/sidebar.json'
+import itSidebar from 'auspice/src/locales/it/sidebar.json'
+import jaSidebar from 'auspice/src/locales/ja/sidebar.json'
 import ptSidebar from 'auspice/src/locales/pt/sidebar.json'
 import ruSidebar from 'auspice/src/locales/ru/sidebar.json'
-// import zhSidebar from 'auspice/src/locales/zh/sidebar.json'
+import trSidebar from 'auspice/src/locales/tr/sidebar.json'
 
-import enTranslation from 'auspice/src/locales/en/translation.json'
 import arTranslation from 'auspice/src/locales/ar/translation.json'
 import deTranslation from 'auspice/src/locales/de/translation.json'
+import enTranslation from 'auspice/src/locales/en/translation.json'
 import esTranslation from 'auspice/src/locales/es/translation.json'
 import frTranslation from 'auspice/src/locales/fr/translation.json'
-// import itTranslation from 'auspice/src/locales/it/translation.json'
-// import koTranslation from 'auspice/src/locales/ko/translation.json'
+import itTranslation from 'auspice/src/locales/it/translation.json'
+import jaTranslation from 'auspice/src/locales/ja/translation.json'
 import ptTranslation from 'auspice/src/locales/pt/translation.json'
 import ruTranslation from 'auspice/src/locales/ru/translation.json'
-// import zhTranslation from 'auspice/src/locales/zh/translation.json'
+import trTranslation from 'auspice/src/locales/tr/translation.json'
 
 export const AUSPICE_I18N_NAMESPACES = ['language', 'sidebar', 'translation']
 
 export function i18nAuspiceInit() {
   const i18nAuspice = i18nOriginal.use(initReactI18next).createInstance({
     resources: {
-      en: { sidebar: enSidebar, translation: enTranslation },
       ar: { sidebar: arSidebar, translation: arTranslation },
       de: { sidebar: deSidebar, translation: deTranslation },
+      en: { sidebar: enSidebar, translation: enTranslation },
       es: { sidebar: esSidebar, translation: esTranslation },
       fr: { sidebar: frSidebar, translation: frTranslation },
-      // it: { sidebar: itSidebar, translation: itTranslation },
-      // ko: { sidebar: koSidebar, translation: koTranslation },
+      it: { sidebar: itSidebar, translation: itTranslation },
+      ja: { sidebar: jaSidebar, translation: jaTranslation },
       pt: { sidebar: ptSidebar, translation: ptTranslation },
       ru: { sidebar: ruSidebar, translation: ruTranslation },
-      // zh: { sidebar: zhSidebar, translation: zhTranslation },
+      tr: { sidebar: trSidebar, translation: trTranslation },
     },
     lng: DEFAULT_LOCALE_KEY,
     fallbackLng: DEFAULT_LOCALE_KEY,


### PR DESCRIPTION
Here I import and add "it", "ja" and "tr" locales, which are available in Auspice, but have not been used so far.

