### PR TITLE
feat: use placement priors as tie breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Upcoming
 
+### Attach sequences to a priori most likely node if reference tree contains "placement_prior"
+
+Until now, when there were multiple positions with equal numbers of mismatches between a query sequence and reference tree position, Nextclade always attached the query sequence to the reference tree node with the fewest number of ancestors. Due to the way recombinants are placed in the SARS-CoV-2 reference trees, this meant that in particular partial sequences were often attached to recombinants. With most recombinants being rare, this bias to attach to recombinants was often surprising.
+
+In this version, we introduce a new [feature](https://github.com/nextstrain/nextclade/pull/1119) that allows to attach sequences to a priori most likely nodes - taking into account which positions on the reference tree are most commonly found in circulation. The information on the prior probability that a particular reference tree node is the best match for a random query sequence is contained in the `placement_prior` reference tree node attribute. This attribute is currently only present in the most recent SARS-CoV-2 reference trees. The calculation can be found in this `nextclade_data_workflows` [pull request](https://github.com/neherlab/nextclade_data_workflows/pull/38).
+
+To given an example: a partial sequence may have as many mismatches when compared to BA.5 as it has to the recombinant XP. Based on sequences in public databases, we know that BA.5 is much more common than XP. Hence, the query sequence is attached to BA.5. Previously, the query sequence would have been attached to XP, because XP has fewer parent nodes in the reference tree.
+
+The impact of the feature is biggest for partial and incomplete sequences.
+
 ### Fix Google Search Console warnings
 
 We resolved warnings in Google Search Console: added canonical URL meta tag, and added `noindex` tag for non-release deployments. This should improve Nextclade appearance in Google Search.

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -35,6 +35,23 @@ impl TreeNodeAttr {
 }
 
 #[derive(Clone, Serialize, Deserialize, Validate, Debug)]
+pub struct TreeNodeAttrF64 {
+  pub value: f64,
+
+  #[serde(flatten)]
+  pub other: serde_json::Value,
+}
+
+impl TreeNodeAttrF64 {
+  pub fn new(value: f64) -> Self {
+    Self {
+      value,
+      other: serde_json::Value::default(),
+    }
+  }
+}
+
+#[derive(Clone, Serialize, Deserialize, Validate, Debug)]
 pub struct TreeBranchAttrs {
   pub mutations: BTreeMap<String, Vec<String>>,
 
@@ -61,6 +78,9 @@ pub struct TreeNodeAttrs {
 
   #[serde(skip_serializing_if = "Option::is_none")]
   pub division: Option<TreeNodeAttr>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub placement_prior: Option<TreeNodeAttrF64>,
 
   #[serde(skip_serializing_if = "Option::is_none")]
   #[serde(rename = "Alignment")]

--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -114,6 +114,7 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
         region: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
         country: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
         division: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
+        placement_prior: None,
         alignment: Some(TreeNodeAttr::new(&alignment)),
         missing: Some(TreeNodeAttr::new(&format_missings(&result.missing, ", "))),
         gaps: Some(TreeNodeAttr::new(&format_nuc_deletions(&result.deletions, ", "))),

--- a/packages_rs/nextclade/src/tree/tree_find_nearest_node.rs
+++ b/packages_rs/nextclade/src/tree/tree_find_nearest_node.rs
@@ -44,7 +44,14 @@ pub fn tree_find_nearest_nodes<'node>(
 
 /// Gets non-log scale prior from node attributes
 fn get_prior(node: &AuspiceTreeNode) -> f64 {
-  10.0_f64.powf(node.node_attrs.placement_prior.clone().map_or(-10.0, |attr| attr.value))
+  10.0_f64.powf(
+    node
+      .node_attrs
+      .placement_prior
+      .as_ref()
+      // Hard coded -10.0 is small but not zero
+      .map_or(-10.0, |attr| attr.value),
+  )
 }
 
 /// Calculates distance metric between a given query sample and a tree node

--- a/packages_rs/nextclade/src/tree/tree_find_nearest_node.rs
+++ b/packages_rs/nextclade/src/tree/tree_find_nearest_node.rs
@@ -5,9 +5,11 @@ use crate::tree::tree::{AuspiceTree, AuspiceTreeNode, TreeNodeAttr};
 use crate::utils::range::Range;
 use itertools::Itertools;
 
-pub struct TreeFindNearestNodeOutput<'node> {
+/// Distance and placement prior for a ref tree node
+pub struct TreePlacementInfo<'node> {
   pub node: &'node AuspiceTreeNode,
   pub distance: i64,
+  pub prior: f64, // prior in non-log scale
 }
 
 /// For a given query sample, finds nearest node on the reference tree (according to the distance metric)
@@ -16,26 +18,33 @@ pub fn tree_find_nearest_nodes<'node>(
   qry_nuc_subs: &[NucSub],
   qry_missing: &[NucRange],
   aln_range: &Range,
-) -> Vec<TreeFindNearestNodeOutput<'node>> {
+) -> Vec<TreePlacementInfo<'node>> {
   // Iterate over tree nodes and calculate distance metric between the sample and each node
   let nodes_by_placement_score = tree
     .iter_depth_first_preorder()
     .map(|(_, node)| {
       let distance = tree_calculate_node_distance(node, qry_nuc_subs, qry_missing, aln_range);
-      TreeFindNearestNodeOutput { node, distance }
+      let prior = get_prior(node);
+      TreePlacementInfo { node, distance, prior }
     })
-    .sorted_by(|a, b| a.distance.cmp(&b.distance))
+    .sorted_by(|a, b| a.distance.cmp(&b.distance).then(b.prior.total_cmp(&a.prior)))
     .collect_vec();
 
   if nodes_by_placement_score.is_empty() {
     // Unlikely case: if there's no nodes, return parent
-    vec![TreeFindNearestNodeOutput {
+    vec![TreePlacementInfo {
       node: &tree.tree,
       distance: 0,
+      prior: 1.0,
     }]
   } else {
     nodes_by_placement_score
   }
+}
+
+/// Gets non-log scale prior from node attributes
+fn get_prior(node: &AuspiceTreeNode) -> f64 {
+  10.0_f64.powf(node.node_attrs.placement_prior.clone().map_or(-10.0, |attr| attr.value))
 }
 
 /// Calculates distance metric between a given query sample and a tree node


### PR DESCRIPTION
This feature improves the placement of sequences that
could be added to multiple nodes on the tree
with the same distance

As tie-braker we use "priors", a number that is present on every tree node

That number represent an a priori likelihood
that sequences attach to that node

The calculation details of this prior could change. All that matters for now
is the ordering of priors

The numerical value has no purpose (yet)
In the future, we intend to use the priors
to display placement confidence information.

This feature should be backwards compatible. Trees without priors should work just as before.

This commit is a placement-only subset of PR #1114

Priors need to be a float with path `node_attrs.placement_prior.value` - they should be on log10 scale (so -2 to mean 0.01).

For SARS-CoV-2, the priors are added in https://github.com/neherlab/nextclade_data_workflows/pull/38
