### PR TITLE
fix: flag to align gaps left

### DIFF
--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -88,6 +88,7 @@ mod tests {
   // rstest fixtures are passed by value
   use super::*;
   use crate::align::gap_open::{get_gap_open_close_scores_codon_aware, GapScoreMap};
+  use crate::align::params::GapAlignmentSide;
   use crate::alphabet::nuc::{from_nuc_seq, to_nuc_seq};
   use crate::gene::gene_map::GeneMap;
   use eyre::Report;
@@ -103,6 +104,8 @@ mod tests {
   fn ctx() -> Context {
     let params = AlignPairwiseParams {
       min_length: 3,
+      penalty_gap_open: 5,
+      gap_alignment_side: GapAlignmentSide::Right,
       ..AlignPairwiseParams::default()
     };
 
@@ -301,11 +304,11 @@ mod tests {
   }
 
   #[rstest]
-  fn aligns_ambiguous_gap_placing(ctx: Context) -> Result<(), Report> {
+  fn aligns_ambiguous_gap_placing_right(ctx: Context) -> Result<(), Report> {
     #[rustfmt::skip]
     let qry_seq = to_nuc_seq("ACATCTTC"   )?;
-    let ref_seq = to_nuc_seq("ACATATACTTC")?;
-    let qry_aln = to_nuc_seq("ACAT---CTTC")?;
+    let ref_seq = to_nuc_seq("ACATAGTCTTC")?;
+    let qry_aln = to_nuc_seq("ACA---TCTTC")?;
 
     let result = align_nuc(0, "", &qry_seq, &ref_seq, &ctx.gap_open_close, &ctx.params)?;
 
@@ -315,11 +318,32 @@ mod tests {
   }
 
   #[rstest]
+  fn aligns_ambiguous_gap_placing_left(ctx: Context) -> Result<(), Report> {
+    #[rustfmt::skip]
+    let qry_seq = to_nuc_seq("ACATCTTC"   )?;
+    let ref_seq = to_nuc_seq("ACATAGTCTTC")?;
+    let qry_aln = to_nuc_seq("ACAT---CTTC")?;
+
+    let params = AlignPairwiseParams {
+      min_length: 3,
+      penalty_gap_open: 5,
+      gap_alignment_side: GapAlignmentSide::Left,
+      ..AlignPairwiseParams::default()
+    };
+
+    let result = align_nuc(0, "", &qry_seq, &ref_seq, &ctx.gap_open_close, &params)?;
+
+    assert_eq!(from_nuc_seq(&ref_seq), from_nuc_seq(&result.ref_seq));
+    assert_eq!(from_nuc_seq(&qry_aln), from_nuc_seq(&result.qry_seq));
+    Ok(())
+  }
+
+  #[rstest]
   fn aligns_ambiguous_gap_placing_case_reversed(ctx: Context) -> Result<(), Report> {
     #[rustfmt::skip]
-    let qry_seq = to_nuc_seq("ACATATACTTG")?;
+    let qry_seq = to_nuc_seq("ACATAGTCTTG")?;
     let ref_seq = to_nuc_seq("ACATCTTG")?;
-    let ref_aln = to_nuc_seq("ACAT---CTTG")?;
+    let ref_aln = to_nuc_seq("ACA---TCTTG")?;
 
     let result = align_nuc(0, "", &qry_seq, &ref_seq, &ctx.gap_open_close, &ctx.params)?;
 

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -139,14 +139,14 @@ pub fn score_matrix<T: Letter<T>>(
           if r_gap_extend >= r_gap_open && qpos > stripes[ri].begin + 1 {
             // extension better than opening (and ^ extension allowed positionally)
             tmp_score = r_gap_extend;
-            tmp_path = REF_GAP_EXTEND;
+            tmp_path += REF_GAP_EXTEND;
           } else {
             // opening better than extension
             tmp_score = r_gap_open;
           }
           // could factor out tmp_score, replacing with ref_gaps but maybe less readable
           ref_gaps = tmp_score;
-          if score + left_align < tmp_score {
+          if score - left_align < tmp_score {
             score = tmp_score;
             origin = REF_GAP_MATRIX;
           }
@@ -172,7 +172,7 @@ pub fn score_matrix<T: Letter<T>>(
             tmp_score = q_gap_open;
           }
           qry_gaps[qpos] = tmp_score;
-          if score + left_align < tmp_score {
+          if score - left_align < tmp_score {
             score = tmp_score;
             origin = QRY_GAP_MATRIX;
           }
@@ -186,7 +186,6 @@ pub fn score_matrix<T: Letter<T>>(
       scores[(ri, qpos)] = score;
     }
   }
-
   ScoreMatrixResult { scores, paths }
 }
 


### PR DESCRIPTION
Historically, nextalign has aligned sequence around gaps on the right when there were equivalent gap placements and we introduced a flag to align left/right. The flag amounts to following a "match" or "gap" path first and algorithmically can be dealt with a `<` vs `<=` comparison of scores when evaluating options (pick first or last). Alas, this switch was not correctly implemented and likely resulted in suboptimal alignments for `--gap-alignment-side left`.

