### PR TITLE
chore(ci): publish to bioconda

### DIFF
--- a/.github/workflows/bioconda.yml
+++ b/.github/workflows/bioconda.yml
@@ -1,0 +1,52 @@
+# Submit new version to Bioconda (https://github.com/bioconda/bioconda-recipes)
+name: bioconda
+
+on:
+  release:
+    types:
+      - published
+
+  repository_dispatch:
+    types: bioconda
+
+  workflow_dispatch:
+
+  workflow_call:
+
+concurrency:
+  group: bioconda-${{ github.workflow }}-${{ github.ref_type }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -euxo pipefail {0}
+
+jobs:
+
+  publish-to-bioconda:
+    name: "Publish to Bioconda"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: "Publish to Bioconda"
+        id: bump-version
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEXTSTRAIN_BOT_GITHUB_TOKEN }}"
+        run: |
+          mkdir -p "${HOME}/bin"
+          export PATH="${HOME}/bin:${PATH}"
+          curl -fsSL "https://github.com/cli/cli/releases/download/v2.10.1/gh_2.10.1_linux_amd64.tar.gz" | tar xz -C "${HOME}/bin" --strip-components=2 gh_2.10.1_linux_amd64/bin/gh
+          curl -fsSL "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -o "${HOME}/bin/dasel" && chmod +x "${HOME}/bin/dasel"
+          curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64" -o ${HOME}/bin/jq && chmod +x ${HOME}/bin/jq
+
+          git config user.email "${{ secrets.GIT_USER_EMAIL }}"
+          git config user.name "${{ secrets.GIT_USER_NAME }}"
+
+          ./scripts/publish_bioconda

