### PR TITLE
chore(ci): remove 'gh auth status' call

### DIFF
--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -49,9 +49,6 @@ parallel --jobs="${#artifacts[@]}" download_artifact ::: "${artifacts[@]}"
 
 chmod +x "${artifacts_dir}"/*
 
-# Check auth
-gh auth status >/dev/null
-
 # Setup git identity
 gh auth setup-git >/dev/null
 


### PR DESCRIPTION
In hope to remove the need for `read:org` permission on the GH token.

