### PR TITLE
fix: ensure phenotype values are attached to new tree nodes

### DIFF
--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -12,7 +12,7 @@ use crate::tree::tree::{
 };
 use crate::types::outputs::NextcladeOutputs;
 use crate::utils::collections::concat_to_vec;
-use itertools::Itertools;
+use itertools::{chain, Itertools};
 use serde_json::json;
 use std::collections::BTreeMap;
 
@@ -83,14 +83,21 @@ fn add_child(node: &mut AuspiceTreeNode, result: &NextcladeOutputs) {
     )
   };
 
-  #[allow(clippy::from_iter_instead_of_collect)]
-  let other = serde_json::Value::from_iter(
-    result
-      .custom_node_attributes
-      .clone()
-      .into_iter()
-      .map(|(key, val)| (key, json!({ "value": val }))),
-  );
+  let custom_node_attributes_json = result
+    .custom_node_attributes
+    .clone()
+    .into_iter()
+    .map(|(key, val)| (key, json!({ "value": val })))
+    .collect_vec();
+
+  let phenotype_values_json = result.phenotype_values.as_ref().map_or(vec![], |phenotype_values| {
+    phenotype_values
+      .iter()
+      .map(|val| (val.name.clone(), json!({ "value": val.value.to_string() })))
+      .collect_vec()
+  });
+
+  let other: serde_json::Value = chain!(phenotype_values_json, custom_node_attributes_json).collect();
 
   node.children.insert(
     0,


### PR DESCRIPTION
This adds custom phenotype values (such as `ace2_binding` and `"immune_escape"`) to the newly placed tree nodes.

They were previously missing, even though the technically similar clade-like node attributes were set. Which makes it somewhat asymmetric. 

I think it was simply an omission when the phenotype values were added.

Here I add the `phenotype_values` to the node similarly to how the `custom_node_attributes` are added.

This allows to see the values and colorings for phenotype values (if they are present in the dataset) on the tree page:

![01](https://user-images.githubusercontent.com/9403403/225179019-3d0fffaa-a612-454f-871d-b0cf3e4be4ef.png)
![02](https://user-images.githubusercontent.com/9403403/225180420-beb78320-a41d-4f54-82c3-7e7b7abcbdd9.png)