--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Submit a PR to https://github.com/bioconda/bioconda-recipes
+# in order to update Nextclade on 'bioconda' channel of 'conda'.
+#
+# Dependencies:
+#  mkdir -p "${HOME}/bin"
+#  export PATH="${HOME}/bin:${PATH}"
+#  curl -fsSL "https://github.com/cli/cli/releases/download/v2.10.1/gh_2.10.1_linux_amd64.tar.gz" | tar xz -C "${HOME}/bin" --strip-components=2 gh_2.10.1_linux_amd64/bin/gh
+#  curl -fsSL "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -o "${HOME}/bin/dasel" && chmod +x "${HOME}/bin/dasel"
+#  curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64" -o ${HOME}/bin/jq && chmod +x ${HOME}/bin/jq
+#
+# Requires git user name and email to be set. For example:
+#  git config user.email "${{ secrets.GIT_USER_EMAIL }}"
+#  git config user.name "${{ secrets.GIT_USER_NAME }}"
+
+set -euo pipefail
+trap 'exit' INT
+
+# Directory where this script resides
+THIS_DIR="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  pwd
+)"
+
+#: "${GITHUB_TOKEN:? Env var \$GITHUB_TOKEN is required.}"
+
+export artifacts_dir="${THIS_DIR}/../artifacts"
+
+artifacts=(
+  'nextalign-aarch64-apple-darwin'
+  'nextalign-x86_64-apple-darwin'
+  'nextalign-x86_64-unknown-linux-gnu'
+  'nextclade-aarch64-apple-darwin'
+  'nextclade-x86_64-apple-darwin'
+  'nextclade-x86_64-unknown-linux-gnu'
+)
+
+mkdir -p "${artifacts_dir}"
+
+function download_artifact() {
+  name=${1:?}
+  curl -fsSL -o "${artifacts_dir}/${name}" "https://github.com/nextstrain/nextclade/releases/latest/download/${name}"
+}
+export -f download_artifact
+
+# Download executables
+parallel --jobs="${#artifacts[@]}" download_artifact ::: "${artifacts[@]}"
+
+chmod +x "${artifacts_dir}"/*
+
+# Check auth
+gh auth status >/dev/null
+
+# Get the version string and validate it
+version="$("${artifacts_dir}/nextclade-x86_64-unknown-linux-gnu" --version | awk '{ print $2 }')"
+if [ "$("${THIS_DIR}/semver" validate "${version}")" != "valid" ]; then
+  echo "The version emitted by 'nextclade --version' is invalid: ${version}. Refusing to proceed." >&2
+  exit 1
+fi
+
+## Clone upstream repo (https://github.com/bioconda/bioconda-recipes)
+git clone --quiet --origin upstream --single-branch --branch master "https://github.com/bioconda/bioconda-recipes"
+
+pushd bioconda-recipes >/dev/null
+
+version_old=$(sed -n 's|.*version = "\(.*\)".*|\1|p' "recipes/nextclade/meta.yaml")
+
+## Add Nextstrain fork (https://github.com/nextstrain/bioconda-recipes) as a remote
+git remote add nextstrain "git@github.com:nextstrain/bioconda-recipes.git" >/dev/null
+
+# Create a new branch
+git switch --quiet --create "bump/nextclade-${version}"
+
+## Bump the version
+"${THIS_DIR}/update-bioconda.py" "nextclade" "${version}" "${artifacts_dir}" "recipes/nextclade/meta.yaml"
+"${THIS_DIR}/update-bioconda.py" "nextalign" "${version}" "${artifacts_dir}" "recipes/nextalign/meta.yaml"
+
+# Print the diff
+git --no-pager diff --unified=0 --no-prefix --no-commit-id --word-diff
+
+# Stage and commit the changes
+git add "recipes/nextclade/meta.yaml"
+git add "recipes/nextalign/meta.yaml"
+git commit --quiet -m "Update nextclade and nextalign to ${version}"
+
+# Push to the fork
+git push --quiet --set-upstream nextstrain "bump/nextclade-${version}"
+
+# Revert any other changes so that they don't get committed accidentally
+git add -A
+git reset --quiet --hard HEAD
+git clean --quiet -dfx
+
+home=$(tail -n +3 recipes/nextclade/meta.yaml | dasel select -r yaml -w json -s ".about.home" | jq -r)
+summary=$(tail -n +3 recipes/nextclade/meta.yaml | dasel select -r yaml -w json -s ".about.summary" | jq -r)
+maintainers=$(tail -n +3 recipes/nextclade/meta.yaml | dasel select -r yaml -w json -s ".extra.recipe-maintainers" | jq -r 'join(",")')
+maintainers_gh_handles=$(tail -n +3 recipes/nextclade/meta.yaml | dasel select -r yaml -w json -s ".extra.recipe-maintainers" | jq -r '[ .[] | "@" + . ] | join(", ")')
+
+# Create PR body. This is what goes to the first message.
+function pr_body() {
+  cat <<~~
+Update [nextclade](https://bioconda.github.io/recipes/nextclade/README.html) and [nextalign](https://bioconda.github.io/recipes/nextalign/README.html): ${version_old} → ${version}.
+
+<img src=https://img.shields.io/conda/dn/bioconda/nextclade.svg />
+
+<table>
+<tr>
+	<td>Home</td>
+	<td><a href="${home}">${home}</a></td>
+</tr>
+<tr>
+	<td>Summary</td>
+	<td>${summary}</td>
+</tr>
+<tr>
+	<td>Recipe maintainers</td>
+	<td>${maintainers_gh_handles}</td>
+</tr>
+</table>
+
+@BiocondaBot please add label
+
+@BiocondaBot please fetch artifacts
+
+Note: this pull request is submitted automatically, triggered by a release in [nextstrain/nextclade](https://github.com/nextstrain/nextclade) repo. If you want to get in touch, please ping recipe maintainers and/or someone from [\`@nextstrain/core\`](https://github.com/orgs/nextstrain/teams/core/members) team.
+
+~~
+}
+
+# Submit the PR, reading message body from stdin
+pr_body | gh pr create \
+  --title "Update nextclade and nextalign to ${version}" \
+  --body-file - \
+  --reviewer "${maintainers}" \
+  --repo "bioconda/bioconda-recipes"
+
+
+popd >/dev/null
+
+rm -rf bioconda-recipes

--- a/scripts/update-bioconda.py
+++ b/scripts/update-bioconda.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+###
+### Update bioconda recipe
+###
+
+from os.path import join
+from hashlib import sha256
+import re
+import sys
+
+archs = {
+  "linux64": "x86_64-unknown-linux-gnu",
+  "osx and x86_64": "x86_64-apple-darwin",
+  "arm64": "aarch64-apple-darwin"
+}
+
+if __name__ == '__main__':
+  # Base name of the executable
+  name = sys.argv[1]
+
+  # New version string, e.g. 1.23.4
+  version = sys.argv[2]
+
+  # Path to directory with executables
+  bin_dir = sys.argv[3]
+
+  # Path to meta.yml file from bioconda recipe
+  meta_yml_path = sys.argv[4]
+
+  with open(meta_yml_path, "r") as f:
+    meta_yaml = f.read()
+
+  meta_yaml = re.sub(r'version = "(.+)"', rf'version = "{version}"', meta_yaml)
+
+  for selector, arch in archs.items():
+      with open(join(bin_dir, f"{name}-{arch}"), "rb") as f:
+        digest = sha256(f.read()).hexdigest()
+
+      meta_yaml = re.sub(rf'(?<=sha256: )(\S+)(?=\s+# \[{selector}\])', f"{digest}", meta_yaml)
+
+  with open(meta_yml_path, "w") as f:
+    f.write(meta_yaml)


### PR DESCRIPTION
Adds a script and a GHA workflow to publish new version on bioconda. 

The workflow is normally to be triggered by a GitHub release (but can also be triggered manually or through API). It downloads the binaries, gets their version,  commits and pushes updated `meta.yaml` to https://github.com/nextstrain/bioconda-recipes and then creates a PR from there to https://github.com/bioconda/bioconda-recipes/branches.

