### PR TITLE
fix: avoid crashes when there is no parent node

### DIFF
--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -172,9 +172,12 @@ pub fn finetune_nearest_node(
           )
         })?;
       }
-    } else if nearest_node.is_leaf() && nearest_node.payload().tmp.private_mutations.nuc_subs.is_empty() {
+    } else if nearest_node.is_leaf()
+      && !nearest_node.is_root()
+      && nearest_node.payload().tmp.private_mutations.nuc_subs.is_empty()
+    {
       // In this case, a leaf identical to its parent in terms of nuc_subs. this happens when we add
-      // auxillary nodes.
+      // auxiliary nodes.
 
       // Mutation subtraction is still necessary because there might be shared mutations even if there are no `nuc_subs`.
       // FIXME: This relies on `is_leaf`. In that case, there is only one entry in `shared_muts_neighbors`

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -271,7 +271,7 @@ pub fn knit_into_graph(
     muts_common_branch,
     muts_target_node,
     muts_new_node,
-  } = if params.without_greedy_tree_builder {
+  } = if params.without_greedy_tree_builder || target_node.is_root() {
     KnitMuts {
       muts_common_branch: target_node_auspice.tmp.private_mutations.clone(), // Keep target node muts unchanged.
       muts_target_node: PrivateMutationsMinimal::default(),                  // Don't subtract any shared mutations.


### PR DESCRIPTION
Addresses part of: https://github.com/nextstrain/nextclade/issues/1207

In corner cases, when a tree is small, consists of a single node or entirely empty, Nextclade would crash, because there were not enough guards when fetching non-existing parent nodes from the graph. In this case, once a root is reached, Nextclade would crash. This PR adds additional checks to prevent this from happening.

