### PR TITLE
fix: ensure `--output-all`, `--output-tsv`, `--output-csv` can be used together again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Nextclade CLI 2.10.1 (2023-01-24)
+
+### Ensure `--output-all`, `--output-tsv`, `--output-csv` can be used together again in Nextclade CLI
+
+This fixes a regression introduced in Nextclade CLI 2.10.0, where `--output-all`, `--output-tsv`, `--output-csv` arguments became mutually exclusive. This was not intended and now resolved.
+
+This bug was breaking out bioconda checks, so Nextclade CLI version 2.10.0 will not be available in bioconda. Use 2.10.1 instead.
+
+Nextclade Web is not affected.
+
+
 ## Nextclade Web 2.10.0, Nextclade CLI 2.10.0 (2023-01-24)
 
 ### Add motifs search

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -839,6 +839,7 @@ pub fn nextclade_parse_cli_args() -> Result<(), Report> {
     }
     NextcladeCommands::Run(mut run_args) => {
       nextclade_check_removed_args(&run_args)?;
+      nextclade_check_column_config_args(&run_args)?;
       nextclade_get_output_filenames(&mut run_args).wrap_err("When deducing output filenames")?;
       nextclade_run(*run_args)
     }

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -11,7 +11,6 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use nextclade::align::params::AlignPairwiseParamsOptional;
 use nextclade::io::fs::add_extension;
-use nextclade::io::nextclade_csv::CSV_POSSIBLE_CATEGORIES;
 use nextclade::utils::global_init::setup_logger;
 use nextclade::{getenv, make_error};
 use std::fmt::Debug;
@@ -383,7 +382,7 @@ pub struct NextcladeRunOutputArgs {
   /// At least one of the output flags is required: `--output-all`, `--output-fasta`, `--output-ndjson`, `--output-json`, `--output-csv`, `--output-tsv`, `--output-tree`, `--output-translations`, `--output-insertions`, `--output-errors`
   ///
   /// If the required directory tree does not exist, it will be created.
-  #[clap(long, short = 'O', group = "tabular_output")]
+  #[clap(long, short = 'O')]
   #[clap(value_hint = ValueHint::DirPath)]
   pub output_all: Option<PathBuf>,
 
@@ -480,7 +479,7 @@ pub struct NextcladeRunOutputArgs {
   /// If the provided file path ends with one of the supported extensions: "gz", "bz2", "xz", "zstd", then the file will be written compressed. Use "-" to write the uncompressed to standard output (stdout).
   ///
   /// If the required directory tree does not exist, it will be created.
-  #[clap(long, short = 'c', group = "tabular_output")]
+  #[clap(long, short = 'c')]
   #[clap(value_hint = ValueHint::AnyPath)]
   pub output_csv: Option<PathBuf>,
 
@@ -495,7 +494,7 @@ pub struct NextcladeRunOutputArgs {
   /// If the provided file path ends with one of the supported extensions: "gz", "bz2", "xz", "zstd", then the file will be written compressed. Use "-" to write the uncompressed to standard output (stdout).
   ///
   /// If the required directory tree does not exist, it will be created.
-  #[clap(long, short = 't', group = "tabular_output")]
+  #[clap(long, short = 't')]
   #[clap(value_hint = ValueHint::AnyPath)]
   pub output_tsv: Option<PathBuf>,
 
@@ -513,7 +512,6 @@ pub struct NextcladeRunOutputArgs {
     multiple_values = true,
     use_value_delimiter = true
   )]
-  #[clap(requires = "tabular_output")]
   pub output_columns_selection: Vec<String>,
 
   /// Path to output phylogenetic tree with input sequences placed onto it, in Auspice JSON V2 format.
@@ -809,6 +807,22 @@ pub fn nextclade_check_removed_args(run_args: &NextcladeRunArgs) -> Result<(), R
 
   if run_args.outputs.output_dir.is_some() {
     return make_error!("{ERROR_MSG_OUTPUT_DIR_REMOVED}");
+  }
+
+  Ok(())
+}
+
+pub fn nextclade_check_column_config_args(run_args: &NextcladeRunArgs) -> Result<(), Report> {
+  let NextcladeRunOutputArgs {
+    output_all,
+    output_csv,
+    output_tsv,
+    output_columns_selection,
+    ..
+  } = &run_args.outputs;
+
+  if !output_columns_selection.is_empty() && [output_all, output_csv, output_tsv].iter().all(|arg| arg.is_none()) {
+    return make_error!("The `--output-columns-selection` argument configures column-based output formats and can only be used when one or more of the column-based file outputs is requested, i.e. together with one or multiple of `--output-all`, `--output-csv`, `--output-tsv`.");
   }
 
   Ok(())


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/1081

Turns out setting `group` for related arguments in `clap` makes them exclusive, so for example `--output-all` and `--output-tsv` could not be used together after the [changes](https://github.com/nextstrain/nextclade/pull/1081/files#diff-b5e102bcc2cc46bbfcf5a19927b6adad0a8a0adb4c0f80b7a46bcf05fdafbd28L385-R500) in https://github.com/nextstrain/nextclade/pull/1081.

In order to fix that I remove the `group` and check the presence of one of `--output-all`, `--output-csv`, `--output-tsv` manually. This is the constraint required for `--output-columns-selection`. I tried to express with the `group`, but that did had the aforementioned unwanted side effect, breaking bioconda tests: https://github.com/bioconda/bioconda-recipes/pull/38990

