### PR TITLE
Add mapping from cds range to reference ranges

### DIFF
--- a/packages_rs/nextclade/src/align/gap_open.rs
+++ b/packages_rs/nextclade/src/align/gap_open.rs
@@ -50,7 +50,7 @@ mod tests {
   use crate::gene::cds::{Cds, CdsSegment, WrappingPart};
   use crate::gene::gene::GeneStrand::{Forward, Reverse};
   use crate::gene::gene::{Gene, GeneStrand};
-  use crate::utils::range::NucRefGlobalRange;
+  use crate::utils::range::{NucRefGlobalRange, Range};
   use eyre::Report;
   use itertools::Itertools;
   use maplit::hashmap;
@@ -71,6 +71,7 @@ mod tests {
             id: index.to_string(),
             name: index.to_string(),
             range: NucRefGlobalRange::from_isize(*begin, *end),
+            range_local: Range::from_isize(0, end - begin),
             landmark: None,
             wrapping_part: WrappingPart::NonWrapping,
             strand: *strand,

--- a/packages_rs/nextclade/src/analyze/aa_changes.rs
+++ b/packages_rs/nextclade/src/analyze/aa_changes.rs
@@ -309,7 +309,7 @@ fn find_aa_changes_for_cds(
     let ranges = group
       .range
       .iter()
-      .map(|codon| cds_codon_pos_to_ref_range(cds, codon))
+      .flat_map(|codon| cds_codon_pos_to_ref_range(cds, codon))
       .collect_vec();
 
     group.nuc_subs = nuc_subs

--- a/packages_rs/nextclade/src/analyze/aa_changes.rs
+++ b/packages_rs/nextclade/src/analyze/aa_changes.rs
@@ -324,6 +324,9 @@ fn find_aa_changes_for_cds(
     }
   }
 
+  // Keep only non-empty groups
+  aa_changes_groups.retain(|group| !group.range.is_empty() && !group.changes.is_empty());
+
   aa_changes_groups.iter_mut().for_each(|group| {
     let ranges = group
       .range

--- a/packages_rs/nextclade/src/analyze/nuc_del.rs
+++ b/packages_rs/nextclade/src/analyze/nuc_del.rs
@@ -10,7 +10,7 @@ pub struct NucDelRange {
 }
 
 impl NucDelRange {
-  pub const fn new(begin: NucRefGlobalPosition, end: NucRefGlobalPosition) -> Self {
+  pub fn new(begin: NucRefGlobalPosition, end: NucRefGlobalPosition) -> Self {
     Self {
       range: NucRefGlobalRange::new(begin, end),
     }

--- a/packages_rs/nextclade/src/translate/coord_map.rs
+++ b/packages_rs/nextclade/src/translate/coord_map.rs
@@ -450,24 +450,32 @@ mod coord_map_tests {
       id: "".to_owned(),
       name: "".to_owned(),
       product: "".to_owned(),
-      segments: segment_ranges
-        .iter()
-        .map(|(start, end)| CdsSegment {
-          index: 0,
-          id: "".to_owned(),
-          name: "".to_owned(),
-          range: NucRefGlobalRange::from_usize(*start, *end),
-          landmark: None,
-          wrapping_part: WrappingPart::NonWrapping,
-          strand: GeneStrand::Forward,
-          frame: 0,
-          exceptions: vec![],
-          attributes: hashmap!(),
-          source_record: None,
-          compat_is_gene: false,
-          color: None,
-        })
-        .collect_vec(),
+      segments: {
+        let mut segment_start = 0;
+        segment_ranges
+          .iter()
+          .map(|(begin, end)| {
+            let segment = CdsSegment {
+              index: 0,
+              id: "".to_owned(),
+              name: "".to_owned(),
+              range: NucRefGlobalRange::from_usize(*begin, *end),
+              range_local: Range::from_usize(segment_start, segment_start + end - begin),
+              landmark: None,
+              wrapping_part: WrappingPart::NonWrapping,
+              strand: GeneStrand::Forward,
+              frame: 0,
+              exceptions: vec![],
+              attributes: hashmap!(),
+              source_record: None,
+              compat_is_gene: false,
+              color: None,
+            };
+            segment_start = segment_start + end - begin;
+            segment
+          })
+          .collect_vec()
+      },
       proteins: vec![],
       exceptions: vec![],
       attributes: hashmap! {},

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use crate::gene::cds::{Cds, WrappingPart};
 use crate::gene::gene::GeneStrand;
 use crate::io::letter::Letter;

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -39,12 +39,11 @@ pub fn cds_range_to_ref_ranges(cds: &Cds, range: &NucRefLocalRange) -> Vec<(NucR
     .filter_map(|segment| {
       intersect_or_none(&segment.range_local, range).map(|NucRefLocalRange { begin, end }| {
         #[rustfmt::skip]
-        let pos1 = cds_nuc_pos_to_ref(cds, begin);
-        let pos2 = cds_nuc_pos_to_ref(cds, end - 1);
-        let global_range = if segment.strand == GeneStrand::Forward {
-          NucRefGlobalRange::new(pos1, pos2 + 1)
-        } else {
-          NucRefGlobalRange::new(pos2, pos1 + 1)
+        let begin = cds_nuc_pos_to_ref(cds, begin);
+        let end = cds_nuc_pos_to_ref(cds, end - 1);
+        let global_range = match segment.strand {
+          GeneStrand::Forward => NucRefGlobalRange::new(begin, end + 1),
+          GeneStrand::Reverse => NucRefGlobalRange::new(end, begin + 1),
         };
         (global_range, segment.strand)
       })

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -39,10 +39,13 @@ pub fn cds_range_to_ref_ranges(cds: &Cds, range: &NucRefLocalRange) -> Vec<(NucR
     .filter_map(|segment| {
       intersect_or_none(&segment.range_local, range).map(|NucRefLocalRange { begin, end }| {
         #[rustfmt::skip]
-        let global_range = NucRefGlobalRange::new(
-          cds_nuc_pos_to_ref(cds, begin),
-          cds_nuc_pos_to_ref(cds, end - 1) + 1,
-        );
+        let pos1 = cds_nuc_pos_to_ref(cds, begin);
+        let pos2 = cds_nuc_pos_to_ref(cds, end - 1);
+        let global_range = if segment.strand == GeneStrand::Forward {
+          NucRefGlobalRange::new(pos1, pos2 + 1)
+        } else {
+          NucRefGlobalRange::new(pos2, pos1 + 1)
+        };
         (global_range, segment.strand)
       })
     })

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -11,18 +11,16 @@ use serde::{Deserialize, Serialize};
 
 pub fn cds_nuc_pos_to_ref(cds: &Cds, pos: NucRefLocalPosition) -> NucRefGlobalPosition {
   assert!(pos < cds.len() as isize);
-  let mut remaining_pos = pos;
-  let mut segment_index = 0;
-  let mut segment = &cds.segments[segment_index];
-  while remaining_pos >= segment.len() as isize {
-    remaining_pos -= segment.len() as isize;
-    segment_index += 1;
-    segment = &cds.segments[segment_index];
-  }
+
+  let segment = cds
+    .segments
+    .iter()
+    .find(|segment| segment.range_local.contains(pos))
+    .expect("Position is expected to be in exactly one segment, but none is found");
 
   match segment.strand {
-    GeneStrand::Forward => segment.range.begin + remaining_pos.as_isize(),
-    GeneStrand::Reverse => segment.range.end - 1 - remaining_pos.as_isize(),
+    GeneStrand::Forward => segment.range.begin + pos.as_isize(),
+    GeneStrand::Reverse => segment.range.end - 1 - pos.as_isize(),
   }
 }
 

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -32,7 +32,7 @@ pub fn cds_codon_pos_to_ref_pos(cds: &Cds, codon: AaRefPosition) -> NucRefGlobal
 
 pub fn cds_range_to_ref_ranges(cds: &Cds, range: &NucRefLocalRange) -> Vec<(NucRefGlobalRange, GeneStrand)> {
   assert!(range.begin <= range.end);
-  assert!(range.end < cds.len() as isize);
+  assert!(range.end <= cds.len() as isize);
 
   let mut remaining_left = range.begin;
   let mut remaining_right = range.end;

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -5,6 +5,7 @@ use crate::utils::range::{
   AaRefPosition, CoordsMarker, NucRefGlobalPosition, NucRefGlobalRange, NucRefLocalPosition, PositionLike,
   SeqTypeMarker, SpaceMarker,
 };
+use assert2::assert;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use crate::gene::cds::{Cds, WrappingPart};
 use crate::gene::gene::GeneStrand;
 use crate::io::letter::Letter;
@@ -30,13 +32,76 @@ pub fn cds_codon_pos_to_ref_pos(cds: &Cds, codon: AaRefPosition) -> NucRefGlobal
   cds_nuc_pos_to_ref(cds, NucRefLocalPosition::new(codon.as_isize() * 3))
 }
 
-pub fn cds_codon_pos_to_ref_range(cds: &Cds, codon: AaRefPosition) -> NucRefGlobalRange {
+pub fn cds_range_to_ref_ranges(
+  cds: &Cds,
+  begin: NucRefLocalPosition,
+  end: NucRefLocalPosition,
+) -> Vec<NucRefGlobalRange> {
+  assert!(begin <= end);
+  assert!(end < cds.len() as isize);
+  let mut remaining_left = begin;
+  let mut remaining_right = end;
+  let mut segment_index = 0;
+  let mut range_start: NucRefGlobalPosition;
+  let mut segment = &cds.segments[segment_index];
+  let mut ranges: Vec<NucRefGlobalRange> = vec![];
+
+  // advance on the CDS until reaching the first segment that overlaps.
+  while remaining_left >= segment.len() as isize {
+    remaining_left -= segment.len() as isize;
+    remaining_right -= segment.len() as isize;
+    segment_index += 1;
+    segment = &cds.segments[segment_index];
+  }
+
+  // calculate the position in the global reference of the beginning of the range
+  // if the segment is on the reverse strand, the distance is measured relative to the end
+  if segment.strand == GeneStrand::Forward {
+    range_start = NucRefGlobalPosition::from(segment.range.begin.as_isize() + remaining_left.as_isize());
+  } else {
+    // on the reverse strand this will point to end of range in the global seq, hence no - 1
+    range_start = NucRefGlobalPosition::from(segment.range.end.as_isize() - remaining_left.as_isize());
+  }
+
+  // advance along the CDS until the end of the range is in the segment
+  while remaining_right >= segment.len() as isize {
+    // the remainder of the segment is full contained.
+    // add the range to the end or from the start depending on strand
+    if segment.strand == GeneStrand::Forward {
+      ranges.push(NucRefGlobalRange::new(range_start, segment.range.end));
+    } else {
+      ranges.push(NucRefGlobalRange::new(segment.range.begin, range_start));
+    }
+    remaining_right -= segment.len() as isize;
+    segment_index += 1;
+    segment = &cds.segments[segment_index];
+    //determine the start position of the next range either as begin or end of segment range
+    if segment.strand == GeneStrand::Forward {
+      range_start = segment.range.begin as NucRefGlobalPosition;
+    } else {
+      range_start = segment.range.end as NucRefGlobalPosition;
+    }
+  }
+
+  // determine end of last segment
+  let range_end = if segment.strand == GeneStrand::Forward {
+    NucRefGlobalPosition::from(segment.range.begin.as_isize() + remaining_right.as_isize()) + 1
+  } else {
+    NucRefGlobalPosition::from(segment.range.end.as_isize() - 1 - remaining_right.as_isize())
+  };
+  // add final segment
+  if segment.strand == GeneStrand::Forward {
+    ranges.push(NucRefGlobalRange::new(range_start, range_end));
+  } else {
+    ranges.push(NucRefGlobalRange::new(range_end, range_start));
+  }
+  ranges
+}
+
+pub fn cds_codon_pos_to_ref_range(cds: &Cds, codon: AaRefPosition) -> Vec<NucRefGlobalRange> {
   let begin = codon.as_isize() * 3;
   let end = begin + 3;
-  NucRefGlobalRange::new(
-    cds_nuc_pos_to_ref(cds, NucRefLocalPosition::new(begin)),
-    cds_nuc_pos_to_ref(cds, NucRefLocalPosition::new(end) - 1) + 1,
-  )
+  cds_range_to_ref_ranges(cds, NucRefLocalPosition::from(begin), NucRefLocalPosition::from(end))
 }
 
 pub fn global_ref_pos_to_local(cds: &Cds, pos: NucRefGlobalPosition) -> Vec<NucRefLocalPosition> {

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -121,7 +121,7 @@ mod coord_map_tests {
   use super::*;
   use crate::gene::cds::{CdsSegment, WrappingPart};
   use crate::gene::gene::GeneStrand::{Forward, Reverse};
-  use crate::utils::range::Position;
+  use crate::utils::range::{Position, Range};
   use maplit::hashmap;
   use pretty_assertions::assert_eq;
   use rstest::rstest;
@@ -131,24 +131,32 @@ mod coord_map_tests {
       id: "".to_owned(),
       name: "".to_owned(),
       product: "".to_owned(),
-      segments: segment_ranges
-        .iter()
-        .map(|(start, end, strand)| CdsSegment {
-          index: 0,
-          id: "".to_owned(),
-          name: "".to_owned(),
-          range: NucRefGlobalRange::from_usize(*start, *end),
-          landmark: None,
-          wrapping_part: WrappingPart::NonWrapping,
-          strand: *strand,
-          frame: 0,
-          exceptions: vec![],
-          attributes: hashmap!(),
-          source_record: None,
-          compat_is_gene: false,
-          color: None,
-        })
-        .collect_vec(),
+      segments: {
+        let mut segment_start = 0;
+        segment_ranges
+          .iter()
+          .map(|(begin, end, strand)| {
+            let segment = CdsSegment {
+              index: 0,
+              id: "".to_owned(),
+              name: "".to_owned(),
+              range: NucRefGlobalRange::from_usize(*begin, *end),
+              range_local: Range::from_usize(segment_start, segment_start + end - begin),
+              landmark: None,
+              wrapping_part: WrappingPart::NonWrapping,
+              strand: *strand,
+              frame: 0,
+              exceptions: vec![],
+              attributes: hashmap!(),
+              source_record: None,
+              compat_is_gene: false,
+              color: None,
+            };
+            segment_start = segment_start + end - begin;
+            segment
+          })
+          .collect_vec()
+      },
       proteins: vec![],
       exceptions: vec![],
       attributes: hashmap! {},

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -18,9 +18,10 @@ pub fn cds_nuc_pos_to_ref(cds: &Cds, pos: NucRefLocalPosition) -> NucRefGlobalPo
     .find(|segment| segment.range_local.contains(pos))
     .expect("Position is expected to be in exactly one segment, but none is found");
 
+  let pos_in_segment = isize::from(pos - segment.range_local.begin);
   match segment.strand {
-    GeneStrand::Forward => segment.range.begin + pos.as_isize(),
-    GeneStrand::Reverse => segment.range.end - 1 - pos.as_isize(),
+    GeneStrand::Forward => segment.range.begin + pos_in_segment,
+    GeneStrand::Reverse => segment.range.end - 1 - pos_in_segment,
   }
 }
 

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -35,7 +35,7 @@ pub fn cds_range_to_ref_ranges(
   cds: &Cds,
   begin: NucRefLocalPosition,
   end: NucRefLocalPosition,
-) -> Vec<NucRefGlobalRange> {
+) -> Vec<(NucRefGlobalRange, GeneStrand)> {
   assert!(begin <= end);
   assert!(end < cds.len() as isize);
   let mut remaining_left = begin;
@@ -43,7 +43,7 @@ pub fn cds_range_to_ref_ranges(
   let mut segment_index = 0;
   let mut range_start: NucRefGlobalPosition;
   let mut segment = &cds.segments[segment_index];
-  let mut ranges: Vec<NucRefGlobalRange> = vec![];
+  let mut ranges = vec![];
 
   // advance on the CDS until reaching the first segment that overlaps.
   while remaining_left >= segment.len() as isize {
@@ -67,9 +67,9 @@ pub fn cds_range_to_ref_ranges(
     // the remainder of the segment is full contained.
     // add the range to the end or from the start depending on strand
     if segment.strand == GeneStrand::Forward {
-      ranges.push(NucRefGlobalRange::new(range_start, segment.range.end));
+      ranges.push((NucRefGlobalRange::new(range_start, segment.range.end), segment.strand));
     } else {
-      ranges.push(NucRefGlobalRange::new(segment.range.begin, range_start));
+      ranges.push((NucRefGlobalRange::new(segment.range.begin, range_start), segment.strand));
     }
     remaining_right -= segment.len() as isize;
     segment_index += 1;
@@ -90,14 +90,14 @@ pub fn cds_range_to_ref_ranges(
   };
   // add final segment
   if segment.strand == GeneStrand::Forward {
-    ranges.push(NucRefGlobalRange::new(range_start, range_end));
+    ranges.push((NucRefGlobalRange::new(range_start, range_end), segment.strand));
   } else {
-    ranges.push(NucRefGlobalRange::new(range_end, range_start));
+    ranges.push((NucRefGlobalRange::new(range_end, range_start), segment.strand));
   }
   ranges
 }
 
-pub fn cds_codon_pos_to_ref_range(cds: &Cds, codon: AaRefPosition) -> Vec<NucRefGlobalRange> {
+pub fn cds_codon_pos_to_ref_range(cds: &Cds, codon: AaRefPosition) -> Vec<(NucRefGlobalRange, GeneStrand)> {
   let begin = codon.as_isize() * 3;
   let end = begin + 3;
   cds_range_to_ref_ranges(cds, NucRefLocalPosition::from(begin), NucRefLocalPosition::from(end))

--- a/packages_rs/nextclade/src/translate/coord_map2.rs
+++ b/packages_rs/nextclade/src/translate/coord_map2.rs
@@ -14,7 +14,7 @@ pub fn cds_nuc_pos_to_ref(cds: &Cds, pos: NucRefLocalPosition) -> NucRefGlobalPo
   let mut remaining_pos = pos;
   let mut segment_index = 0;
   let mut segment = &cds.segments[segment_index];
-  while remaining_pos > segment.len() as isize {
+  while remaining_pos >= segment.len() as isize {
     remaining_pos -= segment.len() as isize;
     segment_index += 1;
     segment = &cds.segments[segment_index];

--- a/packages_rs/nextclade/src/utils/range.rs
+++ b/packages_rs/nextclade/src/utils/range.rs
@@ -417,11 +417,15 @@ pub fn have_intersection<P: PositionLike>(x: &Range<P>, y: &Range<P>) -> bool {
 /// Compute an intersection of two ranges. Returns an empty range if the intersection is empty
 #[inline]
 pub fn intersect<P: PositionLike>(x: &Range<P>, y: &Range<P>) -> Range<P> {
-  let begin = max(x.begin, y.begin);
-  let end = min(x.end, y.end);
-  let mut intersection = Range::new(begin, end);
-  intersection.fix();
-  intersection
+  if y.begin > x.end || x.begin > y.end {
+    Range::from_isize(0, 0)
+  } else {
+    let begin = max(x.begin, y.begin);
+    let end = min(x.end, y.end);
+    let mut intersection = Range::new(begin, end);
+    intersection.fix();
+    intersection
+  }
 }
 
 /// Compute an intersection of two ranges. Returns None if the intersection is empty

--- a/packages_rs/nextclade/src/utils/range.rs
+++ b/packages_rs/nextclade/src/utils/range.rs
@@ -8,6 +8,7 @@
 // This prevents, for example, adding a position in alignment coordinates to the position in the
 // reference coordinates, which is always a bug. Similarly, you cannot pass a range in reference to a function
 // expecting a range in alignment.
+use assert2::assert;
 use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 use derive_more::Display as DeriveDisplay;
 use num::Integer;
@@ -65,7 +66,7 @@ pub trait SeqTypeMarker: PositionLikeAttrs {}
 
 /// Position in a given 1-dimensional coordinate space.
 ///
-/// The coordianate space type parameter ensures that positions and ranges in different coordinate spaces have
+/// The coordinate space type parameter ensures that positions and ranges in different coordinate spaces have
 /// different Rust types and they cannot be used interchangeably.
 #[allow(clippy::partial_pub_fields)]
 #[derive(Clone, Copy, Default)]
@@ -292,7 +293,7 @@ where
 
 /// Range of positions in a given 1-dimensional coordinate space.
 ///
-/// The coordianate space type parameter ensures that positions and ranges in different coordinate spaces have
+/// The coordinate space type parameter ensures that positions and ranges in different coordinate spaces have
 /// different Rust types and they cannot be used interchangeably.
 #[must_use]
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, schemars::JsonSchema)]
@@ -309,12 +310,14 @@ impl<P: PositionLike> AsRef<Range<P>> for Range<P> {
 
 impl<P: PositionLike> Range<P> {
   #[inline]
-  pub const fn new(begin: P, end: P) -> Self {
+  pub fn new(begin: P, end: P) -> Self {
+    assert!(begin <= end);
     Self { begin, end }
   }
 
   #[inline]
   pub fn from_usize(begin: usize, end: usize) -> Self {
+    assert!(begin <= end);
     Self {
       begin: P::from(begin as isize),
       end: P::from(end as isize),
@@ -324,6 +327,7 @@ impl<P: PositionLike> Range<P> {
 
   #[inline]
   pub fn from_isize(begin: isize, end: isize) -> Self {
+    assert!(begin <= end);
     Self {
       begin: P::from(begin),
       end: P::from(end),
@@ -334,6 +338,7 @@ impl<P: PositionLike> Range<P> {
   #[inline]
   pub fn from_range<Q: PositionLike>(range: impl AsRef<Range<Q>>) -> Self {
     let range = range.as_ref();
+    assert!(range.begin <= range.end);
     Self::from_isize(range.begin.as_isize(), range.end.as_isize()).fixed()
   }
 
@@ -588,12 +593,12 @@ pub type NucRefGlobalPosition = Position<ReferenceCoords, GlobalSpace, NucSpace>
 pub type NucRefGlobalRange = Range<NucRefGlobalPosition>;
 
 // Local nucleotide positions in alignment coordinates. "Local" here means that the position is relative
-// to the beginning of a genetic featurem e.g. a gene or a CDS.
+// to the beginning of a genetic feature, e.g. a gene or a CDS.
 pub type NucAlnLocalPosition = Position<AlignmentCoords, LocalSpace, NucSpace>;
 pub type NucAlnLocalRange = Range<NucAlnLocalPosition>;
 
 // Local nucleotide positions in coordinates of reference sequence. "Local" here means that the position is relative
-// to the beginning of a genetic featurem e.g. a gene or a CDS.
+// to the beginning of a genetic feature, e.g. a gene or a CDS.
 pub type NucRefLocalPosition = Position<ReferenceCoords, LocalSpace, NucSpace>;
 pub type NucRefLocalRange = Range<NucRefLocalPosition>;
 


### PR DESCRIPTION
a range on a cds can span multiple segments of the cds
and thus can potentially map to multiple ranges in the global
reference sequence. This adds a function that walks along the
cds and determine the intersection with the range and the segments