### PR TITLE
chore(ci): ensure release notes contain commit log [skip ci]

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -5,10 +5,11 @@ header = """
   <summary><h3>Commit history</h3> (click to expand)</summary>
 """
 
-# https://tera.netlify.app/docs/#introduction
+# This uses "Tera" template language.
+# Docs: https://tera.netlify.app/docs/#introduction
 body = """
 {% for commit in commits %}
-  - [[`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/{{ get_env(name="CIRCLE_PROJECT_USERNAME") }}/{{ get_env(name="CIRCLE_PROJECT_REPONAME") }}/commit/{{ commit.id }})] {{ commit.message }}
+ - [[`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/{{ get_env(name="GITHUB_REPOSITORY") }}/commit/{{ commit.id }})] {{ commit.message }}
 {% endfor %}
 """
 


### PR DESCRIPTION
This fixes fix template string for the cliff tool which creates commit log in the release notes.

