### PR TITLE
fix: ensure tree output is deterministic

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -298,6 +298,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
   });
 
   if let Some(output_tree) = output_tree {
+    outputs.sort_by_key(|o| o.index);
     tree_attach_new_nodes_in_place(&mut tree, &outputs);
     json_write(output_tree, &tree)?;
   }

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -298,7 +298,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
   });
 
   if let Some(output_tree) = output_tree {
-    outputs.sort_by_key(|o| o.index);
+    outputs.sort_by_key(|o| (o.private_nuc_mutations.total_private_substitutions, o.index));
     tree_attach_new_nodes_in_place(&mut tree, &outputs);
     json_write(output_tree, &tree)?;
   }


### PR DESCRIPTION
Currently due to thread scheduling uncertainty, analysis outputs can be stored in unknown order. This affects tree construction in unexpected ways.

Here I ensure that outputs are sorted according to the index of the corresponding input fasta entry before they enter tree construction. This has performance penalty, but ensures deterministic outputs.

