### PR TITLE
Avoid stale datasets in Nextclade Web

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
@@ -9,6 +9,7 @@ import type { Dataset } from 'src/types'
 import { datasetCurrentAtom, datasetsAtom } from 'src/state/dataset.state'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
+import { useUpdatedDatasetIndex } from 'src/io/fetchDatasets'
 import { DatasetSelectorList } from './DatasetSelectorList'
 
 const DatasetSelectorContainer = styled(Container)`
@@ -58,6 +59,9 @@ export function DatasetSelector({ searchTerm, setSearchTerm }: DatasetSelectorPr
   const { datasets } = useRecoilValue(datasetsAtom)
   const [datasetCurrent, setDatasetCurrent] = useRecoilState(datasetCurrentAtom)
   const [datasetHighlighted, setDatasetHighlighted] = useState<Dataset | undefined>(datasetCurrent)
+
+  // This periodically fetches dataset index and updates the list of datasets.
+  useUpdatedDatasetIndex()
 
   const onSearchTermChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetSelector.tsx
@@ -4,12 +4,10 @@ import { ThreeDots } from 'react-loader-spinner'
 import { Button, Col, Container, Input, Row } from 'reactstrap'
 import { useRecoilState, useRecoilValue } from 'recoil'
 import styled from 'styled-components'
-
 import type { Dataset } from 'src/types'
 import { datasetCurrentAtom, datasetsAtom } from 'src/state/dataset.state'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
-import { useUpdatedDatasetIndex } from 'src/io/fetchDatasets'
 import { DatasetSelectorList } from './DatasetSelectorList'
 
 const DatasetSelectorContainer = styled(Container)`
