### PR TITLE
chore: update master branch of the fork before making bioconda PR branch

### DIFF
--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -69,6 +69,9 @@ version_old=$(sed -n 's|.*version = "\(.*\)".*|\1|p' "recipes/nextclade/meta.yam
 ## Add Nextstrain fork (https://github.com/nextstrain/bioconda-recipes) as a remote
 git remote add nextstrain "https://github.com/nextstrain/bioconda-recipes" >/dev/null
 
+# Update master branch of the fork
+git push nextstrain upstream/master:master
+
 # Delete branch if already exists locally
 git branch --delete --force "bump/nextclade-${version}" || true
 

--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -76,7 +76,7 @@ git branch --delete --force "bump/nextclade-${version}" || true
 git push nextstrain --delete "bump/nextclade-${version}" || true
 
 # Create a new branch
-git switch --quiet "upstream/master" --create "bump/nextclade-${version}"
+git switch --quiet --create "bump/nextclade-${version}"
 
 ## Bump the version
 "${THIS_DIR}/update-bioconda.py" "nextclade" "${version}" "${artifacts_dir}" "recipes/nextclade/meta.yaml"

--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -69,10 +69,6 @@ version_old=$(sed -n 's|.*version = "\(.*\)".*|\1|p' "recipes/nextclade/meta.yam
 ## Add Nextstrain fork (https://github.com/nextstrain/bioconda-recipes) as a remote
 git remote add nextstrain "https://github.com/nextstrain/bioconda-recipes" >/dev/null
 
-git switch master
-git pull --ff-only
-git push nextstrain master
-
 # Delete branch if already exists locally
 git branch --delete --force "bump/nextclade-${version}" || true
 

--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -69,6 +69,10 @@ version_old=$(sed -n 's|.*version = "\(.*\)".*|\1|p' "recipes/nextclade/meta.yam
 ## Add Nextstrain fork (https://github.com/nextstrain/bioconda-recipes) as a remote
 git remote add nextstrain "https://github.com/nextstrain/bioconda-recipes" >/dev/null
 
+git switch master
+git pull --ff-only
+git push nextstrain master
+
 # Delete branch if already exists locally
 git branch --delete --force "bump/nextclade-${version}" || true
 


### PR DESCRIPTION
Reverts and replaces #1135

Resolves CI failure: https://github.com/nextstrain/nextclade/actions/runs/4540204046/jobs/8000992798

Bioconda publish action is throwing the following error on `git push`:

```
+ git add recipes/nextalign/meta.yaml
+ git commit --quiet -m 'Update nextclade and nextalign to 2.13.1'
+ git push --quiet --set-upstream nextstrain bump/nextclade-2.13.1
To https://github.com/nextstrain/bioconda-recipes
 ! [remote rejected]       bump/nextclade-2.13.1 -> bump/nextclade-2.13.1 (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/CommentResponder.yml` without `workflow` scope)
```

When a PR is crated it's branch created from the `master` branch of a fork (remote `nextstrain`) to the `master` branch of the upstream (remote `upstream`). The `nextstrain/master` branch is likely out of date and it might contain old versions of bioconda workflow files. Which we think gave the error we observed.

In this PR I added a command to update `nextstrain/master` from `upstream/master`, such that the fork contains fresh workflow files. This should resolve the problem.
