### PR TITLE
fix(web): correctly dismiss dataset update notification

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetCurrent.tsx
@@ -1,7 +1,7 @@
 import { isNil } from 'lodash'
 import React, { useCallback, useState } from 'react'
 import { Button, Col, Collapse, Row, UncontrolledAlert } from 'reactstrap'
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
+import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil'
 import styled from 'styled-components'
 import { useUpdatedDataset } from 'src/io/fetchDatasets'
 import { datasetCurrentAtom, datasetUpdatedAtom } from 'src/state/dataset.state'
@@ -135,12 +135,13 @@ export function DatasetCurrent() {
 
 function DatasetCurrentUpdateNotification() {
   const { t } = useTranslationSafe()
-  const datasetUpdated = useRecoilValue(datasetUpdatedAtom)
+  const [datasetUpdated, setDatasetUpdated] = useRecoilState(datasetUpdatedAtom)
   const setDatasetCurrent = useSetRecoilState(datasetCurrentAtom)
 
   const onDatasetUpdateClicked = useCallback(() => {
     setDatasetCurrent(datasetUpdated)
-  }, [datasetUpdated, setDatasetCurrent])
+    setDatasetUpdated(undefined)
+  }, [datasetUpdated, setDatasetCurrent, setDatasetUpdated])
 
   if (isNil(datasetUpdated)) {
     return null


### PR DESCRIPTION
Current dataset update notification did not disappear after "Update" button is clicked.

This required to make another current dataset version check, triggered e.g. by unfocusing then focusing window or waiting until the next scheduled check.

In this PR I forcibly dismiss notification when button is clicked.

