### PR TITLE
feat: add placement bias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,6 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy_static",
- "libm",
  "log",
  "maplit",
  "num",

--- a/packages_rs/nextclade/Cargo.toml
+++ b/packages_rs/nextclade/Cargo.toml
@@ -52,7 +52,6 @@ tinytemplate = "1.2.1"
 traversal = "0.1.2"
 validator = { version = "0.14.0", features = ["derive"] }
 zip = { version = "0.6.2", default-features = false, features = ["aes-crypto", "deflate", "time"] }
-libm = "0.2.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 atty = "0.2.14"

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -35,8 +35,20 @@ impl TreeNodeAttr {
 }
 
 #[derive(Clone, Serialize, Deserialize, Validate, Debug)]
-pub struct TreeNodeAttrInt {
+pub struct TreeNodeAttrF64 {
   pub value: f64,
+
+  #[serde(flatten)]
+  pub other: serde_json::Value,
+}
+
+impl TreeNodeAttrF64 {
+  pub fn new(value: f64) -> Self {
+    Self {
+      value,
+      other: serde_json::Value::default(),
+    }
+  }
 }
 
 #[derive(Clone, Serialize, Deserialize, Validate, Debug)]
@@ -68,7 +80,7 @@ pub struct TreeNodeAttrs {
   pub division: Option<TreeNodeAttr>,
 
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub placement_prior: Option<TreeNodeAttr>,
+  pub placement_prior: Option<TreeNodeAttrF64>,
 
   #[serde(skip_serializing_if = "Option::is_none")]
   #[serde(rename = "Alignment")]

--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -107,7 +107,7 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
         region: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
         country: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
         division: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
-        placement_prior: Some(TreeNodeAttr::new("")),
+        placement_prior: None,
         alignment: Some(TreeNodeAttr::new(&alignment)),
         missing: Some(TreeNodeAttr::new(&format_missings(&result.missing, ", "))),
         gaps: Some(TreeNodeAttr::new(&format_nuc_deletions(&result.deletions, ", "))),


### PR DESCRIPTION
This proposes refactoring bits for https://github.com/nextstrain/nextclade/pull/1114

 - [x] use `TreeNodeAttrF64` as a type of `placement_prior` field on the tree, which contains f64 value instead of string. This avoid fallible parsing step and the need for magic values when parsing fails. This breaks. The tree needs to be changed. We need to thing whether f64 values are allowed in the tree attributes (notably in augur checks and in JSON schema).
 - [x] set `placement_prior` to `None` on new nodes, instead of empty string, to avoid magic values.
 - [x] deduplicate confidence score calculation and extract it into a separate function. This is handy to clearly set apart the algorithmic bits from the boilerplate and also avoids the problems like changing things in one place, but forgetting to change them in the other place.
 - [x] use the built-in `f64::powf()` instead of `libm::exp10()`. I hope I understand how it works correctly (perhaps arguments need to be swapped). This removes the extra dependency.
