### PR TITLE
Feat/tree builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "bytemuck"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1410,23 @@ dependencies = [
  "num-traits",
  "rand",
  "rand_distr",
- "simba",
+ "simba 0.5.1",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eef2ccf9aefdae3334ad5911b5414724b9047bfe145b3353d5878732cc7b86b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba 0.7.3",
  "typenum",
 ]
 
@@ -1468,6 +1490,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "nalgebra 0.31.3",
  "num",
  "num-traits",
  "num_cpus",
@@ -2210,6 +2233,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2444,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,7 +2505,7 @@ checksum = "05bdbb8e4e78216a85785a85d3ec3183144f98d0097b9281802c019bb07a6f05"
 dependencies = [
  "approx",
  "lazy_static",
- "nalgebra",
+ "nalgebra 0.27.1",
  "num-traits",
  "rand",
 ]
@@ -3106,6 +3151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae41ecad2489a1655c8ef8489444b0b113c0a0c795944a3572a0931cf7d2525c"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/docs/dev/developer-guide.md
+++ b/docs/dev/developer-guide.md
@@ -31,10 +31,11 @@ sudo apt-get install --yes libssl-dev pkg-config
 cp .env.example .env
 
 # Build and run Nextclade in debug mode (convenient for development, fast to build, slow to run, has debug info)
-# Nextclade dataset is expected to be in ./data_dev/
+# Nextclade dataset is expected to be in ./data_dev/, refer to Nextclade dataset information 
+# (https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html#download-a-dataset)
 # Refer to the user documentation for explanation of Nextclade CLI flags (https://docs.nextstrain.org/projects/nextclade/en/stable/)
 cargo run --bin=nextclade -- run \
-  --input-fasta=data_dev/sequences.fasta \
+  data_dev/sequences.fasta \
   --input-dataset=data_dev/ \
   --output-fasta='out/nextclade.aligned.fasta' \
   --output-tsv='out/nextclade.tsv' \
@@ -47,7 +48,7 @@ cargo build --release --bin=nextclade
 
 # Run Nextclade release binary
 ./target/release/nextclade run \
-  --input-fasta=data_dev/sequences.fasta \
+  data_dev/sequences.fasta \
   --input-dataset=data_dev/ \
   --output-fasta='out/nextclade.aligned.fasta' \
   --output-tsv='out/nextclade.tsv' \

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -5,6 +5,7 @@ use crate::cli::nextclade_ordered_writer::NextcladeOrderedWriter;
 use crate::dataset::dataset_download::{
   dataset_dir_load, dataset_individual_files_load, dataset_str_download_and_load, dataset_zip_load, DatasetFiles,
 };
+use assert2::__assert2_impl::print;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::info;
@@ -21,7 +22,9 @@ use nextclade::translate::translate_genes::Translation;
 use nextclade::translate::translate_genes_ref::translate_genes_ref;
 use nextclade::tree::tree_attach_new_nodes::tree_attach_new_nodes_in_place;
 use nextclade::tree::tree_preprocess::tree_preprocess_in_place;
+use nextclade::tree::tree_builder::tree_builder_run_one;
 use nextclade::types::outputs::NextcladeOutputs;
+use serde::de::value::SeqAccessDeserializer;
 use std::path::PathBuf;
 
 pub struct NextcladeRecord {
@@ -198,6 +201,32 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
               alignment_params,
             )
           });
+
+          //just to check output
+          let seq_name1 = seq_name.clone();
+          let seq1 = seq.clone();
+          let qry_seq1 = to_nuc_seq(&seq1).expect("tree builder: failed");
+          for FastaRecord { seq_name, seq, index } in &fasta_receiver {
+            let seq2 = to_nuc_seq(&seq).expect("tree builder: failed");
+            let dist = tree_builder_run_one(
+              index,
+              &seq_name1,
+              &seq_name,
+              &qry_seq1,
+              &seq2,
+              ref_seq,
+              ref_peptides,
+              gene_map,
+              primers,
+              tree,
+              qc_config,
+              virus_properties,
+              gap_open_close_nuc,
+              gap_open_close_aa,
+              alignment_params,
+            );
+            println!("{}", dist);
+          }
 
           let record = NextcladeRecord {
             index,

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -10,7 +10,7 @@ use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::info;
 use nextclade::align::gap_open::{get_gap_open_close_scores_codon_aware, get_gap_open_close_scores_flat};
-use nextclade::align::params::AlignPairwiseParams;
+use nextclade::align::params::{AlignPairwiseParams, AlignPairwiseParamsOptional};
 use nextclade::analyze::phenotype::get_phenotype_attr_descs;
 use nextclade::io::fasta::{FastaReader, FastaRecord};
 use nextclade::io::fs::has_extension;
@@ -295,3 +295,5 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
 
   Ok(())
 }
