### PR TITLE
docs(dev): Add steps for macOS (llvm and env vars)

### DIFF
--- a/docs/dev/developer-guide.md
+++ b/docs/dev/developer-guide.md
@@ -73,6 +73,23 @@ Install Node.js version 14+ (latest LTS release is recommended), by either downl
 
 Let's build the WebAssembly module:
 
+<details>
+<summary>Show extra requirements for macOS</summary>
+
+For macOS, you will also have to install llvm: 
+
+```bash
+brew install llvm
+```
+
+Furthermore, you will need to set the following environment variables before invoking `yarn wasm-prod`:
+
+```bash
+export CC=/opt/homebrew/opt/llvm/bin/clang
+export AR=/opt/homebrew/opt/llvm/bin/llvm-ar 
+```
+</details>
+
 ```bash
 # Clone Nextclade git repository
 git clone https://github.com/nextstrain/nextclade


### PR DESCRIPTION
Had issues during the `wasm-pack` step on my M1 mac, it failed with `error: failed to build archive: section too large`

Solution found here: https://github.com/rust-bitcoin/rust-secp256k1/issues/283#issuecomment-1200858455

Adding it to docs, mostly for my future self as I think I'm the only one on mac right now (hiding behind `<details>`)