### PR TITLE
fix: commit messages section in GitHub Releases

### DIFF
--- a/.github/workflows/bioconda.yml
+++ b/.github/workflows/bioconda.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash -euxo pipefail {0}
 
+env:
+  GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+
 jobs:
 
   publish-to-bioconda:

--- a/.github/workflows/builder-docker-image.yml
+++ b/.github/workflows/builder-docker-image.yml
@@ -17,6 +17,9 @@ defaults:
   run:
     shell: bash -euxo pipefail {0}
 
+env:
+  GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+
 jobs:
   build-base-image:
     name: "Build base image"

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -25,6 +25,8 @@ defaults:
   run:
     shell: bash -euxo pipefail {0}
 
+env:
+  GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
 
 jobs:
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -25,6 +25,8 @@ defaults:
   run:
     shell: bash -euxo pipefail {0}
 
+env:
+  GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
 
 jobs:
   build-web:

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,6 +1,9 @@
 [changelog]
 
 header = """
+
+---
+
 <details>
   <summary><h3>Commit history</h3> (click to expand)</summary>
 """
@@ -9,13 +12,18 @@ header = """
 # Docs: https://tera.netlify.app/docs/#introduction
 body = """
 {% for commit in commits %}
- - [[`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/{{ get_env(name="GITHUB_REPOSITORY") }}/commit/{{ commit.id }})] {{ commit.message }}
+ - [[`{{ commit.id | truncate(length=7, end="") }}`]({{ get_env(name="GITHUB_REPOSITORY_URL") }}/commit/{{ commit.id }})] {{ commit.message }}
 {% endfor %}
 """
 
 trim = true
 
-footer = """</details>"""
+footer = """
+</details>
+
+---
+
+"""
 
 
 [git]

--- a/docs/assets/release-instructions.md
+++ b/docs/assets/release-instructions.md
@@ -1,9 +1,7 @@
 
----
-
 ## Instructions
 
- 📥 Nextclade CLI & Nextalign CLI can be downloaded from the links in the "Assets" section just below. There click "Show all" to show more options. Note the difference between "nextalign" and "nextclade" files.
+ 📥 Nextclade CLI & Nextalign CLI can be downloaded from the links in the "Assets" section just below. Click "Show all" at the bottom of the "Assets" section to show more download options. Note the difference between "nextalign" and "nextclade" files as well as differences in operating systems and computer architectures.
 
  🌐 Nextclade Web is available at [https://clades.nextstrain.org](https://clades.nextstrain.org)
 


### PR DESCRIPTION
Commit messages were missing from the body of GitHub release message. This attempts to fix that.

I also cleaned up formatting and clarified the "instrcutions" section text, while we are at it.

