### PR TITLE
feat(web): notify user on Nextclade Web updates

### DIFF
--- a/packages_rs/nextclade-web/config/next/next.config.ts
+++ b/packages_rs/nextclade-web/config/next/next.config.ts
@@ -7,6 +7,8 @@ import getWithMDX from '@next/mdx'
 import withPlugins from 'next-compose-plugins'
 import getWithTranspileModules from 'next-transpile-modules'
 
+import type { AppJson } from 'src/components/Layout/UpdateNotification'
+
 import { RELEASE_URL } from './../../src/constants'
 import { findModuleRoot } from '../../lib/findModuleRoot'
 import { getGitBranch } from '../../lib/getGitBranch'
@@ -29,6 +31,7 @@ import withFriendlyChunkNames from './withFriendlyChunkNames'
 import withResolve from './withResolve'
 import withUrlAsset from './withUrlAsset'
 import withWasm from './withWasm'
+import { getWithAppJson } from './withAppJson'
 
 const {
   // BABEL_ENV,
@@ -163,6 +166,19 @@ const withTranspileModules = getWithTranspileModules(PRODUCTION ? transpilationL
 
 const withRobotsTxt = getWithRobotsTxt(`User-agent: *\nDisallow:${BRANCH_NAME === 'release' ? '' : ' *'}\n`)
 
+const withAppJson = getWithAppJson({
+  name: pkg.name,
+  version: pkg.version,
+  branchName: getGitBranch(),
+  commitHash: getGitCommitHash(),
+  buildNumber: getBuildNumber(),
+  buildUrl: getBuildUrl(),
+  domain: DOMAIN,
+  domainStripped: DOMAIN_STRIPPED,
+  dataFullDomain: DATA_FULL_DOMAIN,
+  blockSearchIndexing: DOMAIN === RELEASE_URL ? '0' : '1',
+} as AppJson)
+
 const config = withPlugins(
   [
     [withIgnore],
@@ -178,6 +194,7 @@ const config = withPlugins(
     [withRaw],
     [withResolve],
     [withRobotsTxt],
+    [withAppJson],
     [withUrlAsset],
     [withWasm],
     PRODUCTION && [withoutDebugPackage],

--- a/packages_rs/nextclade-web/config/next/withAppJson.ts
+++ b/packages_rs/nextclade-web/config/next/withAppJson.ts
@@ -1,17 +1,18 @@
 import { NextConfig } from 'next'
+import type { AppJson } from 'src/components/Layout/UpdateNotification'
 import { addWebpackPlugin } from './lib/addWebpackPlugin'
 import EmitFilePlugin from './lib/EmitFilePlugin'
 import { getEnvVars } from './lib/getEnvVars'
 
 const { PRODUCTION } = getEnvVars()
 
-export const getWithRobotsTxt = (content: string) => (nextConfig: NextConfig) => {
+export const getWithAppJson = (json: AppJson) => (nextConfig: NextConfig) => {
   return addWebpackPlugin(
     nextConfig,
     new EmitFilePlugin({
       path: PRODUCTION ? '.' : 'static/',
-      filename: 'robots.txt',
-      content,
+      filename: 'app.json',
+      content: JSON.stringify(json, null, 2),
       hash: false,
     }),
   )

--- a/packages_rs/nextclade-web/package.json
+++ b/packages_rs/nextclade-web/package.json
@@ -32,7 +32,7 @@
     "prod:build:vercel": "cp .env.vercel .env && yarn install && yarn prod:build && cp .build/production/tmp/routes-manifest.json .build/production/web/",
     "prod:_build": "yarn run next:build && yarn run next:export",
     "next:build": "cross-env NODE_ENV=production BABEL_ENV=production NODE_OPTIONS=--max_old_space_size=8192  babel-node --config-file \"./babel-node.config.js\" --extensions \".js,.ts\" -- node_modules/.bin/next build",
-    "next:export": "cross-env NODE_ENV=production BABEL_ENV=production NODE_OPTIONS=--max_old_space_size=8192  babel-node --config-file \"./babel-node.config.js\" --extensions \".js,.ts\" -- node_modules/.bin/next export --threads 2 -o \".build/production/web\" && cp .build/production/tmp/robots.txt .build/production/web/robots.txt",
+    "next:export": "cross-env NODE_ENV=production BABEL_ENV=production NODE_OPTIONS=--max_old_space_size=8192  babel-node --config-file \"./babel-node.config.js\" --extensions \".js,.ts\" -- node_modules/.bin/next export --threads 2 -o \".build/production/web\" && cd .build/production/tmp/ && cp app.json robots.txt ../web/",
     "next:build:profile": "PROFILE=1 yarn next:build --profile",
     "prod:clean": "rimraf '.build/production/{*,.*}' 'node_modules/.cache'",
     "prod:serve:nowatch": "babel-node --config-file \"./babel-node.config.js\" --extensions \".ts\" ./tools/server/server.ts",

--- a/packages_rs/nextclade-web/src/components/Layout/LayoutMain.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/LayoutMain.tsx
@@ -9,6 +9,7 @@ import { FaCaretRight } from 'react-icons/fa'
 
 import { NavigationBar } from './NavigationBar'
 import FooterContent from './Footer'
+import { UpdateNotification } from './UpdateNotification'
 
 export const Container = styled(ContainerBase)`
   max-height: 100vh;
@@ -57,7 +58,10 @@ export function LayoutMain({ children }: PropsWithChildren<HTMLProps<HTMLDivElem
         <FaCaretRight />
       </ButtonToResults>
 
-      <MainContent>{children}</MainContent>
+      <MainContent>
+        <UpdateNotification />
+        {children}
+      </MainContent>
 
       <Footer>
         <FooterContent />

--- a/packages_rs/nextclade-web/src/components/Layout/LayoutResults.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/LayoutResults.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 
 import { NavigationBar } from './NavigationBar'
 import FooterContent from './Footer'
+import { UpdateNotification } from './UpdateNotification'
 
 export const LayoutContainer = styled.div`
   max-width: 100vw;
@@ -37,7 +38,10 @@ export function LayoutResults({ children }: PropsWithChildren<HTMLProps<HTMLDivE
         <NavigationBar />
       </Header>
 
-      <MainContent>{children}</MainContent>
+      <MainContent>
+        <UpdateNotification />
+        {children}
+      </MainContent>
 
       <Footer>
         <FooterContent />

--- a/packages_rs/nextclade-web/src/components/Layout/UpdateNotification.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/UpdateNotification.tsx
@@ -41,7 +41,8 @@ export function useAppJson(): AppJson {
     return urljoin(origin, IS_PRODUCTION ? '' : '_next/static', 'app.json')
   }, [])
   return useAxiosQuery(url, {
-    refetchInterval: 60 * 60 * 1000, // 1 hour
+    staleTime: 0,
+    refetchInterval: 10 * 1000, // 1 hour
     refetchIntervalInBackground: false,
     refetchOnMount: true,
     refetchOnReconnect: true,

--- a/packages_rs/nextclade-web/src/components/Layout/UpdateNotification.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/UpdateNotification.tsx
@@ -1,0 +1,148 @@
+import React, { useCallback, useMemo } from 'react'
+import urljoin from 'url-join'
+import { useAxiosQuery } from 'src/helpers/useAxiosQuery'
+import {
+  Button,
+  Col,
+  Row,
+  Toast as ToastBase,
+  ToastBody as ToastBodyBase,
+  ToastHeader as ToastHeaderBase,
+} from 'reactstrap'
+import { useTranslationSafe as useTranslation } from 'src/helpers/useTranslationSafe'
+import styled from 'styled-components'
+import { useReloadPage } from 'src/hooks/useReloadPage'
+import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
+import { MdClose } from 'react-icons/md'
+import { LinkExternal } from 'src/components/Link/LinkExternal'
+import { useRecoilState } from 'recoil'
+import { lastNotifiedAppVersionAtom } from 'src/state/settings.state'
+
+const IS_PRODUCTION = process.env.NODE_ENV === 'production'
+// eslint-disable-next-line prefer-destructuring
+const PACKAGE_VERSION = process.env.PACKAGE_VERSION
+
+export interface AppJson {
+  name: string
+  version: string
+  branchName: string
+  commitHash: string
+  buildNumber: string | null
+  buildUrl: string | null
+  domain: string
+  domainStripped: string
+  dataFullDomain: string
+  blockSearchIndexing: string
+}
+
+export function useAppJson(): AppJson {
+  const url = useMemo(() => {
+    const origin = typeof window !== 'undefined' ? window?.location.origin : '/'
+    return urljoin(origin, IS_PRODUCTION ? '' : '_next/static', 'app.json')
+  }, [])
+  return useAxiosQuery(url, {
+    refetchInterval: 60 * 60 * 1000, // 1 hour
+    refetchIntervalInBackground: false,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+  })
+}
+
+export function UpdateNotification() {
+  const { t } = useTranslation()
+  const { version } = useAppJson()
+  const reload = useReloadPage('/')
+  const [lastNotifiedAppVersion, setLastNotifiedAppVersion] = useRecoilState(lastNotifiedAppVersionAtom)
+
+  const reloadText = t('Reload the page to get the latest version of Nextclade.')
+  const dismissText = t('Dismiss this notification. You can update Nextclade any time later by refreshing the page.')
+
+  const dismiss = useCallback(() => setLastNotifiedAppVersion(version), [setLastNotifiedAppVersion, version])
+
+  if (!(version > (lastNotifiedAppVersion ?? PACKAGE_VERSION ?? ''))) {
+    return null
+  }
+
+  return (
+    <UpdateNotificationWrapper>
+      <Toast className="my-2 rounded">
+        <ToastHeader className="bg-primary text-white text-bold w-100">
+          <div className="w-100 d-flex">
+            <h5 className="mt-1 mb-0 flex-1">{t('Update')}</h5>
+            <ButtonTransparent className="ml-auto" color="transparent" onClick={dismiss} title={dismissText}>
+              <MdClose color="white" />
+            </ButtonTransparent>
+          </div>
+        </ToastHeader>
+        <ToastBody>
+          <Row noGutters>
+            <Col>
+              <p className="my-1 ">
+                {t('A new version of {{nextclade}} is available:', { nextclade: 'Nextclade Web' })}
+              </p>
+              <p className="my-1 font-weight-bold">
+                {/* eslint-disable-next-line only-ascii/only-ascii */}
+                <span>{`${PACKAGE_VERSION} ⟶ ${version}`}</span>
+                {' ('}
+                <LinkExternal
+                  href="https://github.com/nextstrain/nextclade/blob/release/CHANGELOG.md"
+                  title={t('Open changelog to see what has changed in the new version.')}
+                >
+                  {"What's new?"}
+                </LinkExternal>
+                {')'}
+              </p>
+              <p className="my-1">
+                {t('Click "Update" button or refresh the page any time to get the latest updates.')}
+              </p>
+            </Col>
+          </Row>
+
+          <Row noGutters className="w-100 d-flex">
+            <Col className="flex-grow-0 ml-auto d-flex flex-row">
+              <Button className="mx-1" color="link" onClick={dismiss} title={dismissText}>
+                {t('Later')}
+              </Button>
+              <Button className="mx-1" color="primary" onClick={reload} title={reloadText}>
+                {t('Update')}
+              </Button>
+            </Col>
+          </Row>
+        </ToastBody>
+      </Toast>
+    </UpdateNotificationWrapper>
+  )
+}
+
+const TOAST_WIDTH = '360px'
+
+const UpdateNotificationWrapper = styled.div`
+  position: absolute;
+  right: 1rem;
+  top: 50px;
+  z-index: 9999;
+  padding: 0;
+  margin: 0;
+  min-width: ${TOAST_WIDTH};
+`
+
+const Toast = styled(ToastBase)`
+  min-width: ${TOAST_WIDTH};
+  opacity: 1 !important;
+  box-shadow: ${(props) => props.theme.shadows.large};
+`
+
+const ToastBody = styled(ToastBodyBase)`
+  min-width: ${TOAST_WIDTH};
+  opacity: 1 !important;
+  background: ${(props) => props.theme.bodyBg}; ;
+`
+
+const ToastHeader = styled(ToastHeaderBase)`
+  opacity: 1 !important;
+
+  & > strong {
+    width: 100%;
+  }
+`

--- a/packages_rs/nextclade-web/src/helpers/useAxiosQuery.ts
+++ b/packages_rs/nextclade-web/src/helpers/useAxiosQuery.ts
@@ -1,33 +1,33 @@
 import { useQuery } from 'react-query'
-import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type { UseQueryOptions } from 'react-query'
 
 import { axiosFetch } from 'src/io/axiosFetch'
+import { useMemo } from 'react'
 
-export interface UseAxiosQueryOptions<TData> extends UseQueryOptions<TData, Error> {
-  delay?: number
+export type UseAxiosQueryOptions<TData = unknown> = UseQueryOptions<TData, Error, TData, string[]>
+
+function queryOptionsDefaulted<TData>(options?: UseAxiosQueryOptions<TData>): UseAxiosQueryOptions<TData> {
+  let newOptions: UseAxiosQueryOptions<TData> = {
+    staleTime: Number.POSITIVE_INFINITY,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: true,
+    refetchInterval: Number.POSITIVE_INFINITY,
+  }
+  if (options) {
+    newOptions = { ...newOptions, ...options }
+  }
+  return newOptions
 }
 
-export function useAxiosQuery<TData = unknown>(
-  url: string,
-  options?: UseAxiosQueryOptions<TData>,
-): UseQueryResult<TData, Error> {
-  return useQuery<TData, Error>(
-    url,
-    async () => {
-      if (options?.delay) {
-        await new Promise((resolve) => {
-          setInterval(resolve, options.delay)
-        })
-      }
-      return axiosFetch(url)
-    },
-    {
-      staleTime: Number.POSITIVE_INFINITY,
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: true,
-      refetchInterval: Number.POSITIVE_INFINITY,
-      ...options,
-    },
-  )
+/** Makes a cached fetch request */
+export function useAxiosQuery<TData = unknown>(url: string, options?: UseAxiosQueryOptions<TData>): TData {
+  const newOptions = useMemo(() => queryOptionsDefaulted(options), [options])
+  const res = useQuery<TData, Error, TData, string[]>([url], async () => axiosFetch(url), newOptions)
+  return useMemo(() => {
+    if (!res.data) {
+      throw new Error(`Fetch failed: ${url}`)
+    }
+    return res.data
+  }, [res.data, url])
 }

--- a/packages_rs/nextclade-web/src/pages/_app.tsx
+++ b/packages_rs/nextclade-web/src/pages/_app.tsx
@@ -36,7 +36,7 @@ import { ThemeProvider } from 'styled-components'
 import { Provider as ReactReduxProvider } from 'react-redux'
 import { I18nextProvider } from 'react-i18next'
 import { MDXProvider } from '@mdx-js/react'
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClient, QueryClientConfig, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
 
 import { DOMAIN_STRIPPED } from 'src/constants'
@@ -174,8 +174,12 @@ export function RecoilStateInitializer() {
 
 const mdxComponents = { a: LinkExternal }
 
+const REACT_QUERY_OPTIONS: QueryClientConfig = {
+  defaultOptions: { queries: { suspense: true, retry: 1 } },
+}
+
 export function MyApp({ Component, pageProps, router }: AppProps) {
-  const queryClient = useMemo(() => new QueryClient(), [])
+  const queryClient = useMemo(() => new QueryClient(REACT_QUERY_OPTIONS), [])
   const { store } = useMemo(() => configureStore(), [])
   const fallback = useMemo(() => <Loading />, [])
 

--- a/packages_rs/nextclade-web/src/state/settings.state.ts
+++ b/packages_rs/nextclade-web/src/state/settings.state.ts
@@ -59,6 +59,12 @@ export const changelogLastVersionSeenAtom = atom<string>({
   effects: [persistAtom],
 })
 
+export const lastNotifiedAppVersionAtom = atom<string | undefined>({
+  key: 'lastNotifiedAppVersion',
+  default: undefined,
+  effects: [persistAtom],
+})
+
 export const showNewRunPopupAtom = atom({
   key: 'showNewRunPopup',
   default: false,

--- a/packages_rs/nextclade-web/src/theme.ts
+++ b/packages_rs/nextclade-web/src/theme.ts
@@ -106,6 +106,7 @@ export const shadows = {
   light: `1px 1px 1px 1px ${rgba(gray600, 0.2)}`,
   slight: `1px 1px 1px 1px ${rgba(gray700, 0.25)}`,
   medium: `2px 2px 3px 3px ${rgba(gray900, 0.25)}`,
+  large: `2px 2px 10px 10px ${rgba(gray900, 0.1)}`,
   filter: {
     slight: `1px 1px 1px ${rgba(gray700, 0.25)}`,
     medium: `2px 2px 3px ${rgba(gray900, 0.33)}`,


### PR DESCRIPTION
Related to: https://github.com/nextstrain/nextclade/issues/1139 https://github.com/nextstrain/nextclade/pull/1147

This PR introduces a notification toast which is displayed to the user when a new version of Nextclade Web is released. User can:
 - accept the update - this simply hard-reloads the page and, thus, loads the new version of the app
 - dismiss the notification - this hides the notification until the next version is available
 - read changelog - this opens changelog document on GitHub (the new changelog markdown is not yet available in the old app, so we cannot render it nicely and we link to GitHub instead)


### Implementation

The version info is fetched from the server as a field in the new file, `app.json` which is created by webpack and placed into the webroot. The version in this file (always latest available on the server) is compared with the version of the app currently running.

If user dismisses the toast, the last displayed version is remembered in local storage. This version is taken into account on next visit and user is not notified about this particular version anymore.


### Screenshot

![Update notification toast](https://user-images.githubusercontent.com/9403403/236952750-659c843d-497b-42fe-ab73-9591965ce518.png)

