### PR TITLE
chore: remove `DOCKER_BUILDKIT` var

### DIFF
--- a/docker-dev
+++ b/docker-dev
@@ -374,7 +374,7 @@ DOCKER_IMAGE_VERSION="$(./scripts/docker_build_checksum.sh)"
 if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER_IMAGE_VERSION}" &>/dev/null ||
   [ -n "${FORCE_DOCKER_IMAGE_BUILD}" ]; then
 
-  export DOCKER_BUILDKIT=1
+  # export DOCKER_BUILDKIT=1
   export BUILDKIT_PROGRESS=plain
   export PROGRESS_NO_TRUNC=1
 


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1107

(or rather attempts to)

We are using `docker buildx` command, which AFAIU implies `DOCKER_BUILDKIT=1`.  
But someone on the internet* suggested that removing it or setting `DOCKER_BUILDKIT=0` may resolve the errors we are having. I'd like to keep using buildkit though, so don't know if any of it is a good idea. But let's give it a try on a branch.

 \* - https://github.com/docker/buildx/issues/415, https://stackoverflow.com/questions/64221861/an-error-failed-to-solve-with-frontend-dockerfile-v0
