### PR TITLE
feat(web): add row index column to results table

### DIFF
--- a/packages_rs/nextclade-web/src/components/Results/HelpTips/HelpTipsColumnRowIndex.mdx
+++ b/packages_rs/nextclade-web/src/components/Results/HelpTips/HelpTipsColumnRowIndex.mdx
@@ -1,9 +1,9 @@
 ##### Column: row index
 
-Index of the row in the table. Useful for visual counting of sorted and filtered results.
+Index of the row in the table. Useful for visual search and counting of sorted and filtered results.
 
 Not to be confused with sequence index.
 
-Row indices always start with 0 and are sorted in ascending order, and do not change their position when sorting or filtering of the results.
+Row indices always start with 0 and are sorted in ascending order. They do not change their position when data is reordered due to sorting or filtering.
 
 Indices are 0-based.

--- a/packages_rs/nextclade-web/src/components/Results/HelpTips/HelpTipsColumnRowIndex.mdx
+++ b/packages_rs/nextclade-web/src/components/Results/HelpTips/HelpTipsColumnRowIndex.mdx
@@ -1,0 +1,9 @@
+##### Column: row index
+
+Index of the row in the table. Useful for visual counting of sorted and filtered results.
+
+Not to be confused with sequence index.
+
+Row indices always start with 0 and are sorted in ascending order, and do not change their position when sorting or filtering of the results.
+
+Indices are 0-based.

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
@@ -41,6 +41,7 @@ import { ResultsControlsSort } from './ResultsControlsSort'
 import HelpTipsColumnClade from './HelpTips/HelpTipsColumnClade.mdx'
 import HelpTipsColumnGaps from './HelpTips/HelpTipsColumnGaps.mdx'
 import HelpTipsColumnId from './HelpTips/HelpTipsColumnId.mdx'
+import HelpTipsColumnRowIndex from './HelpTips/HelpTipsColumnRowIndex.mdx'
 import HelpTipsColumnInsertions from './HelpTips/HelpTipsColumnInsertions.mdx'
 import HelpTipsColumnMissing from './HelpTips/HelpTipsColumnMissing.mdx'
 import HelpTipsCoverage from './HelpTips/HelpTipsColumnCoverage.mdx'
