### PR TITLE
chore: migrate linux ci build to centos

### DIFF
--- a/docker-cross
+++ b/docker-cross
@@ -22,6 +22,6 @@ declare -a TARGETS=(
 
 for target in "${TARGETS[@]}"; do
   printf "\nBuilding for %s\n" "${target}"
-  CROSS=${target} ./docker-dev br nextalign
+  CROSS=${target} ./docker-dev br
 done
 

--- a/docker-dev
+++ b/docker-dev
@@ -93,7 +93,7 @@ export CACHE_DIR_REL=".cache/docker/${PACKAGE_DIR_REL}"
 export CACHE_DIR="$(abspath "${PACKAGE_DIR}/${CACHE_DIR_REL}")"
 
 export NICE="nice -14 ionice -c2 -n3"
-export TIME="/usr/bin/time --quiet -f \"Cmd : %C\nTime: %E\nMem : %M KB\n\""
+export TIME="/usr/bin/time -f \"Cmd : %C\nTime: %E\nMem : %M KB\n\""
 
 export RUST_BACKTRACE="full"
 export COLORBT_SHOW_HIDDEN="0"
@@ -343,15 +343,15 @@ DOCKER_TARGET="dev"
 RUST_TARGET=""
 if [ -n "${CROSS:-}" ]; then
   if [[ "${CROSS}" == *linux-gnu ]]; then
-
     if [[ "${CROSS}" == x86_64-* ]]; then
-      DOCKER_BASE_IMAGE="debian:7.11"
-      CLANG_VERSION="3.5"
+      # 'manylinux2014_x86_64' image is based on 'centos:7.9.2009' and offers build environment with
+      # the best compatibility across target Linux distros
+      DOCKER_BASE_IMAGE="quay.io/pypa/manylinux2014_x86_64"
+      CLANG_VERSION="3.4"
     else
       DOCKER_BASE_IMAGE="debian:9.13"
       CLANG_VERSION="13"
     fi
-
   fi
 
   DOCKER_TARGET="cross-${CROSS}"
@@ -378,6 +378,7 @@ if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER
     --target="${DOCKER_TARGET}" \
     --tag="${DOCKER_REPO}:${DOCKER_TARGET}" \
     --tag="${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER_IMAGE_VERSION}" \
+    --cache-from="${DOCKER_REPO}" \
     --cache-from="${DOCKER_REPO}:dev" \
     --cache-from="${DOCKER_REPO}:dev-${DOCKER_IMAGE_VERSION}" \
     --cache-from="${DOCKER_REPO}:${DOCKER_TARGET}" \

--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -1,26 +1,66 @@
 ARG DOCKER_BASE_IMAGE
-ARG CLANG_VERSION
 
 FROM $DOCKER_BASE_IMAGE as base
 
 SHELL ["bash", "-euxo", "pipefail", "-c"]
 
+ARG DOCKER_BASE_IMAGE
 ARG DASEL_VERSION="1.22.1"
 ARG WATCHEXEC_VERSION="1.17.1"
 ARG NODEMON_VERSION="2.0.15"
 ARG YARN_VERSION="1.22.18"
-ARG CLANG_VERSION=$CLANG_VERSION
 
+# Install required packages if running CentOS
 RUN set -euxo pipefail >/dev/null \
-&& if grep wheezy /etc/apt/sources.list; then export IS_DEBIAN_WHEEZY=1; else export IS_DEBIAN_WHEEZY=0; fi \
-&& if [ ${IS_DEBIAN_WHEEZY} == 1 ]; then printf "deb http://archive.debian.org/debian wheezy main non-free contrib\ndeb http://archive.debian.org/debian-security wheezy/updates main non-free contrib\n" > "/etc/apt/sources.list"; fi \
-&& if [ ${IS_DEBIAN_WHEEZY} == 1 ]; then echo "Acquire::Check-Valid-Until false;" >> "/etc/apt/apt.conf.d/10-nocheckvalid"; fi \
+&& if [[ "$DOCKER_BASE_IMAGE" != centos* ]] && [[ "$DOCKER_BASE_IMAGE" != *manylinux2014* ]]; then exit 0; fi \
+&& sed -i "s/enabled=1/enabled=0/g" "/etc/yum/pluginconf.d/fastestmirror.conf" \
+&& sed -i "s/enabled=1/enabled=0/g" "/etc/yum/pluginconf.d/ovl.conf" \
+&& yum clean all \
+&& yum -y install dnf epel-release \
+&& dnf install -y \
+  autoconf \
+  automake \
+  bash \
+  bash-completion \
+  binutils \
+  brotli \
+  ca-certificates \
+  cmake \
+  curl \
+  gcc \
+  gcc-c++ \
+  gdb \
+  git \
+  gnupg \
+  gzip \
+  make \
+  parallel \
+  pigz \
+  pkgconfig \
+  python3 \
+  python3-pip \
+  redhat-lsb-core \
+  sudo \
+  tar \
+  time \
+  xz \
+  zstd \
+&& dnf clean all \
+&& rm -rf /var/cache/yum
+
+
+ARG CLANG_VERSION
+
+# Install required packages if running Debian or Ubuntu
+RUN set -euxo pipefail >/dev/null \
+&& if [[ "$DOCKER_BASE_IMAGE" != debian* ]] && [[ "$DOCKER_BASE_IMAGE" != ubuntu* ]]; then exit 0; fi \
 && export DEBIAN_FRONTEND=noninteractive \
 && apt-get update -qq --yes \
 && apt-get install -qq --no-install-recommends --yes \
   apt-transport-https \
   bash \
   bash-completion \
+  brotli \
   build-essential \
   ca-certificates \
   curl \
@@ -29,39 +69,29 @@ RUN set -euxo pipefail >/dev/null \
   libssl-dev \
   lsb-release \
   parallel \
+  pigz \
+  pixz \
   pkg-config \
   python3 \
   python3-pip \
+  rename \
   sudo \
   time \
   xz-utils \
 >/dev/null \
-&& \
-  if [ "$(lsb_release -cs)" == "wheezy" ]; then \
-    echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs) main" >> "/etc/apt/sources.list.d/llvm.list"; \
-  else \
-    echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${CLANG_VERSION} main" >> "/etc/apt/sources.list.d/llvm.list"; \
-  fi \
+&& echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${CLANG_VERSION} main" >> "/etc/apt/sources.list.d/llvm.list" \
 && curl -fsSL "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add - \
 && export DEBIAN_FRONTEND=noninteractive \
 && apt-get update -qq --yes \
 && apt-get install -qq --no-install-recommends --yes \
   clang-${CLANG_VERSION} \
