### PR TITLE
chore(ci): prevent duplicated github action runs in pull requests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,12 +3,9 @@ name: cli
 
 on:
   push:
-    tags:
-    branches:
-    branches-ignore: [ 'staging', 'release' ]
+    branches: ['master', 'staging-cli', 'release-cli']
 
   pull_request:
-    branches:
 
   repository_dispatch:
     types: build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -3,12 +3,9 @@ name: web
 
 on:
   push:
-    tags:
-    branches:
-    branches-ignore: [ 'staging-cli', 'release-cli' ]
+    branches: ['master', 'staging', 'release']
 
   pull_request:
-    branches:
 
   repository_dispatch:
     types: build


### PR DESCRIPTION
Let's save some electricity by limiting actions on 'push' event only to main branches, to avoid the duplicated runs in each pull requests - for 'push' and for 'pull_request' event.

