### PR TITLE
feat: hotlink clade schema

### DIFF
--- a/packages_rs/nextclade-web/.eslintrc.js
+++ b/packages_rs/nextclade-web/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
   ],
   reportUnusedDisableDirectives: true,
   rules: {
+    '@next/next/no-img-element': 'off',
     '@next/next/no-title-in-document-head': 'off',
     '@typescript-eslint/array-type': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/packages_rs/nextclade-web/src/components/Main/CladeSchema.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/CladeSchema.tsx
@@ -27,12 +27,14 @@ export function CladeSchema() {
 
   return (
     <CladeSchemaFigure className="figure w-100 text-center">
-      <CladeSchemaPicture className="w-100 figure-img">
-        <img
-          src={URL_CLADE_SCHEMA_SVG}
-          alt="Illustration of phylogenetic relationships of SARS-CoV-2 clades, as defined by Nextstrain"
-        />
-      </CladeSchemaPicture>
+      <LinkExternal url={URL_CLADE_SCHEMA_SVG}>
+        <CladeSchemaPicture className="w-100 figure-img">
+          <img
+            src={URL_CLADE_SCHEMA_SVG}
+            alt="Illustration of phylogenetic relationships of SARS-CoV-2 clades, as defined by Nextstrain"
+          />
+        </CladeSchemaPicture>
+      </LinkExternal>
       <CladeSchemaFigcaption>
         <small>
           {t('Fig.1. Illustration of phylogenetic relationships of SARS-CoV-2 clades, as defined by Nextstrain')}

--- a/packages_rs/nextclade-web/src/components/Main/CladeSchema.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/CladeSchema.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-
-import { useTranslationSafe as useTranslation } from 'src/helpers/useTranslationSafe'
 import styled from 'styled-components'
 
-import CladeSchemaSvg from 'src/assets/img/clades.svg'
+import { useTranslationSafe as useTranslation } from 'src/helpers/useTranslationSafe'
+import { URL_CLADE_SCHEMA_REPO, URL_CLADE_SCHEMA_SVG } from 'src/constants'
+import { LinkExternal } from 'src/components/Link/LinkExternal'
 
 const CladeSchemaFigure = styled.figure`
   display: flex;
@@ -11,6 +11,7 @@ const CladeSchemaFigure = styled.figure`
   max-width: 850px;
   flex-direction: column;
   margin: 0 auto;
+  margin-bottom: 2rem;
 `
 
 const CladeSchemaPicture = styled.picture`
@@ -27,11 +28,17 @@ export function CladeSchema() {
   return (
     <CladeSchemaFigure className="figure w-100 text-center">
       <CladeSchemaPicture className="w-100 figure-img">
-        <CladeSchemaSvg />
+        <img
+          src={URL_CLADE_SCHEMA_SVG}
+          alt="Illustration of phylogenetic relationships of SARS-CoV-2 clades, as defined by Nextstrain"
+        />
       </CladeSchemaPicture>
       <CladeSchemaFigcaption>
         <small>
           {t('Fig.1. Illustration of phylogenetic relationships of SARS-CoV-2 clades, as defined by Nextstrain')}
+          {' ('}
+          <LinkExternal url={URL_CLADE_SCHEMA_REPO}>{t('source')}</LinkExternal>
+          {')'}
         </small>
       </CladeSchemaFigcaption>
     </CladeSchemaFigure>

--- a/packages_rs/nextclade-web/src/constants.ts
+++ b/packages_rs/nextclade-web/src/constants.ts
@@ -27,6 +27,9 @@ export const URL_GITHUB_ISSUES_FRIENDLY = 'github.com/nextstrain/nextclade/issue
 export const URL_GITHUB_CHANGELOG = 'https://github.com/nextstrain/nextclade/blob/release/packages/web/CHANGELOG.md'
 export const URL_GITHUB_COMMITS = 'https://github.com/nextstrain/nextclade/commits/release'
 
+export const URL_CLADE_SCHEMA_REPO = 'https://github.com/nextstrain/ncov-clades-schema/'
+export const URL_CLADE_SCHEMA_SVG = 'https://raw.githubusercontent.com/nextstrain/ncov-clades-schema/master/clades.svg'
+
 export const SUPPORT_EMAIL = 'hello@nextstrain.org'
 
 export const TWITTER_USERNAME_RAW = 'nextstrain' as const

--- a/packages_rs/nextclade-web/src/i18n/resources/ar/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ar/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " أو كتابة بريد إلكتروني إلى ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "يمكنك الإبلاغ عن ذلك للمطورين عن طريق إنشاء طلب (ما يسمى{{issue}}) على: ",
   "Aminoacid changes ({{count}})": "تغييرات الأحماض الأمينية ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "تغييرات النوكليوتيدات القريبة ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "تغييرات النوكليوتيدات القريبة ({{count}})",
+  "source": "مصدر"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/de/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/de/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " oder schreiben Sie eine E-Mail an ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Sie können es Entwicklern melden, indem Sie eine Anfrage (so genannt{{issue}}) erstellen unter: ",
   "Aminoacid changes ({{count}})": "Veränderungen der Aminosäure ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Nukleotidveränderungen in der Nähe ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Nukleotidveränderungen in der Nähe ({{count}})",
+  "source": "Quelle"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/el/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/el/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " ή γράφοντας ένα email στο ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Μπορείτε να το αναφέρετε στους προγραμματιστές δημιουργώντας ένα αίτημα (το λεγόμενο {{issue}}) στη διεύθυνση: ",
   "Aminoacid changes ({{count}})": "Μεταβολές των αμινοξέων ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Νουκλεοτιδίων αλλαγές σε κοντινή απόσταση ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Νουκλεοτιδίων αλλαγές σε κοντινή απόσταση ({{count}})",
+  "source": "πηγής"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/en/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/en/common.json
@@ -280,6 +280,7 @@
   "sidebar:Filter Data": "sidebar:Filter Data",
   "sidebar:Tree Options": "sidebar:Tree Options",
   "Some of the adblocking browser extensions (AdBlock, uBlock, Privacy Badger and others) and privacy-oriented browsers (such as Brave) are known to prevent {{appName}} from making network requests to other servers. {{appName}} respects your privacy, does not serve ads or collects personal data. All computation is done inside your browser. You can safely disable adblockers on {{domain}} and/or allow {{domain}} to make network requests to your data source server.": "Some of the adblocking browser extensions (AdBlock, uBlock, Privacy Badger and others) and privacy-oriented browsers (such as Brave) are known to prevent {{appName}} from making network requests to other servers. {{appName}} respects your privacy, does not serve ads or collects personal data. All computation is done inside your browser. You can safely disable adblockers on {{domain}} and/or allow {{domain}} to make network requests to your data source server.",
+  "source": "source",
   "Source code": "Source code",
   "Starting {{numWorkers}} threads...": "Starting {{numWorkers}} threads...",
   "Stop codons": "Stop codons",

--- a/packages_rs/nextclade-web/src/i18n/resources/es/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/es/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " o escribir un correo electrónico a ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Puedes informarlo a los desarrolladores creando una solicitud (llamada{{issue}}) en: ",
   "Aminoacid changes ({{count}})": "Cambios de aminoácidos ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Cambios en los nucleótidos cercanos ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Cambios en los nucleótidos cercanos ({{count}})",
+  "source": "fuente"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/fa/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/fa/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " و یا نوشتن یک ایمیل به ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "شما می توانید آن را به توسعه دهندگان با ایجاد یک درخواست (به اصطلاح {{issue}}) در: ",
   "Aminoacid changes ({{count}})": "تغییرات آمینواسید ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "تغییرات نوکلئوتیدی در نزدیکی ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "تغییرات نوکلئوتیدی در نزدیکی ({{count}})",
+  "source": "منبع"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/fr/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/fr/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " ou en écrivant un e-mail à ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Vous pouvez le signaler aux développeurs en créant une demande (appelée{{issue}}) à l'adresse suivante : ",
   "Aminoacid changes ({{count}})": "Changements d'acides aminés ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Changements de nucléotides à proximité ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Changements de nucléotides à proximité ({{count}})",
+  "source": "source"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/he/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/he/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " או כתיבת דוא\"ל אל ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "אתה יכול לדווח על כך למפתחים על ידי יצירת בקשה (שנקראה {{issue}}) בכתובת: ",
   "Aminoacid changes ({{count}})": "שינויים אמינו-חומצה ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "נוקלאוטיד משתנה בקרבת מקום ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "נוקלאוטיד משתנה בקרבת מקום ({{count}})",
+  "source": "מקור"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/hi/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/hi/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " या एक ईमेल लिखने के लिए ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "आप इसे एक अनुरोध (तथाकथित{{issue}}) बनाकर डेवलपर्स को रिपोर्ट कर सकते हैं: ",
   "Aminoacid changes ({{count}})": "अमीनोसिड परिवर्तन ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "न्यूक्लियोटाइड के आस-पास परिवर्तन ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "न्यूक्लियोटाइड के आस-पास परिवर्तन ({{count}})",
+  "source": "स्रोत"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/id/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/id/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " atau menulis email ke ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Anda dapat melaporkannya ke pengembang dengan membuat permintaan (disebut {{issue}}) di: ",
   "Aminoacid changes ({{count}})": "Perubahan aminoacid ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Perubahan nukleotida di dekatnya ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Perubahan nukleotida di dekatnya ({{count}})",
+  "source": "sumber"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/it/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/it/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " o scrivendo una mail a ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Puoi segnalarlo agli sviluppatori creando una richiesta (cosiddetta{{issue}}) all'indirizzo: ",
   "Aminoacid changes ({{count}})": "Cambiamenti degli amminoacidi ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Cambiamenti nucleotidici nelle vicinanze ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Cambiamenti nucleotidici nelle vicinanze ({{count}})",
+  "source": "fonte"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ja/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ja/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " またはにメールを書く ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "次の場所でリクエスト (いわゆる{{issue}}) を作成すると、開発者に報告できます。 ",
   "Aminoacid changes ({{count}})": "アミノ酸の変化 ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "近くのヌクレオチド変化 ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "近くのヌクレオチド変化 ({{count}})",
+  "source": "ソース"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ko/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ko/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " 또는 다음 주소로 이메일 작성 ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "다음 위치에서 요청 (소위{{issue}}) 을 생성하여 개발자에게 보고할 수 있습니다. ",
   "Aminoacid changes ({{count}})": "아미노산 변화 ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "근처의 뉴클레오티드 변화 ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "근처의 뉴클레오티드 변화 ({{count}})",
+  "source": "출처"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/nl/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/nl/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " of een e-mail schrijven naar ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Je kunt het rapporteren aan ontwikkelaars door een verzoek (zogenaamd{{issue}}) aan te maken op: ",
   "Aminoacid changes ({{count}})": "Veranderingen in aminozuur ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Nucleotide-veranderingen in de buurt ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Nucleotide-veranderingen in de buurt ({{count}})",
+  "source": "bron"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/pt/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/pt/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " ou escrevendo um e-mail para ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Você pode denunciá-lo aos desenvolvedores criando uma solicitação (assim chamada{{issue}}) em: ",
   "Aminoacid changes ({{count}})": "Alterações de aminoácidos ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Mudanças de nucleotídeos nas proximidades ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Mudanças de nucleotídeos nas proximidades ({{count}})",
+  "source": "fonte"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ru/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ru/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " или написав электронное письмо ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Вы можете сообщить об этом разработчикам, создав запрос (так называемый{{issue}}) по адресу: ",
   "Aminoacid changes ({{count}})": "Аминокислотные изменения ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Нуклеотидные изменения поблизости ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Нуклеотидные изменения поблизости ({{count}})",
+  "source": "источник"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ta/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ta/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " அல்லது ஒரு மின்னஞ்சலை எழுதுதல் ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "ஒரு கோரிக்கையை உருவாக்குவதன் மூலம் டெவலப்பர்களிடம் அதை நீங்கள் {{issue}}தெரிவிக்கலாம்: ",
   "Aminoacid changes ({{count}})": "அமினோஅமில மாற்றங்கள் ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "நியூக்ளியோடைடு அருகில் மாறுகிறது ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "நியூக்ளியோடைடு அருகில் மாறுகிறது ({{count}})",
+  "source": "மூலம்"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/th/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/th/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " หรือเขียนอีเมลไปที่ ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "คุณสามารถรายงานไปยังนักพัฒนาโดยการสร้างคำขอ (เรียกว่า {{issue}}) ที่: ",
   "Aminoacid changes ({{count}})": "การเปลี่ยนแปลงของกรดอะมิโนกรด ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "นิวคลีโอไทด์เปลี่ยนแปลงในบริเวณใกล้เคียง ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "นิวคลีโอไทด์เปลี่ยนแปลงในบริเวณใกล้เคียง ({{count}})",
+  "source": "ต้นกำเนิด"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/tr/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/tr/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " veya bir e-posta yazarak ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Bunu geliştiricilere şu adresten bir istek oluşturarak (sözde {{issue}}) bildirebilirsiniz: ",
   "Aminoacid changes ({{count}})": "Aminoasit değişiklikleri ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Yakınlarda nükleotid değişiklikleri ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Yakınlarda nükleotid değişiklikleri ({{count}})",
+  "source": "kaynak"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ur/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ur/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " یا ایک ای میل لکھنے کے لئے ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "آپ اس کی درخواست (نام نہاد {{issue}}) کی تخلیق کرکے ڈویلپرز کو رپورٹ کرسکتے ہیں: ",
   "Aminoacid changes ({{count}})": "امینوایسڈ تبدیلیاں ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "نیوکلیوٹائڈ قریبی تبدیلیاں ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "نیوکلیوٹائڈ قریبی تبدیلیاں ({{count}})",
+  "source": "ذریعہ"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/vi/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/vi/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " hoặc viết email tới ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "Bạn có thể báo cáo nó cho nhà phát triển bằng cách tạo một yêu cầu (được gọi là {{issue}}) tại: ",
   "Aminoacid changes ({{count}})": "Aminoacid thay đổi ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "Nucleotide thay đổi gần đó ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "Nucleotide thay đổi gần đó ({{count}})",
+  "source": "nguồn"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/zh/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/zh/common.json
@@ -324,5 +324,6 @@
   " or writing an email to ": " 或者写一封电子邮件给 ",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "您可以通过在以下位置创建请求（所谓的{{issue}}）向开发人员报告： ",
   "Aminoacid changes ({{count}})": "氨基酸变化 ({{count}})",
-  "Nucleotide changes nearby ({{count}})": "附近有核苷酸发生变化 ({{count}})"
+  "Nucleotide changes nearby ({{count}})": "附近有核苷酸发生变化 ({{count}})",
+  "source": "资源"
 }


### PR DESCRIPTION
This replaces inline svg file with a URL to the svg file in the   https://github.com/nextstrain/ncov-clades-schema/ repo.

This way we don't need to do a file copy on every update.