+  clang-tools-${CLANG_VERSION} \
+  lld-${CLANG_VERSION} \
   lldb-${CLANG_VERSION} \
   llvm-${CLANG_VERSION} \
   llvm-${CLANG_VERSION}-dev \
   llvm-${CLANG_VERSION}-tools \
   >/dev/null \
-&& if [ "$(lsb_release -cs)" != "wheezy" ]; then \
-    apt-get install -qq --no-install-recommends --yes \
-      brotli \
-      clang-tools-${CLANG_VERSION} \
-      lld-${CLANG_VERSION} \
-      pigz \
-      pixz \
-      rename \
-    >/dev/null; \
-  fi \
 && apt-get clean autoclean >/dev/null \
 && apt-get autoremove --yes >/dev/null \
 && rm -rf /var/lib/apt/lists/*
@@ -85,11 +115,6 @@ ENV PATH="/usr/lib/llvm-${CLANG_VERSION}/bin:${NODE_DIR}/bin:${HOME}/.local/bin:
 
 # Install Python dependencies
 RUN set -euxo pipefail >/dev/null \
-&& if [ "$(lsb_release -cs)" == "wheezy" ]; then \
-     curl -fsSL https://bootstrap.pypa.io/pip/3.2/get-pip.py | python3 \
-   ;fi
-
-RUN set -euxo pipefail >/dev/null \
 && pip3 install --user --upgrade cram
 
 # Install dasel, a tool to query TOML files
@@ -107,22 +132,25 @@ RUN set -euxo pipefail >/dev/null \
 # Install Node.js
 COPY .nvmrc /
 RUN set -eux >dev/null \
-&& if [ "$(lsb_release -cs)" != "wheezy" ]; then \
-  mkdir -p "${NODE_DIR}" \
-  && cd "${NODE_DIR}" \
-  && NODE_VERSION=$(cat /.nvmrc) \
-  && curl -fsSL  "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" | tar -xJ --strip-components=1 \
-  && npm install -g nodemon@${NODEMON_VERSION} yarn@${YARN_VERSION} >/dev/null \
-  && npm config set scripts-prepend-node-path auto \
-;fi
+&& mkdir -p "${NODE_DIR}" \
+&& cd "${NODE_DIR}" \
+&& NODE_VERSION=$(cat /.nvmrc) \
+&& curl -fsSL  "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" | tar -xJ --strip-components=1 \
+&& npm install -g nodemon@${NODEMON_VERSION} yarn@${YARN_VERSION} >/dev/null \
+&& npm config set scripts-prepend-node-path auto
 
 # Make a user and group
 RUN set -euxo pipefail >/dev/null \
 && \
   if [ -z "$(getent group ${GID})" ]; then \
-    addgroup --system --gid ${GID} ${GROUP}; \
+    groupadd --system --gid ${GID} ${GROUP}; \
   else \
     groupmod -n ${GROUP} $(getent group ${GID} | cut -d: -f1); \
+  fi \
+&& export SUDO_GROUP="sudo" \
+&& \
+  if [[ "$DOCKER_BASE_IMAGE" == centos* ]] || [[ "$DOCKER_BASE_IMAGE" == *manylinux2014* ]]; then \
+    export SUDO_GROUP="wheel"; \
   fi \
 && \
   if [ -z "$(getent passwd ${UID})" ]; then \
@@ -131,7 +159,7 @@ RUN set -euxo pipefail >/dev/null \
       --create-home --home-dir ${HOME} \
       --shell /bin/bash \
       --gid ${GROUP} \
-      --groups sudo \
+      --groups ${SUDO_GROUP} \
       --uid ${UID} \
       ${USER}; \
   fi \
@@ -227,8 +255,8 @@ ENV CXX_x86_64-unknown-linux-gnu=clang++
 # Same as native, but convenient to have for mass cross-compilation.
 FROM dev as cross-x86_64-unknown-linux-gnu
 
-ENV CC_x86_64-unknown-linux-gnu=clang
-ENV CXX_x86_64-unknown-linux-gnu=clang++
+ENV CC_x86_64-unknown-linux-gnu=gcc
+ENV CXX_x86_64-unknown-linux-gnu=g++
 
 
 # Cross-compilation for Linux x86_64 with libmusl

--- a/scripts/test-linux-distros
+++ b/scripts/test-linux-distros
@@ -11,78 +11,66 @@ function abspath() {
   readlink -m "$1"
 }
 
-NEXTCLADE_BIN="${1:-$(pwd)/.out/nextclade-x86_64-unknown-linux-gnu}"
+export NEXTCLADE_BIN="${1:-$(pwd)/.out/nextclade-x86_64-unknown-linux-gnu}"
+export VOLUME="$(abspath "${NEXTCLADE_BIN}"):/nextclade"
+export RUN_COMMAND="/nextclade dataset list >/dev/null"
 
-VOLUME="$(abspath "${NEXTCLADE_BIN}"):/nextclade"
+distros=(
+  "debian:8.0"
+  "debian:9.0"
+  "debian:10.0"
+  "debian:11.0"
+  "debian:stable"
+  "debian:testing"
+  "debian:sid"
+  "debian:latest"
+  "ubuntu:12.04"
+  "ubuntu:14.04"
+  "ubuntu:16.04"
+  "ubuntu:18.04"
+  "ubuntu:20.04"
+  "ubuntu:22.04"
+  "ubuntu:latest"
+  "amazonlinux:2017.12.0.20171212.2"
+  "amazonlinux:2.0.20180622.1"
+  "amazonlinux:2.0.20190115"
+  "amazonlinux:2.0.20191217.0"
+  "amazonlinux:2.0.20200207.1"
+  "amazonlinux:2.0.20210126.0"
+  "amazonlinux:2.0.20220121.0"
+  "amazonlinux:latest"
+  "centos:7.2.1511"
+  "centos:7.5.1804"
+  "centos:8.1.1911"
+  "centos:8.4.2105"
+  "centos:latest"
+  "fedora:27"
+  "fedora:30"
+  "fedora:33"
+  "fedora:36"
+  "fedora:latest"
+  "oraclelinux:7.2"
+  "oraclelinux:8.0"
+  "oraclelinux:8.6"
+  "registry.access.redhat.com/ubi7/ubi"
+  "registry.access.redhat.com/ubi8/ubi"
+  "registry.access.redhat.com/ubi9/ubi"
+  "opensuse/archive:13.2"
+  "opensuse/leap:15.2"
+  "opensuse/tumbleweed:latest"
+  "archlinux:latest"
+)
 
-RUN_COMMAND="/nextclade dataset list >/dev/null"
-
-for distro in \
-  "debian:7.3" \
-  "debian:8.0" \
-  "debian:9.0" \
-  "debian:10.0" \
-  "debian:11.0" \
-  "debian:stable" \
-  "debian:testing" \
-  "debian:sid" \
-  "debian:latest" \
-  "ubuntu:16.04" \
-  "ubuntu:18.04" \
-  "ubuntu:20.04" \
-  "ubuntu:22.04" \
-  "ubuntu:latest"; do
+function run_one_distro() {
+  distro=$1
   docker pull -q "$distro" >/dev/null
-  echo "$distro"
-  docker run -it --rm -v "${VOLUME}" "$distro" bash -c "${RUN_COMMAND}" || true
-  echo ""
-done
+  if ! docker run -i --rm -v "${VOLUME}" "$distro" bash -c "${RUN_COMMAND}"; then
+    echo "Failed running '${RUN_COMMAND}' on '$distro'"
+    exit 1
+  fi
+}
+export -f run_one_distro
 
-for distro in \
-  "amazonlinux:2017.12.0.20171212.2" \
-  "amazonlinux:2.0.20180622.1" \
-  "amazonlinux:2.0.20190115" \
-  "amazonlinux:2.0.20191217.0" \
-  "amazonlinux:2.0.20200207.1" \
-  "amazonlinux:2.0.20210126.0" \
-  "amazonlinux:2.0.20220121.0" \
-  "amazonlinux:latest" \
-  "centos:7.2.1511" \
-  "centos:7.5.1804" \
-  "centos:8.1.1911" \
-  "centos:8.4.2105" \
-  "centos:latest" \
-  "fedora:27" \
-  "fedora:30" \
-  "fedora:33" \
-  "fedora:36" \
-  "fedora:latest" \
-  "oraclelinux:7.2" \
-  "oraclelinux:8.0" \
-  "oraclelinux:8.6" \
-  "registry.access.redhat.com/ubi7/ubi" \
-  "registry.access.redhat.com/ubi8/ubi" \
-  "registry.access.redhat.com/ubi9/ubi"; do
-  docker pull -q "$distro" >/dev/null
+for distro in "${distros[@]}"; do
   echo "$distro"
-  docker run -it --rm -v "${VOLUME}" "$distro" bash -c "${RUN_COMMAND}" || true
-  echo ""
-done
-
-for distro in \
-  "opensuse/archive:13.2" \
-  "opensuse/leap:15.2" \
-  "opensuse/tumbleweed:latest"; do
-  docker pull -q "$distro" >/dev/null
-  echo "$distro"
-  docker run -it --rm -v "${VOLUME}" "$distro" bash -c "${RUN_COMMAND}" || true
-  echo ""
-done
-
-for distro in \
-  "archlinux:latest"; do
-  docker pull -q "$distro" >/dev/null
-  echo "$distro"
-  docker run -it --rm -v "${VOLUME}" "$distro" bash -c "${RUN_COMMAND}" || true
-  echo ""
-done
+done | parallel run_one_distro


### PR DESCRIPTION
We use good old Debian 7 (codename: wheezy, glibc 2.14) as a base docker image for our Linux builds, to ensure the best compatibility of Nextclade CLI binaries across Linux distributions.

However, builds on have failed recently. The gpg keys from package repositories of  Debian 7 have expired and don't seem to be renewing for a while. This can be overridden and makes package installation potentially insecure.

In order to resolve that, here I migrate builds to `quay.io/pypa/manylinux2014_x86_64` image (glibc 2.17). This is CentOS 7-based image which is used by Python community to build packages which work on many different Linux distros.

Downside: we lose compatibility with Linux distros with glibc < 2.17, such as debian 7.

Upside: minimum of glibc 2.17 means that we can now use more recent versions of Rust - versions since 1.64 require glibc 2.17.

Items:
 - [x] remove all mentions of Debian wheezy
 - [x] add a section to dockerfile which installs dependencies using yum/dnf when running CentOS or manylinux2014_x86_64
 - [x] use GCC instead of Clang for Linux builds (I could not quickly find a repo with decent version of prebuilt LLVM/Clang for CentOS 7)
 - [x] adjust test-linux-distros; parallelize it

