### PR TITLE
Allow to add example sequences using URL param

### DIFF
--- a/packages_rs/nextclade-web/src/helpers/takeFirstMaybe.ts
+++ b/packages_rs/nextclade-web/src/helpers/takeFirstMaybe.ts
@@ -1,3 +1,5 @@
+import { isNil } from 'lodash'
+
 /**
  * Returns the first element of the array if non array is provided,
  * or `undefined` if empty array is provided, or passes through if
@@ -13,4 +15,22 @@ export function takeFirstMaybe<T>(maybeArray: T | T[]): T | undefined {
   }
 
   return undefined
+}
+
+/**
+ * Returns:
+ *  - array if array is provided
+ *  - array of one element if not array is provided
+ *  - empty array if `undefined` nil-ish value is provided
+ */
+export function takeArray<T>(val: T | T[] | undefined): T[] {
+  if (Array.isArray(val)) {
+    return val
+  }
+
+  if (isNil(val)) {
+    return []
+  }
+
+  return [val]
 }

--- a/packages_rs/nextclade-web/src/io/createInputFromUrlParamMaybe.ts
+++ b/packages_rs/nextclade-web/src/io/createInputFromUrlParamMaybe.ts
@@ -1,7 +1,11 @@
 import type { ParsedUrlQuery } from 'querystring'
 
-import { AlgorithmInputUrl } from 'src/io/AlgorithmInput'
+import { AlgorithmInputDefault, AlgorithmInputUrl } from 'src/io/AlgorithmInput'
 import { getQueryParamMaybe } from 'src/io/getQueryParamMaybe'
+import { takeArray } from 'src/helpers/takeFirstMaybe'
+import { AlgorithmInput, Dataset } from 'src/types'
+import { isString } from 'lodash'
+import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 
 export function createInputFromUrlParamMaybe(urlQuery: ParsedUrlQuery, paramName: string) {
   const url = getQueryParamMaybe(urlQuery, paramName)
@@ -9,4 +13,22 @@ export function createInputFromUrlParamMaybe(urlQuery: ParsedUrlQuery, paramName
     return undefined
   }
   return new AlgorithmInputUrl(url)
+}
+
+export function createInputFastasFromUrlParam(
+  urlQuery: ParsedUrlQuery,
+  dataset: Dataset | undefined,
+): AlgorithmInput[] {
+  const urls = takeArray(urlQuery?.['input-fasta'])
+  return urls
+    .map((url) => {
+      if (url === 'example') {
+        return dataset ? new AlgorithmInputDefault(dataset) : undefined
+      }
+      if (isString(url)) {
+        return new AlgorithmInputUrl(url)
+      }
+      return undefined
+    })
+    .filter(notUndefinedOrNull)
 }


### PR DESCRIPTION
Add special handling of value `example` to `input-fasta` URL param in Nextclade Web.

When `input-fasta=example` param is added, Nextclade Web will automatically start the analysis of example sequences (just like when clicking "Load example" on main page). The dataset should be provided with

This is handy when testing and debugging things.

Can also be used to combine external fasta and the examples. In this case, add multiple `input-fasta` parameters, e.g.

```
?input-fasta=example&input-fasta=http://example.com/my.fasta&dataset-name=my-dataset-name
```

