### PR TITLE
test: add smoke tests for datasets with default refs

### DIFF
--- a/tests/run-smoke-tests
+++ b/tests/run-smoke-tests
@@ -24,7 +24,9 @@ export DATASET_DIR="$THIS_DIR/../tmp/smoke-tests/dataset"
 export OUT_DIR="$THIS_DIR/../tmp/smoke-tests/result"
 
 dataset_names_and_refs=$(${NEXTCLADE_BIN} dataset list --json | jq -r '.[] | select(.attributes.tag.isDefault==true) |  .attributes.name.value + ";" + .attributes.reference.value')
-num_dataset_names_and_refs=$(echo "${dataset_names_and_refs}" | wc -l)
+dataset_names_without_refs=$(${NEXTCLADE_BIN} dataset list --json | jq -r '.[] | select(.attributes.tag.isDefault==true) |  .attributes.name.value + ";"')
+all_datasets="${dataset_names_and_refs} ${dataset_names_without_refs}"
+num_datasets=$(echo "${all_datasets}" | wc -l)
 
 function run_one_test() {
   name_and_ref=$1
@@ -34,15 +36,15 @@ function run_one_test() {
   name="${arr[0]}"
   reference="${arr[1]}"
 
-  echo "Running '${NEXTCLADE_BIN}' for '${name}' with reference '${reference}'"
+  echo "Running '${NEXTCLADE_BIN}' for '${name}' with reference '${reference:-default}'"
 
-  ${NEXTCLADE_BIN} dataset get --name="${name}" --reference="${reference}" --output-dir="$DATASET_DIR/${name}-${reference}"
+  ${NEXTCLADE_BIN} dataset get --name="${name}" ${reference:+--reference "${reference}"} --output-dir="$DATASET_DIR/${name}/${reference:-default}"
 
   ${NEXTCLADE_BIN} run --quiet --in-order \
-    --output-all="$OUT_DIR/${name}-${reference}" \
-    --input-dataset="$DATASET_DIR/${name}-${reference}" \
-    "$DATASET_DIR/${name}-${reference}/sequences.fasta"
+    --output-all="$OUT_DIR/${name}/${reference:-default}" \
+    --input-dataset="$DATASET_DIR/${name}/${reference:-default}" \
+    "$DATASET_DIR/${name}/${reference:-default}/sequences.fasta"
 }
 export -f run_one_test
 
-parallel --jobs="${num_dataset_names_and_refs}" run_one_test ::: "${dataset_names_and_refs}"
+parallel --jobs="${num_datasets}" run_one_test ::: "${all_datasets}"


### PR DESCRIPTION
Related to: https://github.com/nextstrain/nextclade_data/issues/69, https://github.com/nextstrain/nextclade_data/pull/70

We missed a dataset bug where the dataset could not be fetched if the default ref is requested (by not providing `--reference` arg to `dataset get` command).

In order to catch this kind of issues on Nextclade level, here I added smoke tests which run `dataset get` without `--reference` arg for each of the available datasets.

The test currently fails, until the fix in https://github.com/nextstrain/nextclade_data/pull/70 is merged and deployed.
