### PR TITLE
fix: don't consider ambiguous nucs for reversions

### DIFF
--- a/packages_rs/nextclade/src/analyze/is_sequenced.rs
+++ b/packages_rs/nextclade/src/analyze/is_sequenced.rs
@@ -1,3 +1,4 @@
+use crate::alphabet::letter::Letter;
 use crate::analyze::letter_ranges::{GeneAaRange, NucRange};
 use crate::coord::position::{AaRefPosition, NucRefGlobalPosition};
 use crate::coord::range::{AaRefRange, NucRefGlobalRange};
@@ -10,6 +11,13 @@ pub fn is_nuc_sequenced(pos: NucRefGlobalPosition, qry_missing: &[NucRange], aln
   let is_missing = qry_missing.iter().any(|missing| missing.contains_pos(pos));
   let within_alignment = aln_range.contains(pos);
   within_alignment && !is_missing
+}
+
+/// Decides whether a given position in nucleotide sequence contains n.
+pub fn is_nuc_non_acgtn(pos: NucRefGlobalPosition, non_acgtns: &[NucRange]) -> bool {
+  non_acgtns
+    .iter()
+    .any(|NucRange { range, letter }| range.contains(pos) && !letter.is_gap())
 }
 
 /// Decides whether a given position in peptide is considered "sequenced".

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -156,6 +156,7 @@ pub fn nextclade_run_one(
     &missing,
     &alignment_range,
     ref_seq,
+    &non_acgtns,
     virus_properties,
   );
 


### PR DESCRIPTION
Reported on Slack: https://neherlab.slack.com/archives/C015PFP5V44/p1690300205470069

There is a problem when searching for reversions.

Setup:

```
Nuc pos: 22770 (1-based)
Ref:  G
Node: A
Qry:  R
```

When searching for mutations, `R` is not considered a substitution. So when private mutations are searched it is not considered a mutated position. Next, when searching reversions, we see that the position is not mutated, but sequenced, so it is marked as a reversion.

This is wrong, because we cannot tell whether reversion have taken place or not, due to ambiguity.

Here I exclude all query positions with non-ACGTN from consideration.

Example bugged:

https://clades.nextstrain.org/?dataset-name=sars-cov-2&input-tree=https://nextstrain.org/charon/getDataset?prefix=staging/nextclade/sars-cov-2&input-fasta=https%3A%2F%2Flapis.cov-spectrum.org%2Fopen%2Fv1%2Fsample%2Ffasta%3ForderBy%3Drandom%26limit%3D10000%26dateFrom%3D2023-01-23%26dateTo%3D2023-07-18%26nucMutations%3DC355T%26nextcladePangoLineage%3DEG.7%2A%26host%3DHomo%2Bsapiens%26downloadAsFile%3Dtrue

Example fixed:

https://nextclade-git-fix-ambig-reversions-nextstrain.vercel.app//?dataset-name=sars-cov-2&input-tree=https://nextstrain.org/charon/getDataset?prefix=staging/nextclade/sars-cov-2&input-fasta=https%3A%2F%2Flapis.cov-spectrum.org%2Fopen%2Fv1%2Fsample%2Ffasta%3ForderBy%3Drandom%26limit%3D10000%26dateFrom%3D2023-01-23%26dateTo%3D2023-07-18%26nucMutations%3DC355T%26nextcladePangoLineage%3DEG.7%2A%26host%3DHomo%2Bsapiens%26downloadAsFile%3Dtrue

(examples are only valid as long as the files are on third-party services are the same as when I ran them)

