### PR TITLE
perf(web): send minified json between wasm and js

### DIFF
--- a/packages_rs/nextclade-cli/src/bin/featuretree.rs
+++ b/packages_rs/nextclade-cli/src/bin/featuretree.rs
@@ -3,7 +3,7 @@ use ctor::ctor;
 use eyre::Report;
 use log::LevelFilter;
 use nextclade::features::feature_tree::FeatureTree;
-use nextclade::io::json::{json_stringify, json_write};
+use nextclade::io::json::{json_stringify, json_write, JsonPretty};
 use nextclade::io::yaml::yaml_write;
 use nextclade::utils::global_init::global_init;
 use nextclade::utils::global_init::setup_logger;
@@ -45,12 +45,12 @@ fn main() -> Result<(), Report> {
     if output.ends_with("yaml") || output.ends_with("yml") {
       yaml_write(output, &feature_tree)?;
     } else {
-      json_write(output, &feature_tree)?;
+      json_write(output, &feature_tree, JsonPretty(true))?;
     }
   }
 
   if args.json {
-    println!("{}\n", json_stringify(&feature_tree)?);
+    println!("{}\n", json_stringify(&feature_tree, JsonPretty(true))?);
   } else {
     println!("{}", &feature_tree.to_pretty_string()?);
   }

--- a/packages_rs/nextclade-cli/src/bin/genemap.rs
+++ b/packages_rs/nextclade-cli/src/bin/genemap.rs
@@ -3,7 +3,7 @@ use ctor::ctor;
 use eyre::Report;
 use log::LevelFilter;
 use nextclade::io::gene_map::{gene_map_to_string, GeneMap};
-use nextclade::io::json::{json_stringify, json_write};
+use nextclade::io::json::{json_stringify, json_write, JsonPretty};
 use nextclade::io::yaml::yaml_write;
 use nextclade::utils::global_init::global_init;
 use nextclade::utils::global_init::setup_logger;
@@ -44,12 +44,12 @@ fn main() -> Result<(), Report> {
     if output.to_string_lossy().ends_with("yaml") || output.to_string_lossy().ends_with("yml") {
       yaml_write(output, &gene_map)?;
     } else {
-      json_write(output, &gene_map)?;
+      json_write(output, &gene_map, JsonPretty(true))?;
     }
   }
 
   if args.json {
-    println!("{}\n", json_stringify(&gene_map)?);
+    println!("{}\n", json_stringify(&gene_map, JsonPretty(true))?);
   } else {
     println!("{}", gene_map_to_string(&gene_map)?);
   }

--- a/packages_rs/nextclade-cli/src/bin/generate_jsonschema.rs
+++ b/packages_rs/nextclade-cli/src/bin/generate_jsonschema.rs
@@ -9,7 +9,7 @@ use nextclade::io::errors_csv::ErrorsFromWeb;
 use nextclade::io::fasta::FastaRecord;
 use nextclade::io::file::create_file_or_stdout;
 use nextclade::io::gene_map::GeneMap;
-use nextclade::io::json::json_write_impl;
+use nextclade::io::json::{json_write_impl, JsonPretty};
 use nextclade::io::nextclade_csv::CsvColumnConfig;
 use nextclade::qc::qc_config::QcConfig;
 use nextclade::qc::qc_run::QcResult;
@@ -51,7 +51,7 @@ fn write_jsonschema<T: JsonSchema>(output: &Option<PathBuf>) -> Result<(), Repor
   };
 
   let schema = schema_for!(T);
-  json_write_impl(writer, &schema)
+  json_write_impl(writer, &schema, JsonPretty(true))
 }
 
 fn main() -> Result<(), Report> {

--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use log::LevelFilter;
 use nextclade::getenv;
 use nextclade::io::dataset::DatasetsIndexJson;
-use nextclade::io::json::json_stringify;
+use nextclade::io::json::{json_stringify, JsonPretty};
 
 const THIS_VERSION: &str = getenv!("CARGO_PKG_VERSION");
 
@@ -99,7 +99,7 @@ pub fn nextclade_dataset_list(
     .collect_vec();
 
   if json {
-    println!("{}", json_stringify(&filtered)?);
+    println!("{}", json_stringify(&filtered, JsonPretty(true))?);
   } else {
     if filtered.is_empty() {
       return Ok(());

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -15,7 +15,7 @@ use nextclade::analyze::phenotype::get_phenotype_attr_descs;
 use nextclade::io::fasta::{FastaReader, FastaRecord};
 use nextclade::io::fs::has_extension;
 use nextclade::io::gene_map::gene_map_to_string;
-use nextclade::io::json::json_write;
+use nextclade::io::json::{json_write, JsonPretty};
 use nextclade::io::nextclade_csv::CsvColumnConfig;
 use nextclade::io::nuc::{to_nuc_seq, to_nuc_seq_replacing, Nuc};
 use nextclade::make_error;
@@ -292,7 +292,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
 
   if let Some(output_tree) = output_tree {
     tree_attach_new_nodes_in_place(&mut tree, &outputs);
-    json_write(output_tree, &tree)?;
+    json_write(output_tree, &tree, JsonPretty(true))?;
   }
 
   Ok(())

--- a/packages_rs/nextclade-web/src/wasm/analyze.rs
+++ b/packages_rs/nextclade-web/src/wasm/analyze.rs
@@ -10,7 +10,7 @@ use nextclade::analyze::virus_properties::{AaMotifsDesc, PhenotypeAttrDesc, Viru
 use nextclade::gene::gene::Gene;
 use nextclade::io::fasta::read_one_fasta_str;
 use nextclade::io::gene_map::GeneMap;
-use nextclade::io::json::json_stringify;
+use nextclade::io::json::{json_stringify, JsonPretty};
 use nextclade::io::nextclade_csv::CsvColumnConfig;
 use nextclade::io::nuc::{from_nuc_seq, to_nuc_seq, Nuc};
 use nextclade::qc::qc_config::QcConfig;
@@ -233,12 +233,12 @@ impl Nextclade {
   #[inline]
   pub fn get_initial_data(&self) -> Result<AnalysisInitialData, Report> {
     Ok(AnalysisInitialData {
-      gene_map: json_stringify::<Vec<Gene>>(&self.gene_map.genes().cloned().collect())?,
+      gene_map: json_stringify::<Vec<Gene>>(&self.gene_map.genes().cloned().collect(), JsonPretty(false))?,
       genome_size: self.ref_seq.len(),
-      clade_node_attr_key_descs: json_stringify(&self.clade_node_attr_key_descs)?,
-      phenotype_attr_descs: json_stringify(&self.phenotype_attr_descs)?,
-      aa_motifs_descs: json_stringify(&self.aa_motifs_descs)?,
-      csv_column_config_default: json_stringify(&CsvColumnConfig::default())?,
+      clade_node_attr_key_descs: json_stringify(&self.clade_node_attr_key_descs, JsonPretty(false))?,
+      phenotype_attr_descs: json_stringify(&self.phenotype_attr_descs, JsonPretty(false))?,
+      aa_motifs_descs: json_stringify(&self.aa_motifs_descs, JsonPretty(false))?,
+      csv_column_config_default: json_stringify(&CsvColumnConfig::default(), JsonPretty(false))?,
     })
   }
 
@@ -269,10 +269,11 @@ impl Nextclade {
       self.include_nearest_node_info,
     ) {
       Ok((qry_seq_aligned_stripped, translations, nextclade_outputs)) => {
-        let nextclade_outputs_str =
-          json_stringify(&nextclade_outputs).wrap_err("When serializing output results of Nextclade")?;
+        let nextclade_outputs_str = json_stringify(&nextclade_outputs, JsonPretty(false))
+          .wrap_err("When serializing output results of Nextclade")?;
 
-        let translations_str = json_stringify(&translations).wrap_err("When serializing output translations")?;
+        let translations_str =
+          json_stringify(&translations, JsonPretty(false)).wrap_err("When serializing output translations")?;
 
         let qry_seq_str = from_nuc_seq(&qry_seq_aligned_stripped);
 

--- a/packages_rs/nextclade-web/src/wasm/main.rs
+++ b/packages_rs/nextclade-web/src/wasm/main.rs
@@ -7,7 +7,7 @@ use nextclade::io::errors_csv::{errors_to_csv_string, ErrorsFromWeb};
 use nextclade::io::fasta::{read_one_fasta_str, FastaReader, FastaRecord};
 use nextclade::io::gene_map::GeneMap;
 use nextclade::io::insertions_csv::insertions_to_csv_string;
-use nextclade::io::json::{json_parse, json_stringify};
+use nextclade::io::json::{JsonPretty, json_parse, json_stringify};
 use nextclade::io::nextclade_csv::{results_to_csv_string, CsvColumnConfig};
 use nextclade::io::results_json::{results_to_json_string, results_to_ndjson_string};
 use nextclade::qc::qc_config::QcConfig;
@@ -75,13 +75,13 @@ impl NextcladeWasm {
   pub fn get_output_tree(&mut self, nextclade_outputs_json_str: &str) -> Result<String, JsError> {
     let nextclade_outputs = jserr(NextcladeOutputs::many_from_str(nextclade_outputs_json_str))?;
     let tree = self.nextclade.get_output_tree(&nextclade_outputs);
-    jserr(json_stringify(tree))
+    jserr(json_stringify(tree, JsonPretty(false)))
   }
 
   /// Checks that a string containing ref sequence in FASTA format is correct
   pub fn parse_ref_seq_fasta(ref_seq_str: &str) -> Result<String, JsError> {
     let record = jserr(read_one_fasta_str(ref_seq_str))?;
-    jserr(json_stringify(&record))
+    jserr(json_stringify(&record, JsonPretty(false)))
   }
 
   /// Checks that a string containing Auspice tree in JSON format is correct
@@ -93,7 +93,7 @@ impl NextcladeWasm {
   /// Checks that a string containing gene map in GFF format is correct
   pub fn parse_gene_map_gff(gene_map_gff_str: &str) -> Result<String, JsError> {
     let gene_map = jserr(GeneMap::from_str(gene_map_gff_str))?;
-    jserr(json_stringify(&gene_map))
+    jserr(json_stringify(&gene_map, JsonPretty(false)))
   }
 
   /// Checks that a string containing PCT primers in CSV format is correct

--- a/packages_rs/nextclade/src/io/json.rs
+++ b/packages_rs/nextclade/src/io/json.rs
@@ -26,16 +26,29 @@ pub fn json_parse_bytes<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T,
   deserialize_without_recursion_limit(&mut de)
 }
 
-pub fn json_stringify<T: Serialize>(obj: &T) -> Result<String, Report> {
-  serde_json::to_string_pretty(obj).wrap_err("When converting an entry to JSON string")
+#[derive(Clone, Copy, Debug)]
+pub struct JsonPretty(pub bool);
+
+pub fn json_stringify<T: Serialize>(obj: &T, pretty: JsonPretty) -> Result<String, Report> {
+  if pretty.0 {
+    serde_json::to_string_pretty(obj)
+  } else {
+    serde_json::to_string(obj)
+  }
+  .wrap_err("When converting an entry to JSON string")
 }
 
-pub fn json_write_impl<W: Write, T: Serialize>(writer: W, obj: &T) -> Result<(), Report> {
-  serde_json::to_writer_pretty(writer, &obj).wrap_err("When writing JSON")
+pub fn json_write_impl<W: Write, T: Serialize>(writer: W, obj: &T, pretty: JsonPretty) -> Result<(), Report> {
+  if pretty.0 {
+    serde_json::to_writer_pretty(writer, &obj)
+  } else {
+    serde_json::to_writer(writer, &obj)
+  }
+  .wrap_err("When writing JSON")
 }
 
-pub fn json_write<T: Serialize>(filepath: impl AsRef<Path>, obj: &T) -> Result<(), Report> {
+pub fn json_write<T: Serialize>(filepath: impl AsRef<Path>, obj: &T, pretty: JsonPretty) -> Result<(), Report> {
   let filepath = filepath.as_ref();
   let file = create_file_or_stdout(filepath)?;
-  json_write_impl(file, &obj).wrap_err("When writing JSON to file: {filepath:#?}")
+  json_write_impl(file, &obj, pretty).wrap_err("When writing JSON to file: {filepath:#?}")
 }

--- a/packages_rs/nextclade/src/io/results_json.rs
+++ b/packages_rs/nextclade/src/io/results_json.rs
@@ -1,5 +1,5 @@
 use crate::analyze::virus_properties::PhenotypeAttrDesc;
-use crate::io::json::{json_stringify, json_write};
+use crate::io::json::{json_stringify, json_write, JsonPretty};
 use crate::io::ndjson::NdjsonWriter;
 use crate::tree::tree::CladeNodeAttrKeyDesc;
 use crate::types::outputs::{
@@ -92,7 +92,7 @@ impl ResultsJsonWriter {
   }
 
   pub fn finish(&self) -> Result<(), Report> {
-    json_write(&self.filepath, &self.result)
+    json_write(&self.filepath, &self.result, JsonPretty(true))
   }
 }
 
@@ -117,7 +117,7 @@ pub fn results_to_json_string(
     phenotype_attr_keys,
     nextclade_web_version,
   );
-  json_stringify(&results_json)
+  json_stringify(&results_json, JsonPretty(false))
 }
 
 pub fn results_to_ndjson_string(


### PR DESCRIPTION
Currently JSON being sent from wasm to js is prettified. This means more bytes are being sent across language boundaries and might cause unnecessary slowdown.

Here I am adding a function to serialize to JSON without prettifying it. Let's see if it has any visible effect on performance.

However it also means that the downloadable JSON is also minified. Or it will need to be prettified on demand.