+
+

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -33,6 +33,7 @@ indexmap = { version = "1.8.1", features = ["serde"] }
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.16"
+nalgebra = "0.31.3"
 num = "0.4.0"
 num-traits = "0.2.14"
 num_cpus = "1.13.1"

--- a/packages_rs/nextclade/src/tree/mod.rs
+++ b/packages_rs/nextclade/src/tree/mod.rs
@@ -2,3 +2,4 @@ pub mod tree;
 pub mod tree_attach_new_nodes;
 pub mod tree_find_nearest_node;
 pub mod tree_preprocess;
+pub mod tree_builder;

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -90,68 +90,68 @@ pub fn calculate_distance(
   total_muts_1 + total_muts_2 - 2 * shared_differences - shared_sites - undetermined_sites
 }
 
-pub fn calculate_distance_matrix(
-  fasta : &FastaRecord, 
-  ref_seq: &[Nuc],
-  ref_peptides: &TranslationMap,
-  gene_map: &GeneMap,
-  primers: &[PcrPrimer],
-  tree: &AuspiceTree,
-  qc_config: &QcConfig,
-  virus_properties: &VirusProperties,
-  gap_open_close_nuc: &[i32],
-  gap_open_close_aa: &[i32],
-  params: &AlignPairwiseParams,
-) -> Result<DMatrix<i64>, Report> {
+// pub fn calculate_distance_matrix(
+//   fasta : &FastaRecord, 
+//   ref_seq: &[Nuc],
+//   ref_peptides: &TranslationMap,
+//   gene_map: &GeneMap,
+//   primers: &[PcrPrimer],
+//   tree: &AuspiceTree,
+//   qc_config: &QcConfig,
+//   virus_properties: &VirusProperties,
+//   gap_open_close_nuc: &[i32],
+//   gap_open_close_aa: &[i32],
+//   params: &AlignPairwiseParams,
+// ) -> Result<DMatrix<i64>, Report> {
 
-  let mut record_values = HashMap::new();
-  let mut reader = FastaReader::from_paths(fasta).unwrap();
-  let mut k = 0;
-  loop {
-    let mut record = FastaRecord::default();
-    reader.read(&mut record).unwrap();
-    if record.is_empty() {
-      break;
-    }
-    let qry_seq = to_nuc_seq(&record.seq).expect("tree builder: failed");
-    let nao = nextalign_run_one(
-      record.index,
-      &record.seq_name,
-      &qry_seq,
-      ref_seq,
-      ref_peptides,
-      gene_map,
-      gap_open_close_nuc,
-      gap_open_close_aa,
-      params,
-    ).expect("tree builder: alignment failed");
+//   let mut record_values = HashMap::new();
+//   let mut reader = FastaReader::from_paths(fasta).unwrap();
+//   let mut k = 0;
+//   loop {
+//     let mut record = FastaRecord::default();
+//     reader.read(&mut record).unwrap();
+//     if record.is_empty() {
+//       break;
+//     }
+//     let qry_seq = to_nuc_seq(&record.seq).expect("tree builder: failed");
+//     let nao = nextalign_run_one(
+//       record.index,
+//       &record.seq_name,
+//       &qry_seq,
+//       ref_seq,
+//       ref_peptides,
+//       gene_map,
+//       gap_open_close_nuc,
+//       gap_open_close_aa,
+//       params,
+//     ).expect("tree builder: alignment failed");
 
-    let nuc_changes = find_nuc_changes(&nao.stripped.qry_seq, &nao.stripped.ref_seq);
+//     let nuc_changes = find_nuc_changes(&nao.stripped.qry_seq, &nao.stripped.ref_seq);
     
-    let missing = find_letter_ranges(&nao.stripped.qry_seq, Nuc::N);
-    record_values.insert(k, (nuc_changes.substitutions, missing, nuc_changes.alignment_range));
-    k += 1;
-  }
-  let mut distance_matrix = DMatrix::zeros(record_values.keys().len(), record_values.keys().len());
-  for i in 0..record_values.keys().len() {
-    for j in 0..record_values.keys().len() {
-      if i == j {
-        distance_matrix[(i, j)] = 0;
-        continue;
-      }
-      if i >j{
-        continue;
-      }
+//     let missing = find_letter_ranges(&nao.stripped.qry_seq, Nuc::N);
+//     record_values.insert(k, (nuc_changes.substitutions, missing, nuc_changes.alignment_range));
+//     k += 1;
+//   }
+//   let mut distance_matrix = DMatrix::zeros(record_values.keys().len(), record_values.keys().len());
+//   for i in 0..record_values.keys().len() {
+//     for j in 0..record_values.keys().len() {
+//       if i == j {
+//         distance_matrix[(i, j)] = 0;
+//         continue;
+//       }
+//       if i >j{
+//         continue;
+//       }
 
-      let dist = calculate_distance(&record_values[i][0], &record_values[i][1],&record_values[j][0],
-        &record_values[j][1], &record_values[j][2]);
+//       let dist = calculate_distance(&record_values[i][0], &record_values[i][1],&record_values[j][0],
+//         &record_values[j][1], &record_values[j][2]);
 
-      distance_matrix[(i, j)] = dist;
-      distance_matrix[(j, i)] = dist;
-    }
-  }
-  Ok(distance_matrix)
-}
+//       distance_matrix[(i, j)] = dist;
+//       distance_matrix[(j, i)] = dist;
+//     }
+//   }
+//   Ok(distance_matrix)
+// }
 
 pub fn tree_builder_run_one(
   index: usize,
@@ -204,3 +204,4 @@ pub fn tree_builder_run_one(
   
   dist
 }
+

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -1,9 +1,40 @@
+use std::collections::HashMap;
 use crate::analyze::is_sequenced::is_nuc_sequenced;
 use crate::analyze::letter_ranges::NucRange;
 use crate::analyze::nuc_sub::NucSub;
+use crate::io::fasta::{FastaRecord, FastaReader};
 use crate::tree::tree::{AuspiceTree, AuspiceTreeNode};
 use crate::utils::range::Range;
-use crate::utils::nalgebra::DMatrix;
+use crate::align::insertions_strip::{get_aa_insertions, NucIns};
+use crate::align::params::AlignPairwiseParams;
+use crate::analyze::aa_changes::{find_aa_changes, FindAaChangesOutput};
+use crate::analyze::aa_changes_group::group_adjacent_aa_subs_and_dels;
+use crate::analyze::divergence::calculate_divergence;
+use crate::analyze::find_private_aa_mutations::find_private_aa_mutations;
+use crate::analyze::find_private_nuc_mutations::find_private_nuc_mutations;
+use crate::analyze::letter_composition::get_letter_composition;
+use crate::analyze::letter_ranges::{find_aa_letter_ranges, find_letter_ranges, find_letter_ranges_by};
+use crate::analyze::link_nuc_and_aa_changes::{link_nuc_and_aa_changes, LinkedNucAndAaChanges};
+use crate::analyze::nuc_changes::{find_nuc_changes, FindNucChangesOutput};
+use crate::analyze::pcr_primer_changes::get_pcr_primer_changes;
+use crate::analyze::pcr_primers::PcrPrimer;
+use crate::analyze::phenotype::calculate_phenotype;
+use crate::analyze::virus_properties::{PhenotypeData, VirusProperties};
+use crate::io::aa::Aa;
+use crate::io::gene_map::GeneMap;
+use crate::io::letter::Letter;
+use crate::io::nuc::Nuc;
+use crate::io::nuc::{to_nuc_seq, to_nuc_seq_replacing};
+use crate::qc::qc_config::QcConfig;
+use crate::qc::qc_run::qc_run;
+use crate::run::nextalign_run_one::nextalign_run_one;
+use crate::translate::frame_shifts_flatten::frame_shifts_flatten;
+use crate::translate::translate_genes::{Translation, TranslationMap};
+use crate::tree::tree_find_nearest_node::{tree_find_nearest_node, TreeFindNearestNodeOutput};
+use crate::types::outputs::{NextalignOutputs, NextcladeOutputs, PhenotypeValue};
+use eyre::Report;
+use itertools::Itertools;
+use nalgebra::DMatrix;
 
 /// Calculates distance metric between two query samples
 pub fn calculate_distance(
@@ -20,7 +51,7 @@ pub fn calculate_distance(
   let mut j = 0;
   while (i < qry_nuc_subs_1.len()) && (j < qry_nuc_subs_2.len()) {
     let qmut1 = &qry_nuc_subs_1[i];
-    let qmut2 = &qry_nuc_subs_2[i];
+    let qmut2 = &qry_nuc_subs_2[j];
     if &qmut1.pos > &qmut2.pos {
       j += 1;
       continue;
@@ -57,4 +88,119 @@ pub fn calculate_distance(
 
   // calculate distance from set overlaps.
   total_muts_1 + total_muts_2 - 2 * shared_differences - shared_sites - undetermined_sites
+}
+
+pub fn calculate_distance_matrix(
+  fasta : &FastaRecord, 
+  ref_seq: &[Nuc],
+  ref_peptides: &TranslationMap,
+  gene_map: &GeneMap,
+  primers: &[PcrPrimer],
+  tree: &AuspiceTree,
+  qc_config: &QcConfig,
+  virus_properties: &VirusProperties,
+  gap_open_close_nuc: &[i32],
+  gap_open_close_aa: &[i32],
+  params: &AlignPairwiseParams,
+) -> Result<DMatrix<i64>, Report> {
+
+  let mut record_values = HashMap::new();
+  let mut reader = FastaReader::from_paths(fasta).unwrap();
+  let mut k = 0;
+  loop {
+    let mut record = FastaRecord::default();
+    reader.read(&mut record).unwrap();
+    if record.is_empty() {
+      break;
+    }
+    let qry_seq = to_nuc_seq(&record.seq).expect("tree builder: failed");
+    let nao = nextalign_run_one(
+      record.index,
+      &record.seq_name,
+      &qry_seq,
+      ref_seq,
+      ref_peptides,
+      gene_map,
+      gap_open_close_nuc,
+      gap_open_close_aa,
+      params,
+    ).expect("tree builder: alignment failed");
+
+    let nuc_changes = find_nuc_changes(&nao.stripped.qry_seq, &nao.stripped.ref_seq);
+    
+    let missing = find_letter_ranges(&nao.stripped.qry_seq, Nuc::N);
+    record_values.insert(k, (nuc_changes.substitutions, missing, nuc_changes.alignment_range));
+    k += 1;
+  }
+  let mut distance_matrix = DMatrix::zeros(record_values.keys().len(), record_values.keys().len());
+  for i in 0..record_values.keys().len() {
+    for j in 0..record_values.keys().len() {
+      if i == j {
+        distance_matrix[(i, j)] = 0;
+        continue;
+      }
+      if i >j{
+        continue;
+      }
+
+      let dist = calculate_distance(&record_values[i][0], &record_values[i][1],&record_values[j][0],
+        &record_values[j][1], &record_values[j][2]);
+
+      distance_matrix[(i, j)] = dist;
+      distance_matrix[(j, i)] = dist;
+    }
+  }
+  Ok(distance_matrix)
+}
+
+pub fn tree_builder_run_one(
+  index: usize,
+  seq_name1: &str,
+  seq_name2: &str,
+  qry_seq1: &[Nuc],
+  qry_seq2: &[Nuc],
+  ref_seq: &[Nuc],
+  ref_peptides: &TranslationMap,
+  gene_map: &GeneMap,
+  primers: &[PcrPrimer],
+  tree: &AuspiceTree,
+  qc_config: &QcConfig,
+  virus_properties: &VirusProperties,
+  gap_open_close_nuc: &[i32],
+  gap_open_close_aa: &[i32],
+  params: &AlignPairwiseParams,
+) -> i64 {
+  let nao1 = nextalign_run_one(
+    index,
+    seq_name1,
+    qry_seq1,
+    ref_seq,
+    ref_peptides,
+    gene_map,
+    gap_open_close_nuc,
+    gap_open_close_aa,
+    params,
+  ).expect("tree builder: alignment failed");
+  let nao2 = nextalign_run_one(
+    index,
+    seq_name2,
+    qry_seq2,
+    ref_seq,
+    ref_peptides,
+    gene_map,
+    gap_open_close_nuc,
+    gap_open_close_aa,
+    params,
+  ).expect("tree builder: alignment failed");
+
+  let nuc_changes1 = find_nuc_changes(&nao1.stripped.qry_seq, &nao1.stripped.ref_seq);
+  let nuc_changes2 = find_nuc_changes(&nao2.stripped.qry_seq, &nao2.stripped.ref_seq);
+
+  let missing1 = find_letter_ranges(&nao1.stripped.qry_seq, Nuc::N);
+  let missing2 = find_letter_ranges(&nao2.stripped.qry_seq, Nuc::N);
+
+  let dist = calculate_distance(&nuc_changes1.substitutions, &missing1,&nuc_changes2.substitutions,
+    &missing2, &nuc_changes1.alignment_range);
+  
+  dist
 }

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -1,0 +1,60 @@
+use crate::analyze::is_sequenced::is_nuc_sequenced;
+use crate::analyze::letter_ranges::NucRange;
+use crate::analyze::nuc_sub::NucSub;
+use crate::tree::tree::{AuspiceTree, AuspiceTreeNode};
+use crate::utils::range::Range;
+use crate::utils::nalgebra::DMatrix;
+
+/// Calculates distance metric between two query samples
+pub fn calculate_distance(
+  qry_nuc_subs_1: &[NucSub],
+  qry_missing_1: &[NucRange],
+  qry_nuc_subs_2: &[NucSub],
+  qry_missing_2: &[NucRange],
+  aln_range: &Range,
+) -> i64 {
+  let mut shared_differences = 0_i64;
+  let mut shared_sites = 0_i64;
+
+  let mut i = 0;
+  let mut j = 0;
+  while (i < qry_nuc_subs_1.len()) && (j < qry_nuc_subs_2.len()) {
+    let qmut1 = &qry_nuc_subs_1[i];
+    let qmut2 = &qry_nuc_subs_2[i];
+    if &qmut1.pos > &qmut2.pos {
+      j += 1;
+      continue;
+    } else if &qmut1.pos < &qmut2.pos {
+      i += 1;
+      continue;
+    }
+    // position is also mutated in node
+    if qmut1.qry == qmut2.qry {
+      shared_differences += 1; // the exact mutation is shared the two sequences
+    } else {
+      shared_sites += 1; // the same position is mutated, but the states are different
+    }
+    i += 1;
+    j += 1;
+  }
+
+  // determine the number of sites that are mutated in one seq but missing in the other.
+  // for these we can't tell whether the sequences agree
+  let mut undetermined_sites = 0_i64;
+  for qmut1 in qry_nuc_subs_1 {
+    if !is_nuc_sequenced(qmut1.pos, qry_missing_2, aln_range) {
+      undetermined_sites += 1;
+    }
+  }
+  for qmut2 in qry_nuc_subs_2 {
+    if !is_nuc_sequenced(qmut2.pos, qry_missing_1, aln_range) {
+      undetermined_sites += 1;
+    }
+  }
+
+  let total_muts_1 = qry_nuc_subs_1.len() as i64;
+  let total_muts_2 = qry_nuc_subs_2.len() as i64;
+
+  // calculate distance from set overlaps.
+  total_muts_1 + total_muts_2 - 2 * shared_differences - shared_sites - undetermined_sites
+}


### PR DESCRIPTION
### Issue
When sequences are added to a reference tree in `nextclade` they are added to the node which is closest to that sequence according to a distance metric. They are not compared to each other and if most of them are closest to the same node this can result in a large polytomy and additional information about the relationship between nodes is lost. Therefore, if more than two sequences are closest to the same node we would like to build a subtree of these nodes instead of just adding them all to the same node. 

### Steps
1. After finding all the closest node in the reference tree for each sequence in the alignment (i.e. at position: https://github.com/nextstrain/nextclade/blob/2b0a4797933dba0c60bd2c6a91734bfbe175a6cc/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs#L261) see if >=2 sequences should be attached to the same node `c`. Write a function that takes `outputs` and returns lists of sequences that should be attached to the same node. 
For each group of sequences that should be attached to the same node (this can be multithreaded if the nodes each sequence should be attached to are not next to each other) perform the following steps, otherwise just attach the sequence directly: 
2. Create a distance matrix between each sequence that should be attached to the node `c` and the node `c` using the distance metric: https://github.com/anna-parker/nextclade/blob/a2f2166867f5e9ba56b74d9d134e34a558735f19/packages_rs/nextclade/src/tree/tree_builder.rs#L40 (potentially `c.anc` and `c.children` also need to be added to the distance metric `d` to improve the tree structure).
3. Use the neighbor joining algorithm to create an initial tree structure: https://en.wikipedia.org/wiki/Neighbor_joining 
- create a `Q` matrix from `d`
- find the minimum of `Q` and join the corresponding sequences to one node
- recalculate `d` and `Q`
- repeat steps until all sequences have been joined together.
4. (Potentially use the Felsenstein pruning algorithm to find the optimal branch length and sub tree topology)
5. Join the new subtree to the node `c` (or alternatively, if `c.anc`, `c` and `c.children` are part of the distance matrix join the subtree to `c.anc`, and append the children of each child in `c.children` to their parent). 