### PR TITLE
chore" upgrade rust to 1.65

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.65.0"
 profile = "default"


### PR DESCRIPTION
We can now afford it due to https://github.com/nextstrain/nextclade/pull/1057

