### PR TITLE
fix: incorrect 0 coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ To given an example: a partial sequence may have as many mismatches when compare
 
 The impact of the feature is biggest for partial and incomplete sequences.
 
+### Fix incorrect indices in mutation badges 
+
+The mutation badges in various places in Nextclade Web could show position "0", even though they are supposed to be 1-based. This was due to a programming mistake, which is now corrected.
+
 ### Fix Google Search Console warnings
 
 We resolved warnings in Google Search Console: added canonical URL meta tag, and added `noindex` tag for non-release deployments. This should improve Nextclade appearance in Google Search.

--- a/packages_rs/nextclade-web/src/components/Common/MutationBadge.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/MutationBadge.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useRecoilValue } from 'recoil'
-import { get } from 'lodash'
+import { get, isNil } from 'lodash'
 import styled, { useTheme } from 'styled-components'
 import { shade } from 'polished'
 
@@ -77,13 +77,13 @@ export function NucleotideMutationBadge({ mutation }: NucleotideMutationBadgePro
   return (
     <MutationBadgeBox>
       <MutationWrapper>
-        {refNuc && (
+        {!isNil(refNuc) && (
           <ColoredText $background={refBg} $color={refFg}>
             {refNuc}
           </ColoredText>
         )}
-        {pos && <PositionText>{posOneBased}</PositionText>}
-        {queryNuc && (
+        {!isNil(pos) && <PositionText>{posOneBased}</PositionText>}
+        {!isNil(queryNuc) && (
           <ColoredText $background={queryBg} $color={queryFg}>
             {queryNuc}
           </ColoredText>


### PR DESCRIPTION
The `pos` of  `0` caused to show mutation badges with position 0, while they are supposed to be 1-indexed. This was due to incorrect conversion of `0` to `false`.

Here I fix the problem by using the explicit comparison to `undefined` and `null` (using the helper function `isNil()` from `lodash`), which avoids implicit conversions.

