### PR TITLE
correct run command

### DIFF
--- a/docs/dev/developer-guide.md
+++ b/docs/dev/developer-guide.md
@@ -31,10 +31,11 @@ sudo apt-get install --yes libssl-dev pkg-config
 cp .env.example .env
 
 # Build and run Nextclade in debug mode (convenient for development, fast to build, slow to run, has debug info)
-# Nextclade dataset is expected to be in ./data_dev/
+# Nextclade dataset is expected to be in ./data_dev/, refer to Nextclade dataset information 
+# (https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html#download-a-dataset)
 # Refer to the user documentation for explanation of Nextclade CLI flags (https://docs.nextstrain.org/projects/nextclade/en/stable/)
 cargo run --bin=nextclade -- run \
-  --input-fasta=data_dev/sequences.fasta \
+  data_dev/sequences.fasta \
   --input-dataset=data_dev/ \
   --output-fasta='out/nextclade.aligned.fasta' \
   --output-tsv='out/nextclade.tsv' \
@@ -47,7 +48,7 @@ cargo build --release --bin=nextclade
 
 # Run Nextclade release binary
 ./target/release/nextclade run \
-  --input-fasta=data_dev/sequences.fasta \
+  data_dev/sequences.fasta \
   --input-dataset=data_dev/ \
   --output-fasta='out/nextclade.aligned.fasta' \
   --output-tsv='out/nextclade.tsv' \


### PR DESCRIPTION
## Solves 
I had issues running the commands in the developer guide script- the script commands were out of date and did not run and returned the error msg: 
```
The argument `--input-fasta` (alias: `--sequences`, `-i`) is removed in favor of positional arguments.

      Try:

        nextclade run -D dataset/ -O out/ seq1.fasta seq2.fasta

                                              ^          ^
                                     one or multiple positional arguments
                                       with paths to input fasta files

      When positional arguments are not provided, nextclade will read input fasta from standard input.

      For more information, type:

        nextclade run --help
```
Fixing this only requires a small modification but will help future users