### PR TITLE
perf: avoid extra copies of genes and cdses

### DIFF
--- a/packages_rs/nextclade/src/analyze/find_aa_motifs.rs
+++ b/packages_rs/nextclade/src/analyze/find_aa_motifs.rs
@@ -13,7 +13,6 @@ use std::hash::{Hash, Hasher};
 #[serde(rename_all = "camelCase")]
 pub struct AaMotif {
   pub name: String,
-  pub gene: String,
   pub cds: String,
   pub position: usize,
   pub seq: String,
@@ -61,7 +60,7 @@ fn process_one_aa_motifs_desc(
     translation
       .cdses()
       .map(|translation| CountAaMotifsGeneDesc {
-        gene: translation.cds.name.clone(),
+        gene: translation.name.clone(),
         ranges: vec![],
       })
       .collect_vec()
@@ -74,7 +73,7 @@ fn process_one_aa_motifs_desc(
     .flat_map(|CountAaMotifsGeneDesc { gene, ranges }| {
       translation
         .cdses()
-        .filter(|CdsTranslation { cds, .. }| &cds.name == gene)
+        .filter(|CdsTranslation { name, .. }| name == gene)
         .flat_map(|translation| process_one_translation(translation, name, motifs, ranges))
         .collect_vec()
     })
@@ -130,8 +129,7 @@ fn process_one_motif(
       captures.get(0).map(|capture| {
         Ok(AaMotif {
           name: name.to_owned(),
-          gene: translation.gene.name.clone(),
-          cds: translation.cds.name.clone(),
+          cds: translation.name.clone(),
           position: range.begin + capture.start(),
           seq: capture.as_str().to_owned(),
         })
@@ -153,7 +151,7 @@ impl From<AaMotif> for AaMotifWithoutSeq {
 impl Hash for AaMotifWithoutSeq {
   fn hash<H: Hasher>(&self, state: &mut H) {
     self.0.name.hash(state);
-    self.0.gene.hash(state);
+    self.0.cds.hash(state);
     self.0.position.hash(state);
     // NOTE: `.seq` is disregarded
   }
@@ -163,7 +161,7 @@ impl Eq for AaMotifWithoutSeq {}
 
 impl PartialEq<Self> for AaMotifWithoutSeq {
   fn eq(&self, other: &Self) -> bool {
-    (&self.0.name, &self.0.gene, &self.0.position).eq(&(&other.0.name, &other.0.gene, &other.0.position))
+    (&self.0.name, &self.0.cds, &self.0.position).eq(&(&other.0.name, &other.0.cds, &other.0.position))
     // NOTE: `.seq` is disregarded
   }
 }

--- a/packages_rs/nextclade/src/analyze/letter_ranges.rs
+++ b/packages_rs/nextclade/src/analyze/letter_ranges.rs
@@ -116,11 +116,11 @@ impl GeneAaRange {
 pub fn find_aa_letter_ranges(translation: &Translation, letter: Aa) -> Vec<GeneAaRange> {
   translation
     .cdses()
-    .filter_map(|CdsTranslation { cds, seq, .. }| {
+    .filter_map(|CdsTranslation { name, seq, .. }| {
       let ranges = find_letter_ranges_by(seq, |candidate| candidate == letter);
       let length = ranges.iter().map(LetterRange::len).sum();
       (length > 0).then(|| GeneAaRange {
-        gene_name: cds.name.clone(),
+        gene_name: name.clone(),
         letter,
         ranges,
         length,

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -234,8 +234,8 @@ impl FastaPeptideWriter {
   }
 
   pub fn write(&mut self, seq_name: &str, translation: &CdsTranslation) -> Result<(), Report> {
-    match self.writers.get_mut(&translation.cds.name) {
-      None => make_internal_error!("Fasta file writer not found for gene '{}'", &translation.cds.name),
+    match self.writers.get_mut(&translation.name) {
+      None => make_internal_error!("Fasta file writer not found for gene '{}'", &translation.name),
       Some(writer) => writer.write(seq_name, &from_aa_seq(&translation.seq), false),
     }
   }

--- a/packages_rs/nextclade/src/io/gene_map.rs
+++ b/packages_rs/nextclade/src/io/gene_map.rs
@@ -94,6 +94,17 @@ impl GeneMap {
       .ok_or_else(|| make_internal_report!("Gene is expected to be present, but not found: '{gene_name}'"))
   }
 
+  pub fn get_cds<S: AsRef<str>>(&self, cds_name: S) -> Result<&Cds, Report> {
+    let cds_name = cds_name.as_ref();
+    self
+      .genes
+      .iter()
+      .find_map(|(_, gene)| gene.cdses.iter().find(|cds| cds.name == cds_name))
+      .ok_or_else(|| {
+        make_internal_report!("When looking up a CDS translation: CDS '{cds_name}' is expected, but not found")
+      })
+  }
+
   pub fn iter_genes(&self) -> impl Iterator<Item = (&String, &Gene)> + '_ {
     self.genes.iter()
   }

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -806,7 +806,6 @@ fn format_aa_motifs(motifs: &[AaMotif]) -> String {
     .map(
       |AaMotif {
          name,
-         gene,
          cds,
          position,
          seq,

--- a/packages_rs/nextclade/src/qc/qc_rule_stop_codons.rs
+++ b/packages_rs/nextclade/src/qc/qc_rule_stop_codons.rs
@@ -28,13 +28,13 @@ pub fn rule_stop_codons(translation: &Translation, config: &QcRulesConfigStopCod
   let mut stop_codons = Vec::<StopCodonLocation>::new();
   let mut stop_codons_ignored = Vec::<StopCodonLocation>::new();
   for cds_tr in translation.cdses() {
-    let CdsTranslation { cds, seq: peptide, .. } = cds_tr;
+    let CdsTranslation { name, seq: peptide, .. } = cds_tr;
 
     let len_minus_one = peptide.len() - 1; // Minus one to ignore valid stop codon at the end
     for (codon, aa) in peptide.iter().enumerate().take(len_minus_one) {
       if aa.is_stop() {
         let stop_codon = StopCodonLocation {
-          gene_name: cds.name.clone(),
+          gene_name: name.clone(),
           codon,
         };
 

--- a/packages_rs/nextclade/src/run/nextalign_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextalign_run_one.rs
@@ -41,7 +41,7 @@ pub fn nextalign_run_one(
 
       let present_genes: HashSet<String> = translation
         .iter_genes()
-        .flat_map(|(_, gene_tr)| gene_tr.cdses.iter().map(|(_, cds_tr)| cds_tr.cds.name.clone()))
+        .flat_map(|(_, gene_tr)| gene_tr.cdses.iter().map(|(_, cds_tr)| cds_tr.name.clone()))
         .collect();
 
       let missing_genes = gene_map

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -81,7 +81,7 @@ pub fn nextclade_run_one(
   let alignment_end = alignment_range.end;
   let alignment_score = alignment.alignment_score;
 
-  calculate_aa_alignment_ranges_in_place(&alignment_range, &coord_map, &mut translation)?;
+  calculate_aa_alignment_ranges_in_place(&alignment_range, &coord_map, &mut translation, &gene_map)?;
 
   let total_substitutions = substitutions.len();
   let total_deletions = deletions.iter().map(|del| del.length).sum();
@@ -225,7 +225,7 @@ pub fn nextclade_run_one(
         .iter()
         .filter_map(|alignment_range| (!alignment_range.is_empty()).then_some(alignment_range.clone()))
         .collect_vec();
-      (tr.cds.name.clone(), alignment_ranges)
+      (tr.name.clone(), alignment_ranges)
     })
     .collect();
 

--- a/packages_rs/nextclade/src/translate/aa_alignment_ranges.rs
+++ b/packages_rs/nextclade/src/translate/aa_alignment_ranges.rs
@@ -1,3 +1,4 @@
+use crate::io::gene_map::GeneMap;
 use crate::translate::coord_map::CoordMap;
 use crate::translate::translate_genes::Translation;
 use crate::utils::range::{intersect_or_none, Range};
@@ -12,10 +13,12 @@ pub fn calculate_aa_alignment_ranges_in_place(
   alignment_range: &Range,
   coord_map: &CoordMap,
   translation: &mut Translation,
+  gene_map: &GeneMap,
 ) -> Result<(), Report> {
   translation.iter_cdses_mut().try_for_each(|(_, cds_tr)| {
-    let aa_alignment_ranges = cds_tr
-      .cds
+    let cds = gene_map.get_cds(&cds_tr.name)?;
+
+    let aa_alignment_ranges = cds
       .segments
       .iter()
       .filter_map(|segment| {

--- a/packages_rs/nextclade/src/translate/translate_genes.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes.rs
@@ -4,7 +4,7 @@ use crate::align::params::AlignPairwiseParams;
 use crate::align::remove_gaps::remove_gaps_in_place;
 use crate::analyze::count_gaps::GapCounts;
 use crate::gene::cds::Cds;
-use crate::gene::gene::Gene;
+use crate::gene::gene::{Gene, GeneStrand};
 use crate::io::aa::Aa;
 use crate::io::gene_map::GeneMap;
 use crate::io::letter::{serde_deserialize_seq, serde_serialize_seq, Letter};
@@ -121,8 +121,8 @@ impl GeneTranslation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CdsTranslation {
-  pub gene: Gene,
-  pub cds: Cds,
+  pub name: String,
+  pub strand: GeneStrand,
   #[serde(serialize_with = "serde_serialize_seq")]
   #[serde(deserialize_with = "serde_deserialize_seq")]
   pub seq: Vec<Aa>,
@@ -290,8 +290,8 @@ pub fn translate_cds(
   mask_peptide_frame_shifts_in_place(&mut stripped.qry_seq, &frame_shifts);
 
   Ok(CdsTranslation {
-    gene: gene.clone(),
-    cds: cds.clone(),
+    name: cds.name.clone(),
+    strand: cds.strand,
     seq: stripped.qry_seq,
     insertions: stripped.insertions,
     frame_shifts,

--- a/packages_rs/nextclade/src/translate/translate_genes_ref.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes_ref.rs
@@ -27,8 +27,8 @@ pub fn translate_genes_ref(
           (
             cds.name.clone(),
             CdsTranslation {
-              gene: gene.clone(),
-              cds: cds.clone(),
+              name: cds.name.clone(),
+              strand: cds.strand,
               seq: tr.seq,
               insertions: vec![],
               frame_shifts: vec![],

--- a/packages_rs/nextclade/src/tree/tree_preprocess.rs
+++ b/packages_rs/nextclade/src/tree/tree_preprocess.rs
@@ -120,13 +120,13 @@ fn map_aa_muts(
   ref_translation
     .cdses()
     //We iterate over all genes that we have ref_peptides for
-    .map(|ref_cds_tr| match parent_aa_muts.get(&ref_cds_tr.cds.name) {
+    .map(|ref_cds_tr| match parent_aa_muts.get(&ref_cds_tr.name) {
       Some(aa_muts) => (
-        ref_cds_tr.cds.name.clone(),
-        map_aa_muts_for_one_gene(&ref_cds_tr.cds.name, node, &ref_cds_tr.seq, aa_muts),
+        ref_cds_tr.name.clone(),
+        map_aa_muts_for_one_gene(&ref_cds_tr.name, node, &ref_cds_tr.seq, aa_muts),
       ),
       // Initialize aa_muts, default dictionary style
-      None => (ref_cds_tr.cds.name.clone(), Ok(BTreeMap::new())),
+      None => (ref_cds_tr.name.clone(), Ok(BTreeMap::new())),
     })
     .map(|(name, muts)| -> Result<_, Report>  {
       Ok((name, muts?))


### PR DESCRIPTION
The structs for translated genes and CDSes also contain copies (the .clone() is called on construction) of their corresponding gene and CDS annotations (from gene map). This is unnecessary in many cases - only the names and strands are accessed. Let's try to shave off a few microseconds of runtime by removing these clones.

