### PR TITLE
chore(ci): remove rhel 7 from linux repo compat list

### DIFF
--- a/tests/test-linux-distros
+++ b/tests/test-linux-distros
@@ -54,7 +54,6 @@ distros=(
   "oraclelinux:7.2"
   "oraclelinux:8.0"
   "oraclelinux:8.6"
-  "registry.access.redhat.com/ubi7/ubi"
   "registry.access.redhat.com/ubi8/ubi"
   "registry.access.redhat.com/ubi9/ubi"
   "opensuse/archive:13.2"


### PR DESCRIPTION
The docker image for RHEL 7 is no longer available:
```
Error response from daemon: unauthorized: access to the requested resource is not authorized
Failed running '/nextclade dataset list >/dev/null' on 'registry.access.redhat.com/ubi7/ubi'
Unable to find image 'registry.access.redhat.com/ubi7/ubi:latest' locally
docker: Error response from daemon: unauthorized: access to the requested resource is not authorized.
```

https://github.com/nextstrain/nextclade/actions/runs/4875338410/jobs/8698664297

So let's remove it

