### PR TITLE
fix(web): sort empty values

### DIFF
--- a/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTable.tsx
@@ -21,7 +21,8 @@ import {
   phenotypeAttrDescsAtom,
   seqIndicesFilteredAtom,
   sortAnalysisResultsAtom,
-  sortAnalysisResultsByKeyAtom,
+  sortAnalysisResultsByCustomNodeAttributesAtom,
+  sortAnalysisResultsByPhenotypeValuesAtom,
   sortAnalysisResultsByMotifsAtom,
 } from 'src/state/results.state'
 import { FormattedText } from 'src/components/Common/FormattedText'
@@ -177,8 +178,11 @@ export function ResultsTable() {
   const sortByTotalStopCodonsDesc = useRecoilCallback(({ set }) => () => {
     set(sortAnalysisResultsAtom({ category: SortCategory.totalStopCodons, direction: SortDirection.desc }), undefined)
   }, []) // prettier-ignore
-  const sortByKey = useRecoilCallback(({ set }) => (key: string, direction: SortDirection) => () => {
-    set(sortAnalysisResultsByKeyAtom({ key, direction }), undefined)
+  const sortByCustomNodeAttributes = useRecoilCallback(({ set }) => (key: string, direction: SortDirection) => () => {
+    set(sortAnalysisResultsByCustomNodeAttributesAtom({ key, direction }), undefined)
+  }, []) // prettier-ignore
+  const sortByPhenotypeValues = useRecoilCallback(({ set }) => (key: string, direction: SortDirection) => () => {
+    set(sortAnalysisResultsByPhenotypeValuesAtom({ key, direction }), undefined)
   }, []) // prettier-ignore
   const sortByMotifs = useRecoilCallback(
     ({ set }) =>
@@ -193,8 +197,8 @@ export function ResultsTable() {
     return cladeNodeAttrDescs
       .filter((attr) => !attr.hideInWeb)
       .map(({ name: attrKey, displayName, description }) => {
-        const sortAsc = sortByKey(attrKey, SortDirection.asc)
-        const sortDesc = sortByKey(attrKey, SortDirection.desc)
+        const sortAsc = sortByCustomNodeAttributes(attrKey, SortDirection.asc)
+        const sortDesc = sortByCustomNodeAttributes(attrKey, SortDirection.desc)
         return (
           <TableHeaderCell key={attrKey} basis={dynamicCladeColumnWidthPx} grow={0} shrink={0}>
             <TableHeaderCellContent>
@@ -208,12 +212,12 @@ export function ResultsTable() {
           </TableHeaderCell>
         )
       })
-  }, [cladeNodeAttrDescs, dynamicCladeColumnWidthPx, sortByKey])
+  }, [cladeNodeAttrDescs, dynamicCladeColumnWidthPx, sortByCustomNodeAttributes])
 
   const dynamicPhenotypeColumns = useMemo(() => {
     return phenotypeAttrDescs.map(({ name, nameFriendly, description }) => {
-      const sortAsc = sortByKey(name, SortDirection.asc)
-      const sortDesc = sortByKey(name, SortDirection.desc)
+      const sortAsc = sortByPhenotypeValues(name, SortDirection.asc)
+      const sortDesc = sortByPhenotypeValues(name, SortDirection.desc)
       return (
         <TableHeaderCell key={name} basis={dynamicPhenotypeColumnWidthPx} grow={0} shrink={0}>
           <TableHeaderCellContent>
@@ -227,7 +231,7 @@ export function ResultsTable() {
         </TableHeaderCell>
       )
     })
-  }, [phenotypeAttrDescs, dynamicPhenotypeColumnWidthPx, sortByKey])
+  }, [phenotypeAttrDescs, sortByPhenotypeValues, dynamicPhenotypeColumnWidthPx])
 
   const dynamicAaMotifsColumns = useMemo(() => {
     return aaMotifsDescs.map(({ name, nameFriendly, nameShort, description }) => {

--- a/packages_rs/nextclade-web/src/helpers/sortResults.ts
+++ b/packages_rs/nextclade-web/src/helpers/sortResults.ts
@@ -189,11 +189,10 @@ export function sortResultsByKey(results: NextcladeResult[], sorting: SortingKey
   return orderBy(
     results,
     (result) => {
-      return (
-        get(result.result?.analysisResult?.customNodeAttributes ?? {}, key) ??
-        result.result?.analysisResult?.phenotypeValues?.find((ph) => ph.name === key)?.value ??
-        defaultNumber(direction)
-      )
+      // Replace nullish values with empty strings, such that they could be sorted lexicographically
+      const customAttr = get(result.result?.analysisResult?.customNodeAttributes, key) ?? ''
+      const phenotypeAttr = result.result?.analysisResult?.phenotypeValues?.find((ph) => ph.name === key)?.value ?? ''
+      return customAttr ?? phenotypeAttr ?? defaultNumber(direction)
     },
     direction,
   )

--- a/packages_rs/nextclade-web/src/helpers/sortResults.ts
+++ b/packages_rs/nextclade-web/src/helpers/sortResults.ts
@@ -184,15 +184,26 @@ export interface SortingKeyBased {
   direction: SortDirection
 }
 
-export function sortResultsByKey(results: NextcladeResult[], sorting: SortingKeyBased) {
+export function sortCustomNodeAttribute(results: NextcladeResult[], sorting: SortingKeyBased) {
   const { key, direction } = sorting
   return orderBy(
     results,
     (result) => {
       // Replace nullish values with empty strings, such that they could be sorted lexicographically
-      const customAttr = get(result.result?.analysisResult?.customNodeAttributes, key) ?? ''
-      const phenotypeAttr = result.result?.analysisResult?.phenotypeValues?.find((ph) => ph.name === key)?.value ?? ''
-      return customAttr ?? phenotypeAttr ?? defaultNumber(direction)
+      return get(result.result?.analysisResult?.customNodeAttributes, key) ?? ''
+    },
+    direction,
+  )
+}
+
+export function sortPhenotypeValue(results: NextcladeResult[], sorting: SortingKeyBased) {
+  const { key, direction } = sorting
+  return orderBy(
+    results,
+    (result) => {
+      return (
+        result.result?.analysisResult?.phenotypeValues?.find((ph) => ph.name === key)?.value ?? defaultNumber(direction)
+      )
     },
     direction,
   )

--- a/packages_rs/nextclade-web/src/state/results.state.ts
+++ b/packages_rs/nextclade-web/src/state/results.state.ts
@@ -6,7 +6,14 @@ import type { AaMotifsDesc, CsvColumnConfig, Gene, NextcladeResult, PhenotypeAtt
 import { AlgorithmGlobalStatus, AlgorithmSequenceStatus, getResultStatus } from 'src/types'
 import { plausible } from 'src/components/Common/Plausible'
 import { runFilters } from 'src/filtering/runFilters'
-import { SortCategory, SortDirection, sortMotifs, sortResults, sortResultsByKey } from 'src/helpers/sortResults'
+import {
+  SortCategory,
+  SortDirection,
+  sortMotifs,
+  sortResults,
+  sortCustomNodeAttribute,
+  sortPhenotypeValue,
+} from 'src/helpers/sortResults'
 import { datasetCurrentAtom } from 'src/state/dataset.state'
 import {
   aaFilterAtom,
@@ -122,8 +129,11 @@ export const sortAnalysisResultsAtom = selectorFamily<undefined, { category: Sor
     },
 })
 
-export const sortAnalysisResultsByKeyAtom = selectorFamily<undefined, { key: string; direction: SortDirection }>({
-  key: 'sortAnalysisResultsByKey',
+export const sortAnalysisResultsByCustomNodeAttributesAtom = selectorFamily<
+  undefined,
+  { key: string; direction: SortDirection }
+>({
+  key: 'sortAnalysisResultsByCustomNodeAttributes',
 
   get: () => () => undefined,
 
@@ -134,7 +144,29 @@ export const sortAnalysisResultsByKeyAtom = selectorFamily<undefined, { key: str
 
       const resultsSorted = isDefaultValue(def)
         ? sortResults(results, { category: SortCategory.index, direction })
-        : sortResultsByKey(results, { key, direction })
+        : sortCustomNodeAttribute(results, { key, direction })
+
+      const seqIndicesSorted = resultsSorted.map((result) => result.index)
+      set(seqIndicesAtom, seqIndicesSorted)
+    },
+})
+
+export const sortAnalysisResultsByPhenotypeValuesAtom = selectorFamily<
+  undefined,
+  { key: string; direction: SortDirection }
+>({
+  key: 'sortAnalysisResultsByPhenotypeValues',
+
+  get: () => () => undefined,
+
+  set:
+    ({ key, direction }) =>
+    ({ get, set }, def: undefined | DefaultValue) => {
+      const results = get(analysisResultsAtom)
+
+      const resultsSorted = isDefaultValue(def)
+        ? sortResults(results, { category: SortCategory.index, direction })
+        : sortPhenotypeValue(results, { key, direction })
 
       const seqIndicesSorted = resultsSorted.map((result) => result.index)
       set(seqIndicesAtom, seqIndicesSorted)


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1143

The `undefined` values are not comparable to strings, so Cornelius felt that in presence of empty values in custom clade-like columns the table sort misbehaves.

Here I treat the `undefined` values in custom clade-like columns and for phenotype columns as empty strings before sorting them. This way they can be sorted lexicographically along with other string values.

This may or may not what we want, but let's give it a try.

