### PR TITLE
chore: fix CI failure when publishing to bioconda

### DIFF
--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -76,7 +76,7 @@ git branch --delete --force "bump/nextclade-${version}" || true
 git push nextstrain --delete "bump/nextclade-${version}" || true
 
 # Create a new branch
-git switch --quiet --create "bump/nextclade-${version}"
+git switch --quiet "upstream/master" --create "bump/nextclade-${version}"
 
 ## Bump the version
 "${THIS_DIR}/update-bioconda.py" "nextclade" "${version}" "${artifacts_dir}" "recipes/nextclade/meta.yaml"


### PR DESCRIPTION
Resolves CI failure: https://github.com/nextstrain/nextclade/actions/runs/4540204046/jobs/8000992798

Bioconda publish action is throwing the following error on `git push`:

```
+ git add recipes/nextalign/meta.yaml
+ git commit --quiet -m 'Update nextclade and nextalign to 2.13.1'
+ git push --quiet --set-upstream nextstrain bump/nextclade-2.13.1
To https://github.com/nextstrain/bioconda-recipes
 ! [remote rejected]       bump/nextclade-2.13.1 -> bump/nextclade-2.13.1 (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/CommentResponder.yml` without `workflow` scope)
```

When a PR is crated it's created from the `master` branch of a fork to the `upstream/master`. The fork's `master` branch is likely out of date and even though we only modify 1 file, the diff of the PR to the upstream contains all changes from fork's `master` to `upstream/master`.

In this particular CI workflow run it so happened, that the diff contained changes to the upstreams' workflow file  `.github/workflows/CommentResponder.yml`. Which we have no permission, nor need to change, obviously.

In this fix, I change how the PR branch is crated. Instead of spawning it from local `master`, I spawn it from `upstream/master`. This ensures that our PR branch is up to date with the `upstream/master`, which is the target branch pf the PR. This way we don't have unrelated changes in the diff, and error should now be resolved.

Let's make a CI run and see how it goes.

