### PR TITLE
fix(web): swap `input-pcr-primers` and `input-virus-properties` params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The impact of the feature is biggest for partial and incomplete sequences.
 
 The mutation badges in various places in Nextclade Web could show position "0", even though they are supposed to be 1-based. This was due to a programming mistake, which is now corrected.
 
+### Fix `input-pcr-primers` and `input-virus-properties` URL params in Nextclade Web
+
+The `input-pcr-primers` and `input-virus-properties` URL params were swapped in the code accidentally, so one was incorrectly setting the other. This is now fixed.
+
 ### Fix Google Search Console warnings
 
 We resolved warnings in Google Search Console: added canonical URL meta tag, and added `noindex` tag for non-release deployments. This should improve Nextclade appearance in Google Search.

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -132,8 +132,8 @@ export function RecoilStateInitializer() {
         set(geneMapInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-gene-map'))
         set(refTreeInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-tree'))
         set(qcConfigInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-qc-config'))
-        set(virusPropertiesInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-pcr-primers'))
-        set(primersCsvInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-virus-properties'))
+        set(primersCsvInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-pcr-primers'))
+        set(virusPropertiesInputAtom, createInputFromUrlParamMaybe(urlQuery, 'input-virus-properties'))
 
         if (!isEmpty(inputFastas)) {
           run()


### PR DESCRIPTION
The `input-pcr-primers` and `input-virus-properties` URL params were swapped in the code accidentally, so one was incorrectly setting the other. 

Here I swap the variables back to their proper places.

