### PR TITLE
chore(ci): fix smoke tests

### DIFF
--- a/tests/run-smoke-tests
+++ b/tests/run-smoke-tests
@@ -23,8 +23,8 @@ export THIS_DIR
 export DATASET_DIR="$THIS_DIR/../tmp/smoke-tests/dataset"
 export OUT_DIR="$THIS_DIR/../tmp/smoke-tests/result"
 
-dataset_names_and_refs=$(${NEXTCLADE_BIN} dataset list --json | jq -r '.[] | select(.attributes.tag.isDefault==true) |  .attributes.name.value + ";" + .attributes.reference.value')
-dataset_names_without_refs=$(${NEXTCLADE_BIN} dataset list --json | jq -r '.[] | select(.attributes.tag.isDefault==true) |  .attributes.name.value + ";"')
+dataset_names_and_refs=$(${NEXTCLADE_BIN} dataset list --json | jq -r '.[] | select(.attributes.tag.isDefault==true) |  .attributes.name.value + ";" + .attributes.reference.value' | sort | uniq)
+dataset_names_without_refs=$(${NEXTCLADE_BIN} dataset list --json | jq -r '.[] | select(.attributes.tag.isDefault==true) |  .attributes.name.value + ";"' | sort | uniq)
 all_datasets="${dataset_names_and_refs} ${dataset_names_without_refs}"
 num_datasets=$(echo "${all_datasets}" | wc -l)
 


### PR DESCRIPTION
Ensure that there is no duplicate combinations of dataset names and dataset references, to avoid parallel runs to overwrite dataset files while another is reading them.

