### PR TITLE
fix(web): prevent main page from blinking when selecting dataset

### DIFF
--- a/packages_rs/nextclade-web/src/components/Layout/UpdateNotification.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/UpdateNotification.tsx
@@ -42,6 +42,7 @@ export function useAppJson(): AppJson | undefined {
     return urljoin(origin, IS_PRODUCTION ? '' : '_next/static', 'app.json')
   }, [])
   return useAxiosQueryOrUndefined(url, {
+    suspense: false,
     staleTime: 0,
     refetchInterval: 60 * 60 * 1000, // 1 hour
     refetchIntervalInBackground: false,

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -61,6 +61,7 @@ export function useUpdatedDatasetIndex() {
       setDatasetsState(datasetsState)
     },
     {
+      suspense: false,
       staleTime: 0,
       refetchInterval: 2 * 60 * 60 * 1000, // 2 hours
       refetchIntervalInBackground: true,
@@ -97,6 +98,7 @@ export function useUpdatedDataset() {
       return undefined
     },
     {
+      suspense: false,
       staleTime: 0,
       refetchInterval: 60 * 60 * 1000, // 1 hour
       refetchIntervalInBackground: false,


### PR DESCRIPTION
The main page blinks when selecting dataset, because at this point background update fetches are running, triggering React Suspense.

In this case we don't need to block the UI with suspense though, because these are background checks and their results are deferred to later time.

So let's disable suspense for the background checks for: 
 - dataset index update
 - current dataset version update
 - software update

