### PR TITLE
perf: avoid cloning global coord map

### DIFF
--- a/packages_rs/nextclade/src/translate/frame_shifts_translate.rs
+++ b/packages_rs/nextclade/src/translate/frame_shifts_translate.rs
@@ -81,7 +81,7 @@ pub fn frame_shift_transform(
 
   // determine the range(s) of the frame shift in the reference nucleotide sequence
   let nuc_abs_ref = qry_cds_map
-    .cds_to_global_ref_range(nuc_rel_aln)
+    .cds_to_global_ref_range(nuc_rel_aln, &coord_map)
     .into_iter()
     .filter_map(|cds_range| match cds_range {
       CdsRange::Covered(range) => Some(range),

--- a/packages_rs/nextclade/src/translate/translate_genes_ref.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes_ref.rs
@@ -33,8 +33,8 @@ pub fn translate_genes_ref(
               insertions: vec![],
               frame_shifts: vec![],
               alignment_ranges: vec![Range::new(0, len)],
-              ref_cds_map: CoordMapForCds::new(vec![], CoordMap::new(&[])), // dummy values
-              qry_cds_map: CoordMapForCds::new(vec![], CoordMap::new(&[])), // dummy values
+              ref_cds_map: CoordMapForCds::new(vec![]), // dummy values
+              qry_cds_map: CoordMapForCds::new(vec![]), // dummy values
               coord_map_local: CoordMapLocal::new(&[]),
             },
           )


### PR DESCRIPTION
This clone is very slow, let's try to avoid it:
https://github.com/nextstrain/nextclade/blob/3fa246198951a108778542114214adadd6bc478c/packages_rs/nextclade/src/translate/coord_map.rs#L212

