### PR TITLE
Feat/avoid matches with n x

### DIFF
--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -359,6 +359,20 @@ mod tests {
   }
 
   #[rstest]
+  fn preferentially_gap_unknown(ctx: Context) -> Result<(), Report> {
+    #[rustfmt::skip]
+    let ref_seq = to_nuc_seq("ACATATACTTG")?;
+    let qry_seq = to_nuc_seq("ACATNATACTTG")?;
+    let ref_aln = to_nuc_seq("ACAT-ATACTTG")?;
+
+    let result = align_nuc(0, "", &qry_seq, &ref_seq, &ctx.gap_open_close, &ctx.params)?;
+
+    assert_eq!(from_nuc_seq(&ref_aln), from_nuc_seq(&result.ref_seq));
+    assert_eq!(from_nuc_seq(&qry_seq), from_nuc_seq(&result.qry_seq));
+    Ok(())
+  }
+
+  #[rstest]
   #[rustfmt::skip]
   fn general_case(ctx: Context) -> Result<(), Report> {
     let ref_seq = to_nuc_seq("CTTGGAGGTTCCGTGGCTAGATAACAGAACATTCTTGGAATGCTGATCTTTATAAGCTCATGCGACACTTCGCATGGTGAGCCTTTGT"       )?;

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -115,7 +115,11 @@ pub fn score_matrix<T: Letter<T>>(
         if qpos > stripes[ri - 1].begin && qpos - 1 < stripes[ri - 1].end {
           // ^ If stripes allow to move up diagonally to upper left
           if T::lookup_match_score(qry_seq[qpos - 1], ref_seq[ri - 1]) > 0 {
-            score = scores[(ri - 1, qpos - 1)] + params.score_match;
+            score = if qry_seq[qpos - 1].is_unknown() || ref_seq[ri - 1].is_unknown() {
+              scores[(ri - 1, qpos - 1)] + params.score_match - 1
+            } else {
+              scores[(ri - 1, qpos - 1)] + params.score_match
+            };
           } else {
             score = scores[(ri - 1, qpos - 1)] - params.penalty_mismatch;
           };

--- a/packages_rs/nextclade/src/align/score_matrix.rs
+++ b/packages_rs/nextclade/src/align/score_matrix.rs
@@ -114,14 +114,14 @@ pub fn score_matrix<T: Letter<T>>(
         // TODO: Double bounds check -> wasteful, make better
         if qpos > stripes[ri - 1].begin && qpos - 1 < stripes[ri - 1].end {
           // ^ If stripes allow to move up diagonally to upper left
-          if T::lookup_match_score(qry_seq[qpos - 1], ref_seq[ri - 1]) > 0 {
-            score = if qry_seq[qpos - 1].is_unknown() || ref_seq[ri - 1].is_unknown() {
-              scores[(ri - 1, qpos - 1)] + params.score_match - 1
-            } else {
-              scores[(ri - 1, qpos - 1)] + params.score_match
-            };
+          score = if qry_seq[qpos - 1].is_unknown() || ref_seq[ri - 1].is_unknown() {
+            // no need to look-up match score since unknown matches with everything.
+            // reduce match score by 1 to de-prioritize matches with unknown states.
+            scores[(ri - 1, qpos - 1)] + params.score_match - 1
+          } else if T::lookup_match_score(qry_seq[qpos - 1], ref_seq[ri - 1]) > 0 {
+            scores[(ri - 1, qpos - 1)] + params.score_match
           } else {
-            score = scores[(ri - 1, qpos - 1)] - params.penalty_mismatch;
+            scores[(ri - 1, qpos - 1)] - params.penalty_mismatch
           };
           origin = MATCH;
         }


### PR DESCRIPTION
if there is an insertion of `N` or `X` in the sequence, these match
with any other sequence are often preferentially aligned while bona
fide sequence ends up in indels. this commit avoids this by reducing
match score for `N` and `X` by the smallest possible amount == 1



super-seeds [PR #848](https://github.com/nextstrain/nextclade/pull/848/files)