### PR TITLE
chore(ci): fix wasm CI build

### DIFF
--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -238,7 +238,7 @@ RUN set -euxo pipefail >/dev/null \
 && cargo quickinstall cargo-deny \
 && cargo quickinstall cargo-edit \
 && cargo quickinstall cargo-watch \
-&& cargo quickinstall wasm-pack \
+&& cargo quickinstall wasm-pack --version 0.10.3 \
 && cargo quickinstall xargo
 
 # Setup bash


### PR DESCRIPTION
There seems to be an issue (or an expected change) in wasm-pack 0.11.0: https://github.com/rustwasm/wasm-pack/issues/1062, where a path to`wasm-opt` is not detected correctly. This [breaks our build](https://github.com/nextstrain/nextclade/actions/runs/4474405842/jobs/7862840403). Everything seems to be working well on wasm-pack 0.10.3, so let's freeze the version for the time being.

