### PR TITLE
fix(web): length of 3' unsequenced aa ranges

### DIFF
--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
@@ -102,8 +102,8 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
   }
 
   const { index, seqName, unknownAaRanges, frameShifts, aaChangesGroups, aaInsertions, aaAlignmentRanges } = sequence
-  const geneLength = gene.end - gene.start
-  const pixelsPerAa = width / Math.round(geneLength / 3)
+  const geneLength = (gene.end - gene.start) / 3
+  const pixelsPerAa = width / Math.round(geneLength)
   const groups = aaChangesGroups.filter((group) => group.gene === viewedGene)
 
   const unknownAaRangesForGene = unknownAaRanges.find((range) => range.geneName === viewedGene)


### PR DESCRIPTION
The UI calculations were using nuc length of a gene, where there should be aa length. This led to wrong right boundary on 3' unsequenced range displayed in peptide views (e.g. above 3000 for gene S in SC2, while the gene is only 1200-something long)

In this fix, I ensure that `geneLength` is counted in codons, not nucs.

Before:

<img width="1827" alt="image" src="https://user-images.githubusercontent.com/9403403/223987514-fb35fe9f-a394-4d4c-81b2-7071dc821232.png">

After:

![01](https://user-images.githubusercontent.com/9403403/223987730-7fd1472c-a350-41fa-a19f-a63e847fafb0.png)

