### PR TITLE
feat: improve cropping of extended seeds

### DIFF
--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -103,6 +103,7 @@ mod tests {
   fn ctx() -> Context {
     let params = AlignPairwiseParams {
       min_length: 3,
+      min_match_length: 10,
       ..AlignPairwiseParams::default()
     };
 

--- a/packages_rs/nextclade/src/align/seed_match2.rs
+++ b/packages_rs/nextclade/src/align/seed_match2.rs
@@ -477,7 +477,7 @@ mod tests {
 
   #[rustfmt::skip]
   #[rstest]
-  fn test_me() -> Result<(), Report> {
+  fn extends_seed_general_case() -> Result<(), Report> {
     //             0         1         2         3         4         5         6         7         8         9
     //             0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
     //                                                    |---------|

--- a/packages_rs/nextclade/src/align/seed_match2.rs
+++ b/packages_rs/nextclade/src/align/seed_match2.rs
@@ -10,6 +10,7 @@ use eyre::Report;
 use gcollections::ops::{Bounded, Intersection, IsEmpty, Union};
 use interval::interval_set::{IntervalSet, ToIntervalSet};
 use itertools::Itertools;
+use std::cmp::min;
 use std::collections::{BTreeMap, VecDeque};
 
 /// Copied from https://stackoverflow.com/a/75084739/7483211
@@ -109,21 +110,21 @@ impl SeedMatch2 {
       ..
     } = self.clone();
 
-    let ref_seq_len = ref_seq.len();
-    let qry_seq_len = qry_seq.len();
+    let max_length = min(ref_seq.len() - ref_pos, qry_seq.len() - qry_pos);
 
+    // vector of boolean indicating whether the large window_size position in the
+    // extension was matching or not.
     let mut mismatch_queue = VecDeque::from(vec![false; config.window_size]);
-
+    // counter to keep track of total number of mismatches in window
     let mut forward_mismatches = 0;
 
-    while forward_mismatches < config.allowed_mismatches
-      && ref_pos + length < ref_seq_len
-      && qry_pos + length < qry_seq_len
-    {
+    while forward_mismatches < config.allowed_mismatches && length < max_length {
+      // remove first position in queue, decrement mismatch counter in case of mismatch
       if mismatch_queue.pop_front().unwrap() {
         forward_mismatches = forward_mismatches.saturating_sub(1);
       }
 
+      // determine whether extension is match
       if ref_seq[ref_pos + length] != qry_seq[qry_pos + length] {
         forward_mismatches += 1;
         mismatch_queue.push_back(true);
@@ -134,10 +135,28 @@ impl SeedMatch2 {
       length += 1;
     }
 
+    // determine the longest stretch of matches in the window before extension stopped
+    // crop the extended seed at the end of the that stretch.
+    let mut crop = 0;
+    let mut longest_match_stretch = 0;
+    let mut current_match_stretch = 0;
+    for (pos, &mismatch) in mismatch_queue.iter().enumerate() {
+      if mismatch {
+        current_match_stretch = 0;
+      } else {
+        current_match_stretch += 1;
+      }
+      if current_match_stretch > longest_match_stretch {
+        longest_match_stretch = current_match_stretch;
+        crop = pos;
+      }
+    }
+    // reduce the length of the seed
+    length -= config.window_size - crop;
+
+    // repeat in other direction
     mismatch_queue = VecDeque::from(vec![false; config.window_size]);
-
     let mut backward_mismatches = 0;
-
     while backward_mismatches < config.allowed_mismatches && ref_pos > 0 && qry_pos > 0 {
       if mismatch_queue.pop_front().unwrap() {
         backward_mismatches = backward_mismatches.saturating_sub(1);
@@ -155,7 +174,24 @@ impl SeedMatch2 {
       length += 1;
     }
 
-    length = length.saturating_sub(2 * config.window_size);
+    let mut crop = 0;
+    let mut longest_match_stretch = 0;
+    let mut current_match_stretch = 0;
+    for (pos, &mismatch) in mismatch_queue.iter().enumerate() {
+      if mismatch {
+        current_match_stretch = 0;
+      } else {
+        current_match_stretch += 1;
+      }
+      if current_match_stretch > longest_match_stretch {
+        longest_match_stretch = current_match_stretch;
+        crop = pos;
+      }
+    }
+
+    length -= config.window_size - crop;
+    ref_pos += config.window_size - crop;
+    qry_pos += config.window_size - crop;
 
     SeedMatch2 {
       ref_pos,

--- a/packages_rs/nextclade/src/align/seed_match2.rs
+++ b/packages_rs/nextclade/src/align/seed_match2.rs
@@ -450,6 +450,13 @@ pub fn get_seed_matches2(
     .filter(|m| m.length > params.min_match_length)
     .collect_vec();
 
+  if matches.is_empty() {
+    return make_error!(
+      "Unable to align: seed alignment was unable to find any matches that were extendable to at least {} nucleotides.",
+      params.min_match_length
+    );
+  }
+
   let seed_matches = chain_seeds(&matches);
 
   let sum_of_seed_length: usize = seed_matches.iter().map(|sm| sm.length).sum();

--- a/packages_rs/nextclade/src/align/seed_match2.rs
+++ b/packages_rs/nextclade/src/align/seed_match2.rs
@@ -466,3 +466,32 @@ pub fn get_seed_matches2(
 
   Ok(seed_matches)
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::alphabet::nuc::to_nuc_seq;
+  use eyre::Report;
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  #[rustfmt::skip]
+  #[rstest]
+  fn test_me() -> Result<(), Report> {
+    //             0         1         2         3         4         5         6         7         8         9
+    //             0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+    //                                                    |---------|
+    let ref_seq = "CGCATCGCTGATCGTACGATCGTACTGGTACTGCACTCTAAAAAAAAAACGTGCTGACTGCACTGCATTTATACGATTCTCTCTTCCGACTGTCGACTG";
+    let qry_seq =    "TCGCTGATCGTACGATCCGTACTGGTACTGCACTCAAAAAAAAAAAGGTGCTGACTGCACTGCATTTATAGATTCTCTCTTCCGACTGTCGA";
+    //                                 |----------------------------------------------------|
+    //                012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+    //                0         1         2         3         4         5         6         7         8         9
+
+    let input    = SeedMatch2 { ref_pos: 40, qry_pos: 38, length: 10, offset: 0 };
+    let expected = SeedMatch2 { ref_pos: 20, qry_pos: 17, length: 52, offset: 0 };
+    let actual = input.extend_seed(&to_nuc_seq(qry_seq)?, &to_nuc_seq(ref_seq)?, &AlignPairwiseParams::default());
+
+    assert_eq!(expected, actual);
+    Ok(())
+  }
+}

--- a/packages_rs/nextclade/src/align/seed_match2.rs
+++ b/packages_rs/nextclade/src/align/seed_match2.rs
@@ -134,7 +134,6 @@ impl SeedMatch2 {
 
       length += 1;
     }
-
     // determine the longest stretch of matches in the window before extension stopped
     // crop the extended seed at the end of the that stretch.
     let mut crop = 0;
@@ -148,7 +147,7 @@ impl SeedMatch2 {
       }
       if current_match_stretch > longest_match_stretch {
         longest_match_stretch = current_match_stretch;
-        crop = pos;
+        crop = pos + 1;
       }
     }
     // reduce the length of the seed
@@ -185,7 +184,7 @@ impl SeedMatch2 {
       }
       if current_match_stretch > longest_match_stretch {
         longest_match_stretch = current_match_stretch;
-        crop = pos;
+        crop = pos + 1;
       }
     }
 
@@ -480,15 +479,15 @@ mod tests {
   fn extends_seed_general_case() -> Result<(), Report> {
     //             0         1         2         3         4         5         6         7         8         9
     //             0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-    //                                                    |---------|
+    //                                                     |-------|
     let ref_seq = "CGCATCGCTGATCGTACGATCGTACTGGTACTGCACTCTAAAAAAAAAACGTGCTGACTGCACTGCATTTATACGATTCTCTCTTCCGACTGTCGACTG";
     let qry_seq =    "TCGCTGATCGTACGATCCGTACTGGTACTGCACTCAAAAAAAAAAAGGTGCTGACTGCACTGCATTTATAGATTCTCTCTTCCGACTGTCGA";
     //                                 |----------------------------------------------------|
     //                012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
     //                0         1         2         3         4         5         6         7         8         9
 
-    let input    = SeedMatch2 { ref_pos: 40, qry_pos: 38, length: 10, offset: 0 };
-    let expected = SeedMatch2 { ref_pos: 20, qry_pos: 17, length: 52, offset: 0 };
+    let input    = SeedMatch2 { ref_pos: 40, qry_pos: 37, length: 8, offset: 0 };
+    let expected = SeedMatch2 { ref_pos: 20, qry_pos: 17, length: 53, offset: 0 };
     let actual = input.extend_seed(&to_nuc_seq(qry_seq)?, &to_nuc_seq(ref_seq)?, &AlignPairwiseParams::default());
 
     assert_eq!(expected, actual);


### PR DESCRIPTION
extend_seed now determines the longest matching stretch in the last window and will terminate the seed match after that stretch.

There is substantial duplication here for forward and backward extension with the only difference that in one case we are incrementing `length` and looking up `ref_seq[ref_pos + length]` and  `qry_seq[qry_pos + length]` and in the other case `ref_seq[ref_pos - 1]` and  `qry_seq[qry_pos - 1]`.

as for tests, this function can be readily tested. for an input:

```
seed = {ref_pos: 40, qry_pos: 38; length: 10, }
//                                                |---------|
ref_seq = "CGCATCGCTGATCGTACGATCGTACTGGTACTGCACTCTAAAAAAAAAACGTGCTGACTGCACTGCATTTATACGATTCTCTCTTCCGACTGTCGACTG";
qry_seq =    "TCGCTGATCGTACGATCCGTACTGGTACTGCACTCAAAAAAAAAAAGGTGCTGACTGCACTGCATTTATAGATTCTCTCTTCCGACTGTCGA";
//                             |----------------------------------------------------|
extend_seed = {length: 52, qry_pos: 17, ref_pos: 20}
```


