### PR TITLE
perf: avoid calculating stripped ref sequence

### DIFF
--- a/packages_rs/nextclade/src/align/insertions_strip.rs
+++ b/packages_rs/nextclade/src/align/insertions_strip.rs
@@ -48,7 +48,6 @@ impl<T: Letter<T>> PartialOrd for Insertion<T> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StripInsertionsResult<T: Letter<T>> {
   pub qry_seq: Vec<T>,
-  pub ref_seq: Vec<T>,
   pub insertions: Vec<Insertion<T>>,
 }
 
@@ -97,13 +96,8 @@ pub fn insertions_strip<T: Letter<T>>(qry_seq: &[T], ref_seq: &[T]) -> StripInse
   insertions.shrink_to_fit();
   insertions.sort();
 
-  // Remove gaps from ref
-  let mut ref_stripped = ref_seq.to_vec();
-  ref_stripped.retain(|c| c != &T::GAP);
-
   StripInsertionsResult {
     qry_seq: qry_stripped,
-    ref_seq: ref_stripped,
     insertions,
   }
 }
@@ -166,11 +160,10 @@ mod tests {
       Insertion::<Nuc> { pos: 9, ins: to_nuc_seq("CATC")? }
     ];
 
-    #[rustfmt::skip]
-    let StripInsertionsResult { insertions, ref_seq, qry_seq } = insertions_strip(&qry_seq, &ref_seq);
+    let stripped = insertions_strip(&qry_seq, &ref_seq);
 
-    assert_eq!(insertions, expected_insertions);
-    assert_eq!(qry_seq, ref_seq);
+    assert_eq!(stripped.insertions, expected_insertions);
+    assert_eq!(stripped.qry_seq, ref_seq);
     Ok(())
   }
 }

--- a/packages_rs/nextclade/src/align/insertions_strip.rs
+++ b/packages_rs/nextclade/src/align/insertions_strip.rs
@@ -1,8 +1,7 @@
-use crate::io::aa::{from_aa_seq, to_aa_seq, Aa};
+use crate::io::aa::Aa;
 use crate::io::letter::{serde_deserialize_seq, serde_serialize_seq, Letter};
-use crate::io::nuc::{from_nuc_seq, Nuc};
+use crate::io::nuc::Nuc;
 use crate::translate::translate_genes::Translation;
-use crate::utils::error::{from_eyre_error, keep_ok};
 use color_eyre::SectionExt;
 use eyre::Report;
 use itertools::Itertools;
@@ -146,7 +145,7 @@ mod tests {
   use crate::io::nuc::to_nuc_seq;
   use eyre::Report;
   use pretty_assertions::assert_eq;
-  use rstest::{fixture, rstest};
+  use rstest::rstest;
 
   #[rstest]
   fn finds_terminal_insertions() -> Result<(), Report> {
@@ -163,7 +162,7 @@ mod tests {
     let stripped = insertions_strip(&qry_seq, &ref_seq);
 
     assert_eq!(stripped.insertions, expected_insertions);
-    assert_eq!(stripped.qry_seq, ref_seq);
+    assert_eq!(stripped.qry_seq, to_nuc_seq("ACGCTCGCAT")?);
     Ok(())
   }
 }

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -74,7 +74,7 @@ pub fn nextclade_run_one(
     substitutions,
     deletions,
     alignment_range,
-  } = find_nuc_changes(&stripped.qry_seq, &stripped.ref_seq);
+  } = find_nuc_changes(&stripped.qry_seq, ref_seq);
 
   let alignment_start = alignment_range.begin;
   let alignment_end = alignment_range.end;
@@ -106,7 +106,7 @@ pub fn nextclade_run_one(
     aa_substitutions,
     aa_deletions,
   } = find_aa_changes(
-    &stripped.ref_seq,
+    ref_seq,
     &stripped.qry_seq,
     ref_peptides,
     &translations,


### PR DESCRIPTION
Stripped ref is the same as the original red, so this is redundant.

