### PR TITLE
fix: identify datasets uniquely

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useState } from 'react'
 
 import { Button, Col, Collapse, Row } from 'reactstrap'
 import { useRecoilValue, useResetRecoilState } from 'recoil'
-import { datasetCurrentAtom, datasetCurrentNameAtom } from 'src/state/dataset.state'
 import styled from 'styled-components'
 
+import { datasetCurrentAtom } from 'src/state/dataset.state'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { ButtonCustomize } from 'src/components/Main/ButtonCustomize'
 import { FilePickerAdvanced } from 'src/components/FilePicker/FilePickerAdvanced'
@@ -71,7 +71,7 @@ export function DatasetCurrent() {
   const { t } = useTranslationSafe()
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const datasetCurrent = useRecoilValue(datasetCurrentAtom)
-  const resetDatasetCurrent = useResetRecoilState(datasetCurrentNameAtom)
+  const resetDatasetCurrent = useResetRecoilState(datasetCurrentAtom)
 
   const onChangeClicked = useCallback(() => {
     resetDatasetCurrent()

--- a/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
@@ -1,14 +1,14 @@
 import React, { HTMLProps, useCallback, useState } from 'react'
-
 import classNames from 'classnames'
 import { ThreeDots } from 'react-loader-spinner'
 import { Button, Col, Container, Input, Row } from 'reactstrap'
 import { useRecoilState, useRecoilValue } from 'recoil'
-import { LinkExternal } from 'src/components/Link/LinkExternal'
-import { datasetCurrentNameAtom, datasetsAtom } from 'src/state/dataset.state'
 import styled from 'styled-components'
 
+import type { Dataset } from 'src/types'
+import { datasetCurrentAtom, datasetsAtom } from 'src/state/dataset.state'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { DatasetSelectorList } from './DatasetSelectorList'
 
 const DatasetSelectorContainer = styled(Container)`
@@ -48,17 +48,16 @@ const Spinner = styled(ThreeDots)`
 
 export interface DatasetSelectorProps {
   searchTerm: string
+
   setSearchTerm(searchTerm: string): void
 }
 
 export function DatasetSelector({ searchTerm, setSearchTerm }: DatasetSelectorProps) {
   const { t } = useTranslationSafe()
   const [error, setError] = useState<string | undefined>()
-  const { datasets, defaultDatasetName } = useRecoilValue(datasetsAtom)
-  const [datasetCurrentName, setDatasetCurrent] = useRecoilState(datasetCurrentNameAtom)
-  const [datasetHighlighted, setDatasetHighlighted] = useState<string | undefined>(
-    datasetCurrentName ?? defaultDatasetName,
-  )
+  const { datasets } = useRecoilValue(datasetsAtom)
+  const [datasetCurrent, setDatasetCurrent] = useRecoilState(datasetCurrentAtom)
+  const [datasetHighlighted, setDatasetHighlighted] = useState<Dataset | undefined>(datasetCurrent)
 
   const onSearchTermChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages_rs/nextclade-web/src/components/Main/DatasetSelectorList.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetSelectorList.tsx
@@ -4,6 +4,7 @@ import { ListGroup, ListGroupItem } from 'reactstrap'
 import styled from 'styled-components'
 
 import type { Dataset } from 'src/types'
+import { areDatasetsEqual } from 'src/types'
 import { search } from 'src/helpers/search'
 import { DatasetInfo } from 'src/components/Main/DatasetInfo'
 
@@ -60,8 +61,9 @@ export function DatasetSelectorListItem({ dataset, isCurrent, isDimmed, onClick 
 export interface DatasetSelectorListProps {
   datasets: Dataset[]
   searchTerm: string
-  datasetHighlighted?: string
-  onDatasetHighlighted(dataset: string): void
+  datasetHighlighted?: Dataset
+
+  onDatasetHighlighted(dataset?: Dataset): void
 }
 
 export function DatasetSelectorList({
@@ -70,10 +72,7 @@ export function DatasetSelectorList({
   datasetHighlighted,
   onDatasetHighlighted,
 }: DatasetSelectorListProps) {
-  const onItemClick = useCallback(
-    (dataset: Dataset) => () => onDatasetHighlighted(dataset.attributes.name.value),
-    [onDatasetHighlighted],
-  )
+  const onItemClick = useCallback((dataset: Dataset) => () => onDatasetHighlighted(dataset), [onDatasetHighlighted])
 
   const { itemsStartWith, itemsInclude, itemsNotInclude } = useMemo(() => {
     if (searchTerm.trim().length === 0) {
@@ -93,10 +92,10 @@ export function DatasetSelectorList({
         {[itemsStartWith, itemsInclude].map((datasets) =>
           datasets.map((dataset) => (
             <DatasetSelectorListItem
-              key={dataset.attributes.name.value}
+              key={dataset.id}
               dataset={dataset}
               onClick={onItemClick(dataset)}
-              isCurrent={dataset.attributes.name.value === datasetHighlighted}
+              isCurrent={areDatasetsEqual(dataset, datasetHighlighted)}
             />
           )),
         )}
@@ -104,10 +103,10 @@ export function DatasetSelectorList({
         {[itemsNotInclude].map((datasets) =>
           datasets.map((dataset) => (
             <DatasetSelectorListItem
-              key={dataset.attributes.name.value}
+              key={dataset.id}
               dataset={dataset}
               onClick={onItemClick(dataset)}
-              isCurrent={dataset.attributes.name.value === datasetHighlighted}
+              isCurrent={areDatasetsEqual(dataset, datasetHighlighted)}
               isDimmed
             />
           )),

--- a/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages_rs/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -8,7 +8,7 @@ import { AlgorithmGlobalStatus } from 'src/types'
 import { sanitizeError } from 'src/helpers/sanitizeError'
 import { auspiceStartClean, treeFilterByNodeType } from 'src/state/auspice/auspice.actions'
 import { createAuspiceState } from 'src/state/auspice/createAuspiceState'
-import { datasetCurrentAtom, datasetCurrentNameAtom } from 'src/state/dataset.state'
+import { datasetCurrentAtom } from 'src/state/dataset.state'
 import { globalErrorAtom } from 'src/state/error.state'
 import {
   geneMapInputAtom,
@@ -47,7 +47,6 @@ export function useRunAnalysis() {
         reset(analysisResultsAtom)
 
         const numThreads = getPromise(numThreadsAtom)
-        const datasetCurrentName = getPromise(datasetCurrentNameAtom)
         const datasetCurrent = getPromise(datasetCurrentAtom)
 
         const qryInputs = getPromise(qrySeqInputsStorageAtom)
@@ -97,7 +96,7 @@ export function useRunAnalysis() {
           .push('/results', '/results')
           .then(async () => {
             set(analysisStatusGlobalAtom, AlgorithmGlobalStatus.initWorkers)
-            return launchAnalysis(qryInputs, inputs, callbacks, datasetCurrentName, datasetCurrent, numThreads)
+            return launchAnalysis(qryInputs, inputs, callbacks, datasetCurrent, numThreads)
           })
           .catch((error) => {
             set(analysisStatusGlobalAtom, AlgorithmGlobalStatus.failed)

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -32,15 +32,11 @@ export async function initializeDatasets(urlQuery: ParsedUrlQuery, datasetServer
 
   const datasetsIndexJson = await fetchDatasetsIndex(datasetServerUrl)
 
-  const { datasets, defaultDatasetName, defaultDatasetNameFriendly } = getLatestCompatibleEnabledDatasets(
-    datasetServerUrl,
-    datasetsIndexJson,
-  )
+  const { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly } =
+    getLatestCompatibleEnabledDatasets(datasetServerUrl, datasetsIndexJson)
 
   // Check if URL params specify dataset params and try to find the corresponding dataset
   const currentDataset = await getDatasetFromUrlParams(urlQuery, datasets)
 
-  const currentDatasetName = currentDataset?.attributes.name.value
-
-  return { datasets, defaultDatasetName, defaultDatasetNameFriendly, currentDatasetName }
+  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
 }

--- a/packages_rs/nextclade-web/src/io/fetchDatasetsIndex.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasetsIndex.ts
@@ -54,6 +54,7 @@ export function getLatestCompatibleEnabledDatasets(datasetServerUrl: string, dat
 
   return {
     datasets,
+    defaultDataset,
     defaultDatasetName: value,
     defaultDatasetNameFriendly: valueFriendly ?? value,
   }

--- a/packages_rs/nextclade-web/src/io/fetchSingleDatasetFromUrl.ts
+++ b/packages_rs/nextclade-web/src/io/fetchSingleDatasetFromUrl.ts
@@ -15,6 +15,7 @@ export async function fetchSingleDatasetFromUrl(
   const tag = await axiosFetchOrUndefined<DatasetTag>(urljoin(datasetRootUrl, 'tag.json'))
 
   const currentDataset: Dataset = {
+    id: '0',
     enabled: true,
     attributes: {
       name: {
@@ -62,6 +63,7 @@ export async function fetchSingleDatasetFromUrl(
   }
 
   const datasets = [currentDataset]
+  const defaultDataset = currentDataset
   const currentDatasetName = currentDataset.attributes.name.value
   const defaultDatasetName = currentDatasetName
   const defaultDatasetNameFriendly = currentDataset.attributes.name.valueFriendly ?? currentDatasetName
@@ -84,7 +86,7 @@ export async function fetchSingleDatasetFromUrl(
     Object.entries(currentDataset.files).filter(([filename, _]) => !['tag.json', 'sequences.fasta'].includes(filename)),
   )
 
-  return { datasets, defaultDatasetName, defaultDatasetNameFriendly, currentDatasetName }
+  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
 }
 
 export class ErrorDatasetFileMissing extends Error {

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -50,7 +50,7 @@ import { SEO } from 'src/components/Common/SEO'
 import { Plausible } from 'src/components/Common/Plausible'
 import i18n, { changeLocale, getLocaleWithKey } from 'src/i18n/i18n'
 import { theme } from 'src/theme'
-import { datasetCurrentNameAtom, datasetsAtom, datasetServerUrlAtom } from 'src/state/dataset.state'
+import { datasetCurrentAtom, datasetsAtom, datasetServerUrlAtom } from 'src/state/dataset.state'
 import { ErrorBoundary } from 'src/components/Error/ErrorBoundary'
 import { PreviewWarning } from 'src/components/Common/PreviewWarning'
 
@@ -108,13 +108,14 @@ export function RecoilStateInitializer() {
         set(globalErrorAtom, sanitizeError(error))
         throw error
       })
-      .then(({ datasets, defaultDatasetName, defaultDatasetNameFriendly, currentDatasetName }) => {
+      .then(({ datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }) => {
         set(datasetsAtom, {
           datasets,
+          defaultDataset,
           defaultDatasetName,
           defaultDatasetNameFriendly,
         })
-        set(datasetCurrentNameAtom, (previous) => currentDatasetName ?? previous)
+        set(datasetCurrentAtom, (previous) => currentDataset ?? previous)
 
         return undefined
       })

--- a/packages_rs/nextclade-web/src/state/dataset.state.ts
+++ b/packages_rs/nextclade-web/src/state/dataset.state.ts
@@ -8,6 +8,7 @@ import { inputResetAtom } from 'src/state/inputs.state'
 import { persistAtom } from 'src/state/persist/localStorage'
 import { viewedGeneAtom } from 'src/state/seqViewSettings.state'
 import { isDefaultValue } from 'src/state/utils/isDefaultValue'
+import { areDatasetsEqual } from 'src/types'
 
 export function getDefaultDatasetServer(): string {
   let datasetServerUrl = process.env.DATA_FULL_DOMAIN ?? '/'
@@ -25,6 +26,7 @@ export const datasetServerUrlAtom = atom<string>({
 
 export interface Datasets {
   datasets: Dataset[]
+  defaultDataset: Dataset
   defaultDatasetName: string
   defaultDatasetNameFriendly: string
 }
@@ -33,39 +35,26 @@ export const datasetsAtom = atom<Datasets>({
   key: 'datasets',
 })
 
-const datasetCurrentNameStorageAtom = atom<string | undefined>({
-  key: 'datasetCurrentNameStorage',
+const datasetCurrentStorageAtom = atom<Dataset | undefined>({
+  key: 'datasetCurrentStorage',
   default: undefined,
   effects: [persistAtom],
-})
-
-export const datasetCurrentNameAtom = selector<string | undefined>({
-  key: 'datasetCurrentName',
-  get({ get }) {
-    return get(datasetCurrentNameStorageAtom)
-  },
-  set({ get, set, reset }, newDatasetCurrentName: string | undefined | DefaultValue) {
-    const datasetCurrentName = get(datasetCurrentNameStorageAtom)
-    if (isDefaultValue(newDatasetCurrentName) || isNil(newDatasetCurrentName)) {
-      reset(datasetCurrentNameStorageAtom)
-    } else if (datasetCurrentName !== newDatasetCurrentName) {
-      const { datasets } = get(datasetsAtom)
-      const dataset = datasets.find((dataset) => dataset.attributes.name.value === newDatasetCurrentName)
-      if (dataset) {
-        set(datasetCurrentNameStorageAtom, dataset.attributes.name.value)
-        set(viewedGeneAtom, dataset.params?.defaultGene ?? GENE_OPTION_NUC_SEQUENCE)
-        reset(inputResetAtom)
-      }
-    }
-  },
 })
 
 export const datasetCurrentAtom = selector<Dataset | undefined>({
   key: 'datasetCurrent',
   get({ get }) {
-    const { datasets } = get(datasetsAtom)
-    const datasetCurrentName = get(datasetCurrentNameAtom)
-    return datasets.find((dataset) => dataset.attributes.name.value === datasetCurrentName)
+    return get(datasetCurrentStorageAtom)
+  },
+  set({ get, set, reset }, dataset: Dataset | undefined | DefaultValue) {
+    const datasetCurrent = get(datasetCurrentStorageAtom)
+    if (isDefaultValue(dataset) || isNil(dataset)) {
+      reset(datasetCurrentStorageAtom)
+    } else if (!areDatasetsEqual(datasetCurrent, dataset)) {
+      set(datasetCurrentStorageAtom, dataset)
+      set(viewedGeneAtom, dataset.params?.defaultGene ?? GENE_OPTION_NUC_SEQUENCE)
+      reset(inputResetAtom)
+    }
   },
 })
 

--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -7,7 +7,7 @@ import { AlgorithmGlobalStatus, AlgorithmSequenceStatus, getResultStatus } from 
 import { plausible } from 'src/components/Common/Plausible'
 import { runFilters } from 'src/filtering/runFilters'
 import { SortCategory, SortDirection, sortResults, sortResultsByKey } from 'src/helpers/sortResults'
-import { datasetCurrentNameAtom } from 'src/state/dataset.state'
+import { datasetCurrentAtom } from 'src/state/dataset.state'
 import {
   aaFilterAtom,
   cladesFilterAtom,
@@ -243,15 +243,20 @@ export const analysisStatusGlobalAtom = atom({
       onSet((status) => {
         switch (status) {
           case AlgorithmGlobalStatus.started:
-            void getPromise(datasetCurrentNameAtom).then((datasetName) => {
-              plausible('Run started', { props: { dataset: datasetName } })
+            void getPromise(datasetCurrentAtom).then((dataset) => {
+              plausible('Run started', { props: { dataset: dataset?.attributes.name.value ?? 'unknown' } })
             })
             break
 
           case AlgorithmGlobalStatus.done:
-            void Promise.all([getPromise(analysisResultStatusesAtom), getPromise(datasetCurrentNameAtom)]).then(
-              ([results, datasetName]) => {
-                plausible('Run completed', { props: { sequences: results.length, dataset: datasetName } })
+            void Promise.all([getPromise(analysisResultStatusesAtom), getPromise(datasetCurrentAtom)]).then(
+              ([results, dataset]) => {
+                plausible('Run completed', {
+                  props: {
+                    sequences: results.length,
+                    dataset: dataset?.attributes.name.value ?? 'unknown',
+                  },
+                })
               },
             )
             break

--- a/packages_rs/nextclade-web/src/types.ts
+++ b/packages_rs/nextclade-web/src/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import type { Tagged } from 'src/helpers/types'
 import type { QCFilters } from 'src/filtering/filterByQCIssues'
+import { isEqual, isNil } from 'lodash'
 
 /** Type-safe representation of a nucleotide */
 export type Nucleotide = Tagged<string, 'Nucleotide'>
@@ -565,6 +566,7 @@ export interface DatasetTag {
 }
 
 export interface Dataset {
+  id: string
   enabled: boolean
   attributes: DatasetAttributes
   comment: string
@@ -572,6 +574,10 @@ export interface Dataset {
   files: DatasetFiles
   params: DatasetParams
   zipBundle: string
+}
+
+export function areDatasetsEqual(left?: Dataset, right?: Dataset): boolean {
+  return !isNil(left) && !isNil(right) && isEqual(left.attributes, right.attributes)
 }
 
 export interface DatasetsIndexV2Json {

--- a/packages_rs/nextclade-web/src/workers/launchAnalysis.ts
+++ b/packages_rs/nextclade-web/src/workers/launchAnalysis.ts
@@ -50,7 +50,6 @@ export async function launchAnalysis(
   qryFastaInputs: Promise<AlgorithmInput[]>,
   paramInputs: LaunchAnalysisInputs,
   callbacks: LaunchAnalysisCallbacks,
-  datasetNamePromise: Promise<string | undefined>,
   datasetPromise: Promise<Dataset | undefined>,
   numThreads: Promise<number>,
 ) {
@@ -59,8 +58,8 @@ export async function launchAnalysis(
   // Resolve inputs into the actual strings
   const qryFastaStr = await getQueryFasta(await qryFastaInputs)
 
-  const [dataset, datasetName] = await Promise.all([datasetPromise, datasetNamePromise])
-  if (!dataset || !datasetName) {
+  const [dataset] = await Promise.all([datasetPromise])
+  if (!dataset) {
     throw new ErrorInternal('Dataset is required but not found')
   }
 


### PR DESCRIPTION
This fixes a problem where datasets could not be selected in dataset selector of Nextclade Web if they have the same name.

In this PR the datasets are now distinguished by the unique combination of attributes, not only name, and when rendering also by the `.id` field, which was added in data repo here: https://github.com/nextstrain/nextclade_data/pull/52

