### PR TITLE
fix(web): ensure correct width of gene map

### DIFF
--- a/packages_rs/nextclade-web/src/state/settings.state.ts
+++ b/packages_rs/nextclade-web/src/state/settings.state.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/components/Results/ResultsTableStyle'
 import { getNumThreads, guessNumThreads } from 'src/helpers/getNumThreads'
 import { persistAtom } from 'src/state/persist/localStorage'
-import { aaMotifsDescsAtom, cladeNodeAttrKeysAtom, phenotypeAttrKeysAtom } from 'src/state/results.state'
+import { aaMotifsDescsAtom, cladeNodeAttrDescsAtom, phenotypeAttrKeysAtom } from 'src/state/results.state'
 
 export const isInitializedAtom = atom<boolean>({
   key: 'isInitialized',
@@ -108,7 +108,8 @@ export const resultsTableTotalWidthAtom = selector<number>({
   key: 'resultsTableTotalWidth',
   get({ get }) {
     const dynamicCladeColumnsWidthTotal =
-      get(cladeNodeAttrKeysAtom).length * get(resultsTableDynamicCladeColumnWidthAtom)
+      get(cladeNodeAttrDescsAtom).filter((desc) => !desc.hideInWeb).length *
+      get(resultsTableDynamicCladeColumnWidthAtom)
 
     const dynamicPhenotypeColumnsWidthTotal =
       get(phenotypeAttrKeysAtom).length * get(resultsTableDynamicPhenotypeColumnWidthAtom)


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1084

The gene map (genome annotation) schema is not aligned with sequence views (it is narrower).

This was caused by extra width added to the gene map name column to the left of the schema. There are clade-like columns in the inputs that are hidden from web app. However, they were still counted when calculating gene map width.

Here I filter out the hidden clade-like entries before calculating width. This should resolve the issue.

