### PR TITLE
fix(cli): emit index csv/tsv column when there's an error

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -196,10 +196,10 @@ impl<'a> NextcladeOrderedWriter<'a> {
           errors_csv_writer.write_nuc_error(&seq_name, &cause)?;
         }
         if let Some(output_csv_writer) = &mut self.output_csv_writer {
-          output_csv_writer.write_nuc_error(&seq_name, &cause)?;
+          output_csv_writer.write_nuc_error(index, &seq_name, &cause)?;
         }
         if let Some(output_tsv_writer) = &mut self.output_tsv_writer {
-          output_tsv_writer.write_nuc_error(&seq_name, &cause)?;
+          output_tsv_writer.write_nuc_error(index, &seq_name, &cause)?;
         }
         if let Some(output_ndjson_writer) = &mut self.output_ndjson_writer {
           output_ndjson_writer.write_nuc_error(index, &seq_name, &[cause.clone()])?;

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -853,7 +853,7 @@ pub fn results_to_csv_string(
       match output_or_error {
         NextcladeOutputOrError::Outputs(output) => writer.write(&output)?,
         NextcladeOutputOrError::Error(error) => {
-          writer.write_nuc_error(error.index, &error.seq_name, &error.errors.join(";"))?
+          writer.write_nuc_error(error.index, &error.seq_name, &error.errors.join(";"))?;
         }
       };
     }

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -554,7 +554,8 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
   }
 
   /// Writes one row for the case of error
-  pub fn write_nuc_error(&mut self, seq_name: &str, errors: &str) -> Result<(), Report> {
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, errors: &str) -> Result<(), Report> {
+    self.add_entry("index", &index)?;
     self.add_entry("seqName", &seq_name)?;
     self.add_entry("errors", &errors)?;
     self.write_row()?;
@@ -622,8 +623,8 @@ impl NextcladeResultsCsvFileWriter {
   }
 
   /// Writes one row into nextclade.csv or .tsv file for the case of error
-  pub fn write_nuc_error(&mut self, seq_name: &str, errors: &str) -> Result<(), Report> {
-    self.writer.write_nuc_error(seq_name, errors)
+  pub fn write_nuc_error(&mut self, index: usize, seq_name: &str, errors: &str) -> Result<(), Report> {
+    self.writer.write_nuc_error(index, seq_name, errors)
   }
 }
 
@@ -851,7 +852,9 @@ pub fn results_to_csv_string(
     for (_, output_or_error) in outputs_or_errors {
       match output_or_error {
         NextcladeOutputOrError::Outputs(output) => writer.write(&output)?,
-        NextcladeOutputOrError::Error(error) => writer.write_nuc_error(&error.seq_name, &error.errors.join(";"))?,
+        NextcladeOutputOrError::Error(error) => {
+          writer.write_nuc_error(error.index, &error.seq_name, &error.errors.join(";"))?
+        }
       };
     }
   }


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1101

Nextclade emits the new `index` column in case of sucessful analysis, but is missing it when outputs an error row  into CSV and TSV. That's a big whoopsie-doopsie which caused havoc in downstream applications.

Here I fix the omission by writing the `index` column in case of errors too.