@@ -250,9 +251,18 @@ export function ResultsTable() {
   return (
     <Table rounded={isResultsFilterPanelCollapsed}>
       <TableHeaderRow>
-        <TableHeaderCell first basis={columnWidthsPx.id} grow={0} shrink={0}>
+        <TableHeaderCell first basis={columnWidthsPx.rowIndex} grow={0} shrink={0}>
           <TableHeaderCellContent>
-            <TableCellText>{t('ID')}</TableCellText>
+            <TableCellText>{t('#')}</TableCellText>
+          </TableHeaderCellContent>
+          <ButtonHelpStyled identifier="btn-help-col-row-index">
+            <HelpTipsColumnRowIndex />
+          </ButtonHelpStyled>
+        </TableHeaderCell>
+
+        <TableHeaderCell basis={columnWidthsPx.id} grow={0} shrink={0}>
+          <TableHeaderCellContent>
+            <TableCellText>{t('i')}</TableCellText>
             <ResultsControlsSort sortAsc={sortByIndexAsc} sortDesc={sortByIndexDesc} />
           </TableHeaderCellContent>
           <ButtonHelpStyled identifier="btn-help-col-seq-id">

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRow.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRow.tsx
@@ -51,7 +51,8 @@ function ResultsTableRowUnmemoed({ index, data, ...restProps }: RowProps) {
     return (
       <ResultsTableRowResult
         {...restProps}
-        index={seqIndex}
+        rowIndex={index}
+        seqIndex={seqIndex}
         columnWidthsPx={columnWidthsPx}
         dynamicCladeColumnWidthPx={dynamicCladeColumnWidthPx}
         dynamicPhenotypeColumnWidthPx={dynamicPhenotypeColumnWidthPx}

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
@@ -22,7 +22,6 @@ import {
   TableCellName,
   TableCellRowIndex,
   TableCellText,
-  TableHeaderCell,
   TableRow,
 } from 'src/components/Results/ResultsTableStyle'
 import { PeptideView } from 'src/components/SequenceView/PeptideView'

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
@@ -20,7 +20,9 @@ import {
   TableCell,
   TableCellAlignedLeft,
   TableCellName,
+  TableCellRowIndex,
   TableCellText,
+  TableHeaderCell,
   TableRow,
 } from 'src/components/Results/ResultsTableStyle'
 import { PeptideView } from 'src/components/SequenceView/PeptideView'
@@ -31,7 +33,8 @@ import { ColumnCoverage } from 'src/components/Results/ColumnCoverage'
 import { ColumnAaMotifs } from 'src/components/Results/ColumnAaMotifs'
 
 export interface ResultsTableRowResultProps {
-  index: number
+  rowIndex: number
+  seqIndex: number
   viewedGene: string
   cladeNodeAttrDescs: CladeNodeAttrDesc[]
   phenotypeAttrDescs: PhenotypeAttrDesc[]
@@ -76,7 +79,8 @@ export function TableRowColored({
 }
 
 export function ResultsTableRowResult({
-  index,
+  rowIndex,
+  seqIndex,
   viewedGene,
   cladeNodeAttrDescs,
   phenotypeAttrDescs,
@@ -87,7 +91,7 @@ export function ResultsTableRowResult({
   dynamicAaMotifsColumnWidthPx,
   ...restProps
 }: ResultsTableRowResultProps) {
-  const { seqName, result } = useRecoilValue(analysisResultAtom(index))
+  const { seqName, result } = useRecoilValue(analysisResultAtom(seqIndex))
 
   const data = useMemo(() => {
     if (!result) {
@@ -107,13 +111,17 @@ export function ResultsTableRowResult({
   const { analysisResult, qc, warnings } = data
 
   return (
-    <TableRowColored {...restProps} index={index} overallStatus={qc.overallStatus}>
+    <TableRowColored {...restProps} index={seqIndex} overallStatus={qc.overallStatus}>
+      <TableCellRowIndex basis={columnWidthsPx.rowIndex} grow={0} shrink={0}>
+        <TableCellText>{rowIndex}</TableCellText>
+      </TableCellRowIndex>
+
       <TableCell basis={columnWidthsPx.id} grow={0} shrink={0}>
-        <TableCellText>{index}</TableCellText>
+        <TableCellText>{seqIndex}</TableCellText>
       </TableCell>
 
       <TableCellName basis={columnWidthsPx.seqName} shrink={0}>
-        <ColumnName index={index} seqName={seqName} />
+        <ColumnName index={seqIndex} seqName={seqName} />
       </TableCellName>
 
       <TableCell basis={columnWidthsPx.qc} grow={0} shrink={0}>

--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableStyle.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableStyle.tsx
@@ -14,6 +14,7 @@ export const DYNAMIC_PHENOTYPE_COLUMN_WIDTH = 65
 export const DYNAMIC_AA_MOTIFS_COLUMN_WIDTH = 85
 
 export const COLUMN_WIDTHS = {
+  rowIndex: 45,
   id: 45,
   seqName: 250,
   qc: 130,
@@ -35,7 +36,6 @@ export const Table = styled.div<{ rounded?: boolean }>`
   height: 100%;
   background-color: #b3b3b3aa;
   overflow: hidden;
-  border-radius: ${(props) => props.rounded && '3px'};
   transition: border-radius 250ms linear;
 `
 
@@ -84,6 +84,20 @@ export const TableCell = styled.div<{ basis?: string; grow?: number; shrink?: nu
   align-items: center;
   text-align: center;
   border-left: 1px solid #b3b3b3;
+`
+
+export const TableCellRowIndex = styled.div<{ basis?: string; grow?: number; shrink?: number }>`
+  flex-basis: ${(props) => props?.basis};
+  flex-grow: ${(props) => props?.grow};
+  flex-shrink: ${(props) => props?.shrink};
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  background-color: #495057;
+  color: #e7e7e7;
+  border-top: 1px solid #b3b3b3aa;
+  height: calc(100% - 1px);
 `
 
 export const TableCellName = styled(TableCell)<{ basis?: string; grow?: number; shrink?: number }>`


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1085

Adds column with index of the row in the table. Useful for visual search and counting of sorted and filtered results.

Not to be confused with sequence index.

Row indices always start with 0 and sorted in ascending order, and do not change their position when sorting or filtering the results.

Indices are 0-based.

These indices are not a part of output files. Spreadsheet software like Excel usually already have rows numbered in this manner.

In this screenshot, the "Row index" column is denoted as "#". The cells in this column have the same background as table header row, to indicate special meaning, just like in Excel. I sorted rows by clade and selected rows with 22F. If you look at row indices, you can quickly see that there are 6 rows (11 - 6 + 1) without counting them manually.

![01](https://user-images.githubusercontent.com/9403403/214697142-cabe8048-6fe4-4ba9-9f46-690734d4b5f6.png)
