### PR TITLE
fix(cli): show non-default references in "dataset list" command

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -107,9 +107,12 @@ pub struct NextcladeDatasetListArgs {
   pub name: Option<String>,
 
   /// Restrict list to datasets based on this reference sequence (given its accession ID). Equivalent to `--attribute='reference=<value>'`.
+  /// Special values:
+  ///  - "all" show datasets with any reference sequences
+  ///  - "default" show datasets with any reference sequences
   #[clap(long, short = 'r')]
   #[clap(value_hint = ValueHint::Other)]
-  #[clap(default_value = "default")]
+  #[clap(default_value = "all")]
   pub reference: String,
 
   /// Restrict list to datasets with this version tag. Equivalent to `--attribute='tag=<value>'`.

--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -57,7 +57,9 @@ pub fn nextclade_dataset_list(
     })
     // Filter by reference sequence
     .filter(|dataset| {
-      if reference == "default" {
+      if reference == "all" {
+        true
+      } else if reference == "default" {
         dataset.attributes.reference.is_default
       } else {
         dataset.attributes.reference.value == reference
@@ -85,6 +87,14 @@ pub fn nextclade_dataset_list(
       }
       should_include
     })
+    .sorted_by_key(|dataset| (
+      !dataset.attributes.name.is_default,
+      dataset.attributes.name.value.to_ascii_lowercase(),
+      !dataset.attributes.reference.is_default,
+      dataset.attributes.reference.value.to_ascii_lowercase(),
+      !dataset.attributes.tag.is_default,
+      dataset.attributes.tag.value.to_ascii_lowercase(),
+    ))
     .collect_vec();
 
   if json {


### PR DESCRIPTION
This introduces special value "all" for `--reference` param of `dataset list` command. And it is now set as default value for this flag. When it's in force, datasets with all reference sequences are included into the displayed list.

Additionally sorting is applied to group datasets with related attributes visually.

