### PR TITLE
Update developer-guide.md

### DIFF
--- a/docs/dev/developer-guide.md
+++ b/docs/dev/developer-guide.md
@@ -83,6 +83,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # Add Rust tools to the $PATH
 export PATH="$PATH:$HOME/.cargo/bin"
 
+# Prepare dotenv file with default values
+cp .env.example .env
+
 # Install wasm-pack
 cargo install wasm-pack
 


### PR DESCRIPTION
Hello! I tried Nextclade web on my private server.

I followed instructions from the Nextclade Web section but faced an error.
I found `.env` is needed not only for Nextclade CLI but also for Nextclade web.
It works in my environment now.

So, it would be better to add this cp command in this section.

Thank you!