### PR TITLE
feat(web): reimplement gene selector in results table

### DIFF
--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceSelector.tsx
@@ -3,10 +3,10 @@ import type { Cds, Gene, Protein } from '_SchemaRoot'
 import { isEmpty } from 'lodash'
 import React, { useCallback, useMemo } from 'react'
 import ReactSelect, { StylesConfig } from 'react-select'
-import { FilterOptionOption } from 'react-select/dist/declarations/src/filters'
+import type { FilterOptionOption } from 'react-select/dist/declarations/src/filters'
 import type { FormatOptionLabelMeta } from 'react-select/dist/declarations/src/Select'
-import { Theme } from 'react-select/dist/declarations/src/types'
-import { Badge } from 'reactstrap'
+import type { Theme } from 'react-select/dist/declarations/src/types'
+import { Badge as BadgeBase } from 'reactstrap'
 import styled from 'styled-components'
 import { viewedGeneAtom } from 'src/state/seqViewSettings.state'
 import { useRecoilState, useRecoilValue } from 'recoil'
@@ -86,7 +86,7 @@ export function SequenceSelector() {
     return {
       menuPortal: (base) => ({ ...base, zIndex: 9999 }),
       menuList: (base) => ({ ...base, fontSize: '1rem' }),
-      option: (base) => ({ ...base, fontSize: '1rem' }),
+      option: (base) => ({ ...base, fontSize: '1rem', padding: '2px 8px' }),
       singleValue: (base) => ({ ...base, fontSize: '1rem' }),
     }
   }, [])
@@ -105,7 +105,7 @@ export function SequenceSelector() {
           menuPortalTarget={menuPortalTarget}
           styles={reactSelectStyles}
           theme={reactSelectTheme}
-          maxMenuHeight={500}
+          maxMenuHeight={400}
         />
       </InnerWrapper>
     </div>
@@ -147,7 +147,7 @@ function OptionLabelFullGenome({ isMenu: _ }: { isMenu?: boolean }) {
   const { t } = useTranslationSafe()
   return (
     <Indent>
-      <Badge color="success" className="mr-1 px-2 py-1">
+      <Badge $color="#54AD56" className="mr-1 px-2 py-1" title={t('Full genome')}>
         {t('Full genome')}
       </Badge>
     </Indent>
@@ -157,8 +157,8 @@ function OptionLabelFullGenome({ isMenu: _ }: { isMenu?: boolean }) {
 function OptionLabelGene({ gene }: { gene: Gene; isMenu?: boolean }) {
   const { t } = useTranslationSafe()
   return (
-    <Indent>
-      <Badge color="secondary" className="mr-1 px-2 py-1">
+    <Indent title={gene.name}>
+      <Badge $color="#4e7ede" className="mr-1 px-2 py-1">
         {t('Gene')}
       </Badge>
       <span className="text-body">{gene.name}</span>
@@ -166,15 +166,17 @@ function OptionLabelGene({ gene }: { gene: Gene; isMenu?: boolean }) {
   )
 }
 
-function OptionLabelGeneAndCds({ gene }: { gene: Gene; cds: Cds; isMenu?: boolean }) {
+function OptionLabelGeneAndCds({ cds }: { gene: Gene; cds: Cds; isMenu?: boolean }) {
   const { t } = useTranslationSafe()
   return (
-    <Indent>
-      <Badge className="mr-1 px-2 py-1">{t('Gene')}</Badge>
-      <Badge color="primary" className="mr-1">
+    <Indent title={cds.name}>
+      <Badge $color="#4e7ede" className="mr-1 px-2 py-1">
+        {t('Gene')}
+      </Badge>
+      <Badge $color="#846ab8" className="mr-1">
         {t('CDS')}
       </Badge>
-      <span>{gene.name}</span>
+      <span>{cds.name}</span>
     </Indent>
   )
 }
@@ -182,8 +184,8 @@ function OptionLabelGeneAndCds({ gene }: { gene: Gene; cds: Cds; isMenu?: boolea
 function OptionLabelCds({ cds, isMenu = false }: { cds: Cds; isMenu?: boolean }) {
   const { t } = useTranslationSafe()
   return (
-    <Indent indent={isMenu && 1}>
-      <Badge color="primary" className="mr-1 px-2 py-1">
+    <Indent indent={isMenu && 1} title={cds.name}>
+      <Badge $color="#846ab8" className="mr-1 px-2 py-1">
         {t('CDS')}
       </Badge>
       <span>{cds.name}</span>
@@ -194,17 +196,28 @@ function OptionLabelCds({ cds, isMenu = false }: { cds: Cds; isMenu?: boolean })
 function OptionLabelProtein({ protein, isMenu = false }: { protein: Protein; isMenu?: boolean }) {
   const { t } = useTranslationSafe()
   return (
-    <Indent indent={isMenu && 2}>
-      <Badge className="mr-1">{t('Protein')}</Badge>
-      <span>{protein.name}</span>
+    <Indent indent={isMenu && 2} title={protein.name}>
+      <Badge $color="#9c8668" className="mr-1">
+        {t('Protein')}
+      </Badge>
+      <span className="text-body">{protein.name}</span>
     </Indent>
   )
 }
 
+const Badge = styled(BadgeBase)<{ $color?: string }>`
+  background-color: ${(props) => props.$color ?? props.theme.gray600};
+`
+
 // noinspection CssReplaceWithShorthandSafely
 const Indent = styled.div<{ indent?: number | boolean }>`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  padding: 0;
   margin: 0;
-  margin-left: ${(props) => (Number(props.indent) ?? 0) * 1.5}rem;
+  padding-left: ${(props) => (Number(props.indent) ?? 0) * 0.8}rem;
 `
 
 function prepareOptions(genes: Gene[]) {

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceSelector.tsx
@@ -1,63 +1,260 @@
+// noinspection JSUnusedLocalSymbols
+import type { Cds, Gene, Protein } from '_SchemaRoot'
+import { isEmpty } from 'lodash'
 import React, { useCallback, useMemo } from 'react'
-import { viewedGeneAtom } from 'src/state/seqViewSettings.state'
+import ReactSelect, { StylesConfig } from 'react-select'
+import { FilterOptionOption } from 'react-select/dist/declarations/src/filters'
+import type { FormatOptionLabelMeta } from 'react-select/dist/declarations/src/Select'
+import { Theme } from 'react-select/dist/declarations/src/types'
+import { Badge } from 'reactstrap'
 import styled from 'styled-components'
+import { viewedGeneAtom } from 'src/state/seqViewSettings.state'
+import { useRecoilState, useRecoilValue } from 'recoil'
 import { GENE_OPTION_NUC_SEQUENCE } from 'src/constants'
-import { useRecoilCallback, useRecoilValue } from 'recoil'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { cdsNamesAtom } from 'src/state/results.state'
+import { genesAtom } from 'src/state/results.state'
 
-const Select = styled.select`
-  text-align: center;
-  margin: auto;
-  border-radius: 3px;
-  height: 30px;
-  min-width: 150px;
-  text-align-last: center;
-`
+const menuPortalTarget = typeof document === 'object' ? document.body : null
+
+export interface Option {
+  value: string
+  color?: string
+  gene?: Gene
+  cds?: Cds
+  protein?: Protein
+  isDisabled?: boolean
+}
 
 export function SequenceSelector() {
-  const { t } = useTranslationSafe()
+  const genes = useRecoilValue(genesAtom)
+  const [viewedGene, setViewedGene] = useRecoilState(viewedGeneAtom)
 
-  const cdsNames = useRecoilValue(cdsNamesAtom)
+  const { options, defaultOption } = useMemo(() => {
+    return prepareOptions(genes)
+  }, [genes])
 
-  const viewedGene = useRecoilValue(viewedGeneAtom)
-  const onChangeGene = useRecoilCallback(
-    ({ set }) =>
-      (e: React.ChangeEvent<HTMLSelectElement>) => {
-        set(viewedGeneAtom, e.target.value)
-      },
-    [],
-  )
+  const option = useMemo((): Option => {
+    if (viewedGene === GENE_OPTION_NUC_SEQUENCE) {
+      return { value: GENE_OPTION_NUC_SEQUENCE }
+    }
+    return options.find((option) => option.cds?.name === viewedGene) ?? defaultOption
+  }, [defaultOption, options, viewedGene])
 
-  const getOptionText = useCallback(
-    (gene: string) => {
-      if (gene === GENE_OPTION_NUC_SEQUENCE) {
-        return t('Nucleotide sequence')
+  const onChange = useCallback(
+    (option: Option | null) => {
+      if (option?.value === GENE_OPTION_NUC_SEQUENCE) {
+        setViewedGene(GENE_OPTION_NUC_SEQUENCE)
       }
 
-      return t('Gene {{geneName}}', { geneName: gene })
+      if (option?.cds?.name) {
+        setViewedGene(option.cds?.name)
+      }
     },
-    [t],
+    [setViewedGene],
   )
 
-  const geneOptions = useMemo(() => {
-    return [GENE_OPTION_NUC_SEQUENCE, ...cdsNames].map((gene) => {
+  const filterOptions = useCallback((candidate: FilterOptionOption<Option>, searchTerm: string): boolean => {
+    if (candidate.value === GENE_OPTION_NUC_SEQUENCE) {
+      return true
+    }
+    if (!isEmpty(searchTerm)) {
       return (
-        <option key={gene} value={gene}>
-          {getOptionText(gene)}
-        </option>
+        (candidate.data.gene?.name?.split(' ').some((word) => word.includes(searchTerm)) ||
+          candidate.data.cds?.name?.split(' ').some((word) => word.includes(searchTerm)) ||
+          candidate.data.protein?.name?.split(' ').some((word) => word.includes(searchTerm))) ??
+        false
       )
-    })
-  }, [cdsNames, getOptionText])
+    }
+    return true
+  }, [])
+
+  const reactSelectTheme = useCallback((theme: Theme): Theme => {
+    return {
+      ...theme,
+      borderRadius: 2,
+      spacing: {
+        ...theme.spacing,
+        menuGutter: 0,
+      },
+      colors: {
+        ...theme.colors,
+      },
+    }
+  }, [])
+
+  const reactSelectStyles = useMemo((): StylesConfig<Option, false> => {
+    return {
+      menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+      menuList: (base) => ({ ...base, fontSize: '1rem' }),
+      option: (base) => ({ ...base, fontSize: '1rem' }),
+      singleValue: (base) => ({ ...base, fontSize: '1rem' }),
+    }
+  }, [])
 
   return (
-    <Select
-      name="sequence-view-gene-dropdown"
-      id="sequence-view-gene-dropdown"
-      onChange={onChangeGene}
-      value={viewedGene}
-    >
-      {geneOptions}
-    </Select>
+    <div className="d-flex w-100">
+      <InnerWrapper>
+        <ReactSelect
+          name="sequence-view-gene-dropdown"
+          options={options}
+          filterOption={filterOptions}
+          formatOptionLabel={OptionLabel}
+          isMulti={false}
+          value={option}
+          onChange={onChange}
+          menuPortalTarget={menuPortalTarget}
+          styles={reactSelectStyles}
+          theme={reactSelectTheme}
+          maxMenuHeight={500}
+        />
+      </InnerWrapper>
+    </div>
   )
+}
+
+const InnerWrapper = styled.div`
+  width: 100%;
+  min-width: 100px;
+  max-width: 300px;
+  margin: 0.5rem auto;
+`
+
+function OptionLabel(option: Option, meta: FormatOptionLabelMeta<Option>) {
+  if (option.gene && option.cds) {
+    return <OptionLabelGeneAndCds gene={option.gene} cds={option.cds} />
+  }
+
+  if (option.gene) {
+    return <OptionLabelGene gene={option.gene} />
+  }
+
+  if (option.cds) {
+    return <OptionLabelCds cds={option.cds} isMenu={meta.context === 'menu'} />
+  }
+
+  if (option.protein) {
+    return <OptionLabelProtein protein={option.protein} isMenu={meta.context === 'menu'} />
+  }
+
+  if (option.value === GENE_OPTION_NUC_SEQUENCE) {
+    return <OptionLabelFullGenome isMenu={meta.context === 'menu'} />
+  }
+
+  return null
+}
+
+function OptionLabelFullGenome({ isMenu: _ }: { isMenu?: boolean }) {
+  const { t } = useTranslationSafe()
+  return (
+    <Indent>
+      <Badge color="success" className="mr-1 px-2 py-1">
+        {t('Full genome')}
+      </Badge>
+    </Indent>
+  )
+}
+
+function OptionLabelGene({ gene }: { gene: Gene; isMenu?: boolean }) {
+  const { t } = useTranslationSafe()
+  return (
+    <Indent>
+      <Badge color="secondary" className="mr-1 px-2 py-1">
+        {t('Gene')}
+      </Badge>
+      <span className="text-body">{gene.name}</span>
+    </Indent>
+  )
+}
+
+function OptionLabelGeneAndCds({ gene }: { gene: Gene; cds: Cds; isMenu?: boolean }) {
+  const { t } = useTranslationSafe()
+  return (
+    <Indent>
+      <Badge className="mr-1 px-2 py-1">{t('Gene')}</Badge>
+      <Badge color="primary" className="mr-1">
+        {t('CDS')}
+      </Badge>
+      <span>{gene.name}</span>
+    </Indent>
+  )
+}
+
+function OptionLabelCds({ cds, isMenu = false }: { cds: Cds; isMenu?: boolean }) {
+  const { t } = useTranslationSafe()
+  return (
+    <Indent indent={isMenu && 1}>
+      <Badge color="primary" className="mr-1 px-2 py-1">
+        {t('CDS')}
+      </Badge>
+      <span>{cds.name}</span>
+    </Indent>
+  )
+}
+
+function OptionLabelProtein({ protein, isMenu = false }: { protein: Protein; isMenu?: boolean }) {
+  const { t } = useTranslationSafe()
+  return (
+    <Indent indent={isMenu && 2}>
+      <Badge className="mr-1">{t('Protein')}</Badge>
+      <span>{protein.name}</span>
+    </Indent>
+  )
+}
+
+// noinspection CssReplaceWithShorthandSafely
+const Indent = styled.div<{ indent?: number | boolean }>`
+  margin: 0;
+  margin-left: ${(props) => (Number(props.indent) ?? 0) * 1.5}rem;
+`
+
+function prepareOptions(genes: Gene[]) {
+  const options: Option[] = [{ value: GENE_OPTION_NUC_SEQUENCE }]
+
+  if (isEmpty(genes)) {
+    return { options, defaultOption: options[0] }
+  }
+
+  const defaultCds = genes[0].cdses[0]
+  let defaultOption: Option = {
+    value: defaultCds.name,
+    cds: defaultCds,
+  }
+
+  // eslint-disable-next-line no-loops/no-loops
+  for (const gene of genes) {
+    if (gene.cdses.length === 1) {
+      options.push({
+        value: `gene-${gene.name}`,
+        gene,
+        cds: gene.cdses[0],
+      })
+    } else {
+      options.push({
+        value: `gene-${gene.name}`,
+        gene,
+        isDisabled: true,
+      })
+
+      // eslint-disable-next-line no-loops/no-loops
+      for (const cds of gene.cdses) {
+        const option: Option = {
+          value: `cds-${cds.name}`,
+          cds,
+        }
+        defaultOption = option
+        options.push(option)
+
+        // eslint-disable-next-line no-loops/no-loops
+        for (const protein of cds.proteins) {
+          options.push({
+            value: `protein-${protein.name}`,
+            protein,
+            isDisabled: true,
+          })
+        }
+      }
+    }
+  }
+
+  return { options, defaultOption }
 }

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceSelector.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceSelector.tsx
@@ -13,6 +13,7 @@ import { useRecoilState, useRecoilValue } from 'recoil'
 import { GENE_OPTION_NUC_SEQUENCE } from 'src/constants'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { genesAtom } from 'src/state/results.state'
+import { ensureNumber } from 'src/helpers/number'
 
 const menuPortalTarget = typeof document === 'object' ? document.body : null
 
@@ -217,7 +218,7 @@ const Indent = styled.div<{ indent?: number | boolean }>`
   max-width: 100%;
   padding: 0;
   margin: 0;
-  padding-left: ${(props) => (Number(props.indent) ?? 0) * 0.8}rem;
+  padding-left: ${(props) => ensureNumber(props.indent) * 0.8}rem;
 `
 
 function prepareOptions(genes: Gene[]) {

--- a/packages_rs/nextclade-web/src/helpers/number.ts
+++ b/packages_rs/nextclade-web/src/helpers/number.ts
@@ -1,0 +1,6 @@
+export function ensureNumber(x?: boolean | number | null): number {
+  if (!x || typeof x === 'boolean') {
+    return 0
+  }
+  return x
+}


### PR DESCRIPTION
Each entry in the dropdown menu is now denoted with its feature type.

The menu now shows a hierarchy of gene-CDS relationships if a gene contains more than one CDS. Otherwise it's a flat list as before.

Currently, only CDS entries can be selected, because we don't have anything to show for other types of features. But in theory, any entry can be selected if needed.


We can use this new widget to display arbitrary trees of genetic features. For example, we can nest  proteins under CDSes.

More details can be displayed, e.g. frame, phase, length and boundaries of each feature etc.


