### PR TITLE
fix: set default weights in private mutations qc check to 1

### DIFF
--- a/packages_rs/nextclade/src/qc/qc_config.rs
+++ b/packages_rs/nextclade/src/qc/qc_config.rs
@@ -29,14 +29,31 @@ pub struct QcRulesConfigMixedSites {
 #[serde(default)]
 pub struct QcRulesConfigPrivateMutations {
   pub enabled: bool,
+
+  #[serde(default = "one")]
   pub weight_reversion_substitutions: f64,
+
+  #[serde(default = "one")]
   pub weight_reversion_deletions: f64,
+
+  #[serde(default = "one")]
   pub weight_labeled_substitutions: f64,
+
+  #[serde(default = "one")]
   pub weight_labeled_deletions: f64,
+
+  #[serde(default = "one")]
   pub weight_unlabeled_substitutions: f64,
+
+  #[serde(default = "one")]
   pub weight_unlabeled_deletions: f64,
+
   pub typical: f64,
   pub cutoff: f64,
+}
+
+const fn one() -> f64 {
+  1.0
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Validate)]


### PR DESCRIPTION
This fixes the bug when the QC score is 0 when the following QC fields are missing from `qc.json`:
```
    .privateMutations.weightLabeledSubstitutions
    .privateMutations.weightReversionSubstitutions
    .privateMutations.weightUnlabeledSubstitutions
```
In this case Nextclade assumed value 0, and ending up with calculating QC score of 0. Not all datasets were adjusted, so some datasets don't have these fields.

Here I set the default of these weights to 1.0 if they are missing, such that QC have some sensible values again.

