### PR TITLE
feat: only emit nearest node info if a CLI flag is set

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -364,6 +364,7 @@ pub struct NextcladeRunInputArgs {
   pub server: Url,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Parser, Debug, Clone)]
 pub struct NextcladeRunOutputArgs {
   /// REMOVED. Use `--output-all` instead
@@ -555,6 +556,10 @@ pub struct NextcladeRunOutputArgs {
   /// Whether to include aligned reference nucleotide sequence into output nucleotide sequence FASTA file and reference peptides into output peptide FASTA files.
   #[clap(long)]
   pub include_reference: bool,
+
+  /// Whether to include the list of nearest nodes to the outputs
+  #[clap(long)]
+  pub include_nearest_node_info: bool,
 
   /// Emit output sequences in-order.
   ///

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -95,6 +95,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
         output_insertions,
         output_errors,
         include_reference,
+        include_nearest_node_info,
         in_order,
         replace_unknown,
         ..
@@ -230,6 +231,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
               gap_open_close_nuc,
               gap_open_close_aa,
               alignment_params,
+              include_nearest_node_info,
             )
           });
 

--- a/packages_rs/nextclade-web/src/wasm/analyze.rs
+++ b/packages_rs/nextclade-web/src/wasm/analyze.rs
@@ -166,6 +166,7 @@ pub struct Nextclade {
   phenotype_attr_descs: Vec<PhenotypeAttrDesc>,
   aa_motifs_descs: Vec<AaMotifsDesc>,
   aln_params: AlignPairwiseParams,
+  include_nearest_node_info: bool,
 }
 
 impl Nextclade {
@@ -248,6 +249,7 @@ impl Nextclade {
       phenotype_attr_descs,
       aa_motifs_descs,
       aln_params: alignment_params,
+      include_nearest_node_info: false, // Never emit nearest node info in web, to reduce output size
     })
   }
 
@@ -287,6 +289,7 @@ impl Nextclade {
       &self.gap_open_close_nuc,
       &self.gap_open_close_aa,
       &self.aln_params,
+      self.include_nearest_node_info,
     ) {
       Ok((qry_seq_aligned_stripped, translations, nextclade_outputs)) => {
         let nextclade_outputs_str =

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -48,6 +48,7 @@ pub fn nextclade_run_one(
   gap_open_close_nuc: &[i32],
   gap_open_close_aa: &[i32],
   params: &AlignPairwiseParams,
+  include_nearest_node_info: bool,
 ) -> Result<(Vec<Nuc>, Vec<Translation>, NextcladeOutputs), Report> {
   let NextalignOutputs {
     stripped,
@@ -126,12 +127,14 @@ pub fn nextclade_run_one(
   let node = nearest_node_candidates[0].node;
   let nearest_node_id = node.tmp.id;
 
-  let nearest_nodes = nearest_node_candidates
+  let nearest_nodes = include_nearest_node_info.then_some(
+    nearest_node_candidates
     .iter()
     // Choose all nodes with distance equal to the distance of the nearest node
     .filter(|n| n.distance == nearest_node_candidates[0].distance)
     .map(|n| n.node.name.clone())
-    .collect_vec();
+    .collect_vec(),
+  );
 
   let clade = node.clade();
 

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -91,7 +91,8 @@ pub struct NextcladeOutputs {
   pub qc: QcResult,
   pub custom_node_attributes: BTreeMap<String, String>,
   pub nearest_node_id: usize,
-  pub nearest_nodes: Vec<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub nearest_nodes: Option<Vec<String>>,
   pub is_reverse_complement: bool,
   pub phenotype_values: Option<Vec<PhenotypeValue>>,
   pub aa_motifs: AaMotifsMap,


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/1122

Introduces a CLI flag `--include-nearest-node-info` and the correponding internal parameter for Nextclade runs. Skips the `.nearestNodes` field in JSON/NDJSON unless this flag is present.

This parameter is always `false` in web, so this data is never included into the outputs of the web app. This also helps to slightly reduce the amount of data passed between webworkers