### PR TITLE
feat(cli): change gene warnings severity to info

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextalign_ordered_writer.rs
@@ -1,6 +1,6 @@
 use crate::cli::nextalign_loop::NextalignRecord;
 use eyre::{Report, WrapErr};
-use log::warn;
+use log::{info, warn};
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
 use nextclade::io::gene_map::GeneMap;
@@ -106,7 +106,7 @@ impl<'a> NextalignOrderedWriter<'a> {
         }
 
         for warning in warnings {
-          warn!("In sequence #{index} '{seq_name}': {}", warning.warning);
+          info!("In sequence #{index} '{seq_name}': {}", warning.warning);
         }
 
         if let Some(errors_csv_writer) = &mut self.errors_csv_writer {

--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -1,7 +1,7 @@
 use crate::cli::nextclade_loop::NextcladeRecord;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
-use log::warn;
+use log::{info, warn};
 use nextclade::analyze::virus_properties::PhenotypeAttrDesc;
 use nextclade::io::errors_csv::ErrorsCsvWriter;
 use nextclade::io::fasta::{FastaPeptideWriter, FastaRecord, FastaWriter};
@@ -165,7 +165,7 @@ impl<'a> NextcladeOrderedWriter<'a> {
         }
 
         for warning in warnings {
-          warn!("In sequence #{index} '{seq_name}': {}", warning.warning);
+          info!("In sequence #{index} '{seq_name}': {}", warning.warning);
         }
 
         if let Some(errors_csv_writer) = &mut self.errors_csv_writer {


### PR DESCRIPTION
This changes gene warnings severity to info. As discussed on Slack, there are many cases where missing genes is not a problem, notably in case of partial sequences. This is to declutter the logs - warning is the default severity. Info is opt-in.
