### PR TITLE
fix(web): prevent crash when app.json or dataset cannot be fetched

### DIFF
--- a/packages_rs/nextclade-web/src/helpers/useAxiosQuery.ts
+++ b/packages_rs/nextclade-web/src/helpers/useAxiosQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query'
 import type { UseQueryOptions } from 'react-query'
 
-import { axiosFetch } from 'src/io/axiosFetch'
+import { axiosFetch, axiosFetchOrUndefined } from 'src/io/axiosFetch'
 import { useMemo } from 'react'
 
 export type UseAxiosQueryOptions<TData = unknown> = UseQueryOptions<TData, Error, TData, string[]>
@@ -30,4 +30,23 @@ export function useAxiosQuery<TData = unknown>(url: string, options?: UseAxiosQu
     }
     return res.data
   }, [res.data, url])
+}
+
+/** Makes a cached fetch request, ignoring errors */
+export function useAxiosQueryOrUndefined<TData = unknown>(
+  url: string,
+  options?: UseAxiosQueryOptions<TData | undefined>,
+): TData | undefined {
+  const newOptions = useMemo(() => queryOptionsDefaulted<TData | undefined>(options), [options])
+  const res = useQuery<TData | undefined, Error, TData | undefined, string[]>(
+    [url],
+    async () => axiosFetchOrUndefined(url),
+    newOptions,
+  )
+  return useMemo(() => {
+    if (!res.data) {
+      return undefined
+    }
+    return res.data
+  }, [res.data])
 }

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -62,7 +62,7 @@ export function useUpdatedDatasetIndex() {
     },
     {
       staleTime: 0,
-      refetchInterval: 12 * 60 * 60 * 1000, // 12 hours
+      refetchInterval: 2 * 60 * 60 * 1000, // 2 hours
       refetchIntervalInBackground: true,
       refetchOnMount: true,
       refetchOnReconnect: true,


### PR DESCRIPTION
These are meant to be checks performed in background, so let's ignore any failures, for example when network is disconnected. Update will be done when network connection is available again.

Tweak time intervals between update checks. We don't want these checks to put burden on users' computers,k especially on laptop batteries.