@@ -59,9 +57,6 @@ export function DatasetSelector({ searchTerm, setSearchTerm }: DatasetSelectorPr
   const { datasets } = useRecoilValue(datasetsAtom)
   const [datasetCurrent, setDatasetCurrent] = useRecoilState(datasetCurrentAtom)
   const [datasetHighlighted, setDatasetHighlighted] = useState<Dataset | undefined>(datasetCurrent)
-
-  // This periodically fetches dataset index and updates the list of datasets.
-  useUpdatedDatasetIndex()
 
   const onSearchTermChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages_rs/nextclade-web/src/components/Main/MainInputForm.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/MainInputForm.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import { DatasetSelector } from 'src/components/Main/DatasetSelector'
 import { MainInputFormRunStep } from 'src/components/Main/MainInputFormRunStep'
 import { datasetCurrentAtom } from 'src/state/dataset.state'
+import { useUpdatedDatasetIndex } from 'src/io/fetchDatasets'
 
 export const Container = styled(ContainerBase)`
   display: flex;
@@ -32,6 +33,9 @@ export const Centered = styled.section`
 export function MainInputForm() {
   const [searchTerm, setSearchTerm] = useState('')
   const currentDataset = useRecoilValue(datasetCurrentAtom)
+
+  // This periodically fetches dataset index and updates the list of datasets.
+  useUpdatedDatasetIndex()
 
   const FormBody = useMemo(
     () =>

--- a/packages_rs/nextclade-web/src/i18n/resources/ar/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ar/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "حاولنا تنزيل الملف من",
   "What's new": "ما الجديد",
   "you are connected to the internet": "أنت متصل بالإنترنت",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "يمكنك الإبلاغ عن ذلك للمطورين عن طريق إنشاء طلب (يسمى {{issue}}) على: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "يمكنك الإبلاغ عن ذلك للمطورين عن طريق إنشاء طلب (يسمى {{issue}}) على: ",
+  "A new version of this dataset is available.": "يتوفر إصدار جديد من مجموعة البيانات هذه.",
+  "Accept the updated dataset": "اقبل مجموعة البيانات المحدثة",
+  "Update": "تحديث",
+  "What's new?": "ما الجديد؟"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/de/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/de/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Wir haben versucht, die Datei herunterzuladen von",
   "What's new": "Was ist neu",
   "you are connected to the internet": "Sie sind mit dem Internet verbunden",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Sie können es Entwicklern melden, indem Sie eine Anfrage (sogenannte {{issue}}) erstellen unter: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Sie können es Entwicklern melden, indem Sie eine Anfrage (sogenannte {{issue}}) erstellen unter: ",
+  "A new version of this dataset is available.": "Eine neue Version dieses Datensatzes ist verfügbar.",
+  "Accept the updated dataset": "Akzeptiere den aktualisierten Datensatz",
+  "Update": "Aktualisieren",
+  "What's new?": "Was ist neu?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/el/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/el/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Προσπαθήσαμε να κατεβάσουμε το αρχείο από",
   "What's new": "Τι νέο υπάρχει",
   "you are connected to the internet": "είστε συνδεδεμένοι στο διαδίκτυο",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Μπορείτε να το αναφέρετε στους προγραμματιστές δημιουργώντας ένα αίτημα (το λεγόμενο {{issue}}) στη διεύθυνση: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Μπορείτε να το αναφέρετε στους προγραμματιστές δημιουργώντας ένα αίτημα (το λεγόμενο {{issue}}) στη διεύθυνση: ",
+  "A new version of this dataset is available.": "Μια νέα έκδοση αυτού του συνόλου δεδομένων είναι διαθέσιμη.",
+  "Accept the updated dataset": "Αποδοχή του ενημερωμένου συνόλου δεδομένων",
+  "Update": "Ενημέρωση",
+  "What's new?": "Τι νέα;"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/en/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/en/common.json
@@ -17,7 +17,9 @@
   "** {{appName}} requires at least {{memoryRequired}} of memory per thread": "** {{appName}} requires at least {{memoryRequired}} of memory per thread",
   "*Make sure this file is publicly accessible and CORS is enabled on your server": "*Make sure this file is publicly accessible and CORS is enabled on your server",
   "1st nuc.": "1st nuc.",
+  "A new version of this dataset is available.": "A new version of this dataset is available.",
   "Accept the data": "Accept the data",
+  "Accept the updated dataset": "Accept the updated dataset",
   "Add more sequence data": "Add more sequence data",
   "Affected codons:": "Affected codons:",
   "After ref pos.": "After ref pos.",
@@ -319,11 +321,13 @@
   "Unsequenced": "Unsequenced",
   "unsupported": "unsupported",
   "Unsupported browser": "Unsupported browser",
+  "Update": "Update",
   "Updated: {{updated}}": "Updated: {{updated}}",
   "Virus properties": "Virus properties",
   "Warning": "Warning",
   "We tried to download the file from": "We tried to download the file from",
   "What's new": "What's new",
+  "What's new?": "What's new?",
   "you are connected to the internet": "you are connected to the internet",
   "You can report it to developers by creating a request (so called {{issue}}) at: ": "You can report it to developers by creating a request (so called {{issue}}) at: "
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/es/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/es/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Intentamos descargar el archivo desde",
   "What's new": "Qué hay de nuevo",
   "you are connected to the internet": "estás conectado a internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Puede informarlo a los desarrolladores creando una solicitud (llamada así {{issue}}) en: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Puede informarlo a los desarrolladores creando una solicitud (llamada así {{issue}}) en: ",
+  "A new version of this dataset is available.": "Hay disponible una nueva versión de este conjunto de datos.",
+  "Accept the updated dataset": "Aceptar el conjunto de datos actualizado",
+  "Update": "Actualizar",
+  "What's new?": "¿Qué hay de nuevo?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/fa/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/fa/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "ما سعی کردیم فایل را از",
   "What's new": "تازه چه خبر",
   "you are connected to the internet": "شما به اینترنت متصل",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "شما می توانید آن را به توسعه دهندگان با ایجاد یک درخواست (به اصطلاح {{issue}}) در: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "شما می توانید آن را به توسعه دهندگان با ایجاد یک درخواست (به اصطلاح {{issue}}) در: ",
+  "A new version of this dataset is available.": "نسخه جدیدی از این مجموعه داده در دسترس است.",
+  "Accept the updated dataset": "مجموعه داده به روز شده را بپذیرید",
+  "Update": "به روز رسانی",
+  "What's new?": "تازه چه خبر؟"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/fr/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/fr/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Nous avons essayé de télécharger le fichier depuis",
   "What's new": "Nouveautés",
   "you are connected to the internet": "vous êtes connecté à Internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Vous pouvez le signaler aux développeurs en créant une demande (appelée « requête » {{issue}}) à l'adresse suivante : "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Vous pouvez le signaler aux développeurs en créant une demande (appelée « requête » {{issue}}) à l'adresse suivante : ",
+  "A new version of this dataset is available.": "Une nouvelle version de ce jeu de données est disponible.",
+  "Accept the updated dataset": "Accepter le jeu de données mis à jour",
+  "Update": "Mettre à jour",
+  "What's new?": "Qu'y a-t-il de nouveau ?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/he/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/he/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "ניסינו להוריד את הקובץ",
   "What's new": "מה חדש",
   "you are connected to the internet": "אתה מחובר לאינטרנט",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "אתה יכול לדווח על כך למפתחים על ידי יצירת בקשה (שנקראה {{issue}}) בכתובת: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "אתה יכול לדווח על כך למפתחים על ידי יצירת בקשה (שנקראה {{issue}}) בכתובת: ",
+  "A new version of this dataset is available.": "גרסה חדשה של מערך נתונים זה זמינה.",
+  "Accept the updated dataset": "קבל את מערך הנתונים המעודכן",
+  "Update": "עדכון",
+  "What's new?": "מה חדש?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/hi/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/hi/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "हमने फ़ाइल को यहां से डाउनलोड करने की कोशिश की",
   "What's new": "नया क्या है",
   "you are connected to the internet": "आप इंटरनेट से जुड़े हैं",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "आप यहां अनुरोध (तथाकथित {{issue}}) बनाकर डेवलपर्स को इसकी रिपोर्ट कर सकते हैं: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "आप यहां अनुरोध (तथाकथित {{issue}}) बनाकर डेवलपर्स को इसकी रिपोर्ट कर सकते हैं: ",
+  "A new version of this dataset is available.": "इस डेटासेट का नया संस्करण उपलब्ध है।",
+  "Accept the updated dataset": "अपडेट किए गए डेटासेट को स्वीकार करें",
+  "Update": "अपडेट",
+  "What's new?": "नया क्या है?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/id/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/id/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Kami mencoba mengunduh file dari",
   "What's new": "Apa yang baru",
   "you are connected to the internet": "Anda terhubung ke internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Anda dapat melaporkannya ke pengembang dengan membuat permintaan (disebut {{issue}}) di: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Anda dapat melaporkannya ke pengembang dengan membuat permintaan (disebut {{issue}}) di: ",
+  "A new version of this dataset is available.": "Versi baru dari kumpulan data ini tersedia.",
+  "Accept the updated dataset": "Terima kumpulan data yang diperbarui",
+  "Update": "Perbarui",
+  "What's new?": "Apa yang baru?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/it/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/it/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Abbiamo provato a scaricare il file da",
   "What's new": "Cosa c'è di nuovo",
   "you are connected to the internet": "sei connesso a internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Puoi segnalarlo agli sviluppatori creando una richiesta (la cosiddetta {{issue}}) all'indirizzo: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Puoi segnalarlo agli sviluppatori creando una richiesta (la cosiddetta {{issue}}) all'indirizzo: ",
+  "A new version of this dataset is available.": "È disponibile una nuova versione di questo set di dati.",
+  "Accept the updated dataset": "Accetta il set di dati aggiornato",
+  "Update": "Aggiornamento",
+  "What's new?": "Cosa c'è di nuovo?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ja/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ja/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "からファイルをダウンロードしようとしました",
   "What's new": "新着情報",
   "you are connected to the internet": "インターネットに接続している",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "開発者に報告するには、以下の場所でリクエスト (いわゆる {{issue}}) を作成します。 "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "開発者に報告するには、以下の場所でリクエスト (いわゆる {{issue}}) を作成します。 ",
+  "A new version of this dataset is available.": "このデータセットの新しいバージョンが公開されました。",
+  "Accept the updated dataset": "更新されたデータセットを承認",
+  "Update": "[更新]",
+  "What's new?": "何が新しいの？"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ko/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ko/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "에서 파일을 다운로드하려고 했습니다.",
   "What's new": "새 소식",
   "you are connected to the internet": "인터넷에 연결되어 있습니다.",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "다음 주소에서 요청 (소위 {{issue}}) 을 생성하여 개발자에게 신고할 수 있습니다. "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "다음 주소에서 요청 (소위 {{issue}}) 을 생성하여 개발자에게 신고할 수 있습니다. ",
+  "A new version of this dataset is available.": "이 데이터세트의 새 버전을 사용할 수 있습니다.",
+  "Accept the updated dataset": "업데이트된 데이터세트 수락",
+  "Update": "업데이트",
+  "What's new?": "무엇이 새로워졌나요?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/nl/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/nl/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "We hebben geprobeerd het bestand te downloaden van",
   "What's new": "Wat is er nieuw",
   "you are connected to the internet": "je bent verbonden met het internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Je kunt dit aan ontwikkelaars melden door een verzoek in te dienen (zogenaamd {{issue}}) op: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Je kunt dit aan ontwikkelaars melden door een verzoek in te dienen (zogenaamd {{issue}}) op: ",
+  "A new version of this dataset is available.": "Er is een nieuwe versie van deze dataset beschikbaar.",
+  "Accept the updated dataset": "Accepteer de bijgewerkte dataset",
+  "Update": "Bijwerken",
+  "What's new?": "Wat is er nieuw?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/pt/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/pt/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Tentamos baixar o arquivo de",
   "What's new": "O que há de novo",
   "you are connected to the internet": "você está conectado à internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Você pode denunciá-lo aos desenvolvedores criando uma solicitação (assim chamada {{issue}}) em: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Você pode denunciá-lo aos desenvolvedores criando uma solicitação (assim chamada {{issue}}) em: ",
+  "A new version of this dataset is available.": "Uma nova versão desse conjunto de dados está disponível.",
+  "Accept the updated dataset": "Aceite o conjunto de dados atualizado",
+  "Update": "Atualizar",
+  "What's new?": "O que há de novo?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ru/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ru/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Мы попытались загрузить файл с",
   "What's new": "Что нового",
   "you are connected to the internet": "вы подключены к Интернету",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Вы можете сообщить об этом разработчикам, создав запрос (так называемый {{issue}}) по адресу: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Вы можете сообщить об этом разработчикам, создав запрос (так называемый {{issue}}) по адресу: ",
+  "A new version of this dataset is available.": "Доступна новая версия этого набора данных.",
+  "Accept the updated dataset": "Примите обновленный набор данных",
+  "Update": "Обновить",
+  "What's new?": "Что нового?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ta/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ta/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "நாங்கள் கோப்பை பதிவிறக்க முயற்சித்தோம்",
   "What's new": "புதியது என்ன",
   "you are connected to the internet": "நீங்கள் இணையத்துடன் இணைக்கப்பட்டுள்ளீர்கள்",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "ஒரு கோரிக்கையை உருவாக்குவதன் மூலம் டெவலப்பர்களிடம் அதை நீங்கள் {{issue}} தெரிவிக்கலாம்: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "ஒரு கோரிக்கையை உருவாக்குவதன் மூலம் டெவலப்பர்களிடம் அதை நீங்கள் {{issue}} தெரிவிக்கலாம்: ",
+  "A new version of this dataset is available.": "இந்த தரவுத்தொகுப்பின் ஒரு புதிய பதிப்பு கிடைக்கிறது.",
+  "Accept the updated dataset": "மேம்படுத்தப்பட்ட தரவுத்தொகுப்பை ஏற்கவும்",
+  "Update": "புதுப்பிக்கப்பட்டது",
+  "What's new?": "புதிதாக என்ன?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/th/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/th/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "เราพยายามดาวน์โหลดไฟล์จาก",
   "What's new": "มีอะไรใหม่",
   "you are connected to the internet": "คุณเชื่อมต่อกับอินเทอร์เน็ต",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "คุณสามารถรายงานไปยังนักพัฒนาโดยการสร้างคำขอ (เรียกว่า {{issue}}) ที่: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "คุณสามารถรายงานไปยังนักพัฒนาโดยการสร้างคำขอ (เรียกว่า {{issue}}) ที่: ",
+  "A new version of this dataset is available.": "รุ่นใหม่ของชุดข้อมูลนี้สามารถใช้ได้",
+  "Accept the updated dataset": "ยอมรับชุดข้อมูลที่ปรับปรุง",
+  "Update": "อัพเดท",
+  "What's new?": "มีอะไรใหม่"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/tr/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/tr/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Dosyayı indirmeye çalıştık",
   "What's new": "Yenilikler",
   "you are connected to the internet": "internete bağlıysanız",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Bunu geliştiricilere şu adresten bir istek oluşturarak (sözde {{issue}}) bildirebilirsiniz: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Bunu geliştiricilere şu adresten bir istek oluşturarak (sözde {{issue}}) bildirebilirsiniz: ",
+  "A new version of this dataset is available.": "Bu veri kümesinin yeni bir sürümü mevcuttur.",
+  "Accept the updated dataset": "Güncellenmiş veri kümesini kabul et",
+  "Update": "Güncelleme",
+  "What's new?": "Yenilikler ne?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/ur/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/ur/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "ہم نے فائل کو ڈاؤن لوڈ کرنے کی کوشش کی",
   "What's new": "نیا کیا ہے",
   "you are connected to the internet": "آپ انٹرنیٹ سے منسلک ہیں",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "آپ اس کی درخواست (نام نہاد {{issue}}) کی تخلیق کرکے ڈویلپرز کو رپورٹ کرسکتے ہیں: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "آپ اس کی درخواست (نام نہاد {{issue}}) کی تخلیق کرکے ڈویلپرز کو رپورٹ کرسکتے ہیں: ",
+  "A new version of this dataset is available.": "اس ڈیٹا سیٹ کا ایک نیا ورژن دستیاب ہے.",
+  "Accept the updated dataset": "اپ ڈیٹ ڈیٹا سیٹ قبول کریں",
+  "Update": "اپ ڈیٹ کریں",
+  "What's new?": "نیا کیا ہے؟"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/vi/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/vi/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "Chúng tôi đã cố gắng tải xuống tệp từ",
   "What's new": "Có gì mới",
   "you are connected to the internet": "bạn đang kết nối với internet",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Bạn có thể báo cáo nó cho nhà phát triển bằng cách tạo một yêu cầu (được gọi là {{issue}}) tại: "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "Bạn có thể báo cáo nó cho nhà phát triển bằng cách tạo một yêu cầu (được gọi là {{issue}}) tại: ",
+  "A new version of this dataset is available.": "Một phiên bản mới của tập dữ liệu này có sẵn.",
+  "Accept the updated dataset": "Chấp nhận tập dữ liệu được cập nhật",
+  "Update": "Cập nhật",
+  "What's new?": "Có gì mới?"
 }

--- a/packages_rs/nextclade-web/src/i18n/resources/zh/common.json
+++ b/packages_rs/nextclade-web/src/i18n/resources/zh/common.json
@@ -325,5 +325,9 @@
   "We tried to download the file from": "我们尝试从中下载文件",
   "What's new": "新增内容",
   "you are connected to the internet": "你已连接到互联网",
-  "You can report it to developers by creating a request (so called {{issue}}) at: ": "您可以通过在以下地址创建请求（所谓的 {{issue}} ）向开发人员报告： "
+  "You can report it to developers by creating a request (so called {{issue}}) at: ": "您可以通过在以下地址创建请求（所谓的 {{issue}} ）向开发人员报告： ",
+  "A new version of this dataset is available.": "该数据集的新版本可用。",
+  "Accept the updated dataset": "接受更新的数据集",
+  "Update": "更新",
+  "What's new?": "有什么新的？"
 }

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -61,6 +61,7 @@ export function useUpdatedDatasetIndex() {
       setDatasetsState(datasetsState)
     },
     {
+      staleTime: 0,
       refetchInterval: 12 * 60 * 60 * 1000, // 12 hours
       refetchIntervalInBackground: true,
       refetchOnMount: true,
@@ -96,6 +97,7 @@ export function useUpdatedDataset() {
       return undefined
     },
     {
+      staleTime: 0,
       refetchInterval: 60 * 60 * 1000, // 1 hour
       refetchIntervalInBackground: false,
       refetchOnMount: true,

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -3,6 +3,9 @@ import type { ParsedUrlQuery } from 'querystring'
 import { Dataset } from 'src/types'
 import { fetchDatasetsIndex, findDataset, getLatestCompatibleEnabledDatasets } from 'src/io/fetchDatasetsIndex'
 import { getQueryParamMaybe } from 'src/io/getQueryParamMaybe'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { datasetsAtom, datasetServerUrlAtom } from 'src/state/dataset.state'
+import { useQuery } from 'react-query'
 
 export async function getDatasetFromUrlParams(urlQuery: ParsedUrlQuery, datasets: Dataset[]) {
   // Retrieve dataset-related URL params and try to find a dataset based on these params
@@ -39,4 +42,24 @@ export async function initializeDatasets(urlQuery: ParsedUrlQuery, datasetServer
   const currentDataset = await getDatasetFromUrlParams(urlQuery, datasets)
 
   return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
+}
+
+/** Refetch dataset index periodically and update the local copy of if */
+export function useUpdatedDatasetIndex() {
+  const setDatasetsState = useSetRecoilState(datasetsAtom)
+  const datasetServerUrl = useRecoilValue(datasetServerUrlAtom)
+  useQuery(
+    'refetchDatasetIndex',
+    async () => {
+      const { currentDataset: _, ...datasetsState } = await initializeDatasets({}, datasetServerUrl)
+      setDatasetsState(datasetsState)
+    },
+    {
+      refetchInterval: 12 * 60 * 60 * 1000, // 12 hours
+      refetchIntervalInBackground: true,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
+      refetchOnWindowFocus: true,
+    },
+  )
 }

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -96,8 +96,8 @@ export function useUpdatedDataset() {
       return undefined
     },
     {
-      refetchInterval: 5 * 1000, // 5 seconds
-      refetchIntervalInBackground: true,
+      refetchInterval: 60 * 60 * 1000, // 1 hour
+      refetchIntervalInBackground: false,
       refetchOnMount: true,
       refetchOnReconnect: true,
       refetchOnWindowFocus: true,

--- a/packages_rs/nextclade-web/src/io/fetchDatasetsIndex.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasetsIndex.ts
@@ -1,4 +1,4 @@
-import { mapValues } from 'lodash'
+import { first, mapValues, sortBy } from 'lodash'
 import semver from 'semver'
 import { ErrorInternal } from 'src/helpers/ErrorInternal'
 import urljoin from 'url-join'
@@ -60,8 +60,15 @@ export function getLatestCompatibleEnabledDatasets(datasetServerUrl: string, dat
   }
 }
 
+/** Find the latest dataset, optionally by name, ref and tag */
 export function findDataset(datasets: Dataset[], name?: string, refAccession?: string, tag?: string) {
-  return datasets.find((dataset) => {
+  const datasetsFound = filterDatasets(datasets, name, refAccession, tag)
+  return first(sortBy(datasetsFound, (dataset) => dataset.attributes.tag))
+}
+
+/** Find the datasets given name, ref and tag */
+export function filterDatasets(datasets: Dataset[], name?: string, refAccession?: string, tag?: string) {
+  return datasets.filter((dataset) => {
     let isMatch = dataset.attributes.name.value === name
 
     if (refAccession) {

--- a/packages_rs/nextclade-web/src/state/dataset.state.ts
+++ b/packages_rs/nextclade-web/src/state/dataset.state.ts
@@ -58,6 +58,11 @@ export const datasetCurrentAtom = selector<Dataset | undefined>({
   },
 })
 
+export const datasetUpdatedAtom = atom<Dataset | undefined>({
+  key: 'datasetUpdated',
+  default: undefined,
+})
+
 export const geneOrderPreferenceAtom = selector({
   key: 'geneOrderPreference',
   get({ get }) {

--- a/packages_rs/nextclade-web/src/styles/_variables.scss
+++ b/packages_rs/nextclade-web/src/styles/_variables.scss
@@ -59,7 +59,7 @@ $orange: #fd7e14;
 $yellow: #ff9800;
 $green: #4caf50;
 $teal: #20c997;
-$cyan: #9c27b0;
+$cyan: #1dbfc7;
 
 $primary: $blue;
 $secondary: $gray-100;


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1139

This attempts to resolve situations described in the linked issues, when the new datasets are not available for users with stale browser tabs and also unless they switch the current dataset periodically.

To mitigate this, I add 2 kinds of data updates:

 - Re-fetch dataset index and silently update the list of pathogens
 - Check current dataset against the local list of datasets, and notify user when there is an update

Both updates are happening every time when:
 - User visits for the first time
 - The new tab is opened
 - The browser tab with Nextclade Web is focused
 - User navigates between pages

Additionally, these updates also happen periodically:
 - index re-fetch every 12 hours (there is a network request for index file)
 - current dataset check every 5 seconds (there is no network request involved)

If an update found for the currently selected dataset, Nextclade shows a notification. There users can consult datasets changelog and apply the update by clicking the "Update" button.


### Demo

Notice when I click to the field, the dataset version changes:

(there is only one dataset in the list shown in this example, but in real application all datasets will be updated according to the new index JSON file)

https://user-images.githubusercontent.com/9403403/235728933-fd539e26-3b3f-44d4-98ab-8812ce3db212.mp4

Notice when I click on the page, the notification appears, and when I click to the "Update" button, the dataset version changes:


https://user-images.githubusercontent.com/9403403/235729166-705e4d8c-5966-4aa4-a462-775d28d8932b.mp4



### Future work
 - Instead of silent update of the index we might also add notifications for when the index is updated.
 - The updates are currently irreversible. We might allow users to select older dataset versions from the list.




