### PR TITLE
chore(ci): fix aarch64-unknown-linux-gnu builds

### DIFF
--- a/.github/workflows/bioconda.yml
+++ b/.github/workflows/bioconda.yml
@@ -23,6 +23,7 @@ defaults:
 
 env:
   GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  VERBOSE: 1
 
 jobs:
 

--- a/.github/workflows/builder-docker-image.yml
+++ b/.github/workflows/builder-docker-image.yml
@@ -19,6 +19,7 @@ defaults:
 
 env:
   GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  VERBOSE: 1
 
 jobs:
   build-base-image:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -27,6 +27,7 @@ defaults:
 
 env:
   GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  VERBOSE: 1
 
 jobs:
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -27,6 +27,7 @@ defaults:
 
 env:
   GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  VERBOSE: 1
 
 jobs:
   build-web:

--- a/docker-dev
+++ b/docker-dev
@@ -400,6 +400,8 @@ if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER
   CACHE_SCOPE="${DOCKER_REPO}-${DOCKER_TARGET}-${BRANCH}"
   BUILDX_CACHE_DIR="${CACHE_DIR}/buildx"
 
+  mkdir -p "${BUILDX_CACHE_DIR}"
+
   if [ "${VERBOSE:=0}" != "1" ]; then
     ADDITIONAL_DOCKER_BUILD_ARGS="${ADDITIONAL_DOCKER_BUILD_ARGS} -q"
   fi

--- a/docker-dev
+++ b/docker-dev
@@ -400,7 +400,11 @@ if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER
   CACHE_SCOPE="${DOCKER_REPO}-${DOCKER_TARGET}-${BRANCH}"
   BUILDX_CACHE_DIR="${CACHE_DIR}/buildx"
 
-  ${NICE} docker buildx build -q \
+  if [ "${VERBOSE:=0}" != "1" ]; then
+    ADDITIONAL_DOCKER_BUILD_ARGS="${ADDITIONAL_DOCKER_BUILD_ARGS} -q"
+  fi
+
+  ${NICE} docker buildx build \
     --file="docker/docker-dev.dockerfile" \
     --target="${DOCKER_TARGET}" \
     --tag="${DOCKER_REPO}:${DOCKER_TARGET}" \

--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -54,6 +54,7 @@ ARG CLANG_VERSION
 # Install required packages if running Debian or Ubuntu
 RUN set -euxo pipefail >/dev/null \
 && if [[ "$DOCKER_BASE_IMAGE" != debian* ]] && [[ "$DOCKER_BASE_IMAGE" != ubuntu* ]]; then exit 0; fi \
+&& if grep stretch "/etc/apt/sources.list"; then printf "deb http://archive.debian.org/debian/ stretch main non-free contrib\ndeb http://archive.debian.org/debian-security/ stretch/updates main non-free contrib\n" > "/etc/apt/sources.list"; fi \
 && export DEBIAN_FRONTEND=noninteractive \
 && apt-get update -qq --yes \
 && apt-get install -qq --no-install-recommends --yes \


### PR DESCRIPTION
The main debian 9 (stretch) deb repos have been turned off, giving us docker build errors on CI when installing packages via apt-get.

Here I migrate to the deb archive repos, by replacing the contents of `/etc/apt/sources.list` with this:

```
deb http://archive.debian.org/debian/ stretch main non-free contrib
deb http://archive.debian.org/debian-security/ stretch/updates main non-free contrib
```


Additionally:

 - Let's make CI builds more verbose (controllable by `VERBOSE=1` env var)
 - Let's create docker buildx cache directory in advance to avoid missing directory warnings and to make sure the local cache works as expected.
 