### PR TITLE
Fix/subs dels interaction

### DIFF
--- a/packages_rs/nextclade/src/analyze/divergence.rs
+++ b/packages_rs/nextclade/src/analyze/divergence.rs
@@ -1,21 +1,20 @@
-use crate::alphabet::letter::Letter;
 use crate::analyze::nuc_sub::NucSub;
 use crate::tree::tree::DivergenceUnits;
+
+/// Calculate number of nuc muts, only considering ACGT characters
+pub fn count_nuc_muts(nuc_muts: &[NucSub]) -> usize {
+  nuc_muts
+    .iter()
+    .filter(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt())
+    .count()
+}
 
 pub fn calculate_branch_length(
   private_mutations: &[NucSub],
   divergence_units: DivergenceUnits,
   ref_seq_len: usize,
 ) -> f64 {
-  // divergence is just number of substitutions possibly normalized by ref_seq_len
-
-  // FIXME: this filtering probably should not be here. Private "substitutions" (the parameter name says
-  //   `private_mutations`, but outside of this function this is called `private_substitutions`) should not contain
-  //   anything that's being filtered out here.
-  let mut this_div = private_mutations
-    .iter()
-    .filter(|m| !m.ref_nuc.is_gap() && m.qry_nuc.is_acgt())
-    .count() as f64;
+  let mut this_div = count_nuc_muts(private_mutations) as f64;
 
   // If divergence is measured per site, divide by the length of reference sequence.
   // The unit of measurement is deduced from what's already is used in the reference tree nodes.

--- a/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
@@ -31,6 +31,16 @@ impl BranchMutations {
         .collect(),
     }
   }
+
+  /// Calculate number of nuc muts, only considering ACGT characters
+  #[must_use]
+  pub fn n_nuc_muts(&self) -> usize {
+    self
+      .nuc_muts
+      .iter()
+      .filter(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt())
+      .count()
+  }
 }
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Debug)]

--- a/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeMap, BTreeSet};
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct PrivateMutationsMinimal {
   pub nuc_subs: Vec<NucSub>,
-  pub nuc_dels: Vec<NucDel>,
   pub aa_muts: BTreeMap<String, Vec<AaSub>>,
 }
 
@@ -25,7 +24,6 @@ impl PrivateMutationsMinimal {
   pub fn invert(&self) -> PrivateMutationsMinimal {
     PrivateMutationsMinimal {
       nuc_subs: self.nuc_subs.iter().map(NucSub::invert).collect(),
-      nuc_dels: self.nuc_dels.clone(),
       aa_muts: self
         .aa_muts
         .iter()

--- a/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct PrivateMutationsMinimal {
-  pub nuc_subs: Vec<NucSub>,
+  pub nuc_muts: Vec<NucSub>,
   pub aa_muts: BTreeMap<String, Vec<AaSub>>,
 }
 
@@ -23,7 +23,7 @@ impl PrivateMutationsMinimal {
   #[must_use]
   pub fn invert(&self) -> PrivateMutationsMinimal {
     PrivateMutationsMinimal {
-      nuc_subs: self.nuc_subs.iter().map(NucSub::invert).collect(),
+      nuc_muts: self.nuc_muts.iter().map(NucSub::invert).collect(),
       aa_muts: self
         .aa_muts
         .iter()

--- a/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
@@ -1,6 +1,7 @@
 use crate::alphabet::letter::Letter;
 use crate::alphabet::nuc::Nuc;
 use crate::analyze::aa_sub::AaSub;
+use crate::analyze::divergence::count_nuc_muts;
 use crate::analyze::is_sequenced::{is_nuc_non_acgtn, is_nuc_sequenced};
 use crate::analyze::letter_ranges::NucRange;
 use crate::analyze::nuc_del::{NucDel, NucDelRange};
@@ -30,16 +31,6 @@ impl BranchMutations {
         .map(|(gene, subs)| (gene.clone(), subs.iter().map(AaSub::invert).collect()))
         .collect(),
     }
-  }
-
-  /// Calculate number of nuc muts, only considering ACGT characters
-  #[must_use]
-  pub fn n_nuc_muts(&self) -> usize {
-    self
-      .nuc_muts
-      .iter()
-      .filter(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt())
-      .count()
   }
 }
 

--- a/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
@@ -14,15 +14,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
-pub struct PrivateMutationsMinimal {
+pub struct BranchMutations {
   pub nuc_muts: Vec<NucSub>,
   pub aa_muts: BTreeMap<String, Vec<AaSub>>,
 }
 
-impl PrivateMutationsMinimal {
+impl BranchMutations {
   #[must_use]
-  pub fn invert(&self) -> PrivateMutationsMinimal {
-    PrivateMutationsMinimal {
+  pub fn invert(&self) -> BranchMutations {
+    BranchMutations {
       nuc_muts: self.nuc_muts.iter().map(NucSub::invert).collect(),
       aa_muts: self
         .aa_muts

--- a/packages_rs/nextclade/src/tree/split_muts.rs
+++ b/packages_rs/nextclade/src/tree/split_muts.rs
@@ -27,7 +27,7 @@ pub fn split_muts(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinima
     left: subs_left,
     shared: subs_shared,
     right: subs_right,
-  } = split_3_way(&left.nuc_subs, &right.nuc_subs).wrap_err("When splitting private nucleotide substitutions")?;
+  } = split_3_way(&left.nuc_muts, &right.nuc_muts).wrap_err("When splitting private nucleotide substitutions")?;
 
   let SplitAaMutsResult {
     aa_muts_left,
@@ -37,15 +37,15 @@ pub fn split_muts(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinima
 
   Ok(SplitMutsResult {
     left: PrivateMutationsMinimal {
-      nuc_subs: subs_left,
+      nuc_muts: subs_left,
       aa_muts: aa_muts_left,
     },
     shared: PrivateMutationsMinimal {
-      nuc_subs: subs_shared,
+      nuc_muts: subs_shared,
       aa_muts: aa_muts_shared,
     },
     right: PrivateMutationsMinimal {
-      nuc_subs: subs_right,
+      nuc_muts: subs_right,
       aa_muts: aa_muts_right,
     },
   })
@@ -163,7 +163,7 @@ pub fn union_of_muts(
   right: &PrivateMutationsMinimal,
 ) -> Result<PrivateMutationsMinimal, Report> {
   Ok(PrivateMutationsMinimal {
-    nuc_subs: union(&left.nuc_subs, &right.nuc_subs)
+    nuc_muts: union(&left.nuc_muts, &right.nuc_muts)
       .wrap_err("When calculating union of private nucleotide substitutions")?,
     aa_muts: union_of_aa_muts(&left.aa_muts, &right.aa_muts)
       .wrap_err("When calculating union of private aminoacid mutations")?,
@@ -249,7 +249,7 @@ pub fn difference_of_muts(
   right: &PrivateMutationsMinimal,
 ) -> Result<PrivateMutationsMinimal, Report> {
   Ok(PrivateMutationsMinimal {
-    nuc_subs: difference(&left.nuc_subs, &right.nuc_subs)
+    nuc_muts: difference(&left.nuc_muts, &right.nuc_muts)
       .wrap_err("When calculating union of private nucleotide substitutions")?,
     aa_muts: difference_of_aa_muts(&left.aa_muts, &right.aa_muts)
       .wrap_err("When calculating union of private aminoacid mutations")?,

--- a/packages_rs/nextclade/src/tree/split_muts.rs
+++ b/packages_rs/nextclade/src/tree/split_muts.rs
@@ -29,12 +29,6 @@ pub fn split_muts(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinima
     right: subs_right,
   } = split_3_way(&left.nuc_subs, &right.nuc_subs).wrap_err("When splitting private nucleotide substitutions")?;
 
-  let Split3WayResult {
-    left: dels_left,
-    shared: dels_shared,
-    right: dels_right,
-  } = split_3_way(&left.nuc_dels, &right.nuc_dels).wrap_err("When splitting private nucleotide deletions")?;
-
   let SplitAaMutsResult {
     aa_muts_left,
     aa_muts_shared,
@@ -44,17 +38,14 @@ pub fn split_muts(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinima
   Ok(SplitMutsResult {
     left: PrivateMutationsMinimal {
       nuc_subs: subs_left,
-      nuc_dels: dels_left,
       aa_muts: aa_muts_left,
     },
     shared: PrivateMutationsMinimal {
       nuc_subs: subs_shared,
-      nuc_dels: dels_shared,
       aa_muts: aa_muts_shared,
     },
     right: PrivateMutationsMinimal {
       nuc_subs: subs_right,
-      nuc_dels: dels_right,
       aa_muts: aa_muts_right,
     },
   })
@@ -174,8 +165,6 @@ pub fn union_of_muts(
   Ok(PrivateMutationsMinimal {
     nuc_subs: union(&left.nuc_subs, &right.nuc_subs)
       .wrap_err("When calculating union of private nucleotide substitutions")?,
-    nuc_dels: union(&left.nuc_dels, &right.nuc_dels)
-      .wrap_err("When calculating union of private nucleotide deletions")?,
     aa_muts: union_of_aa_muts(&left.aa_muts, &right.aa_muts)
       .wrap_err("When calculating union of private aminoacid mutations")?,
   })
@@ -262,8 +251,6 @@ pub fn difference_of_muts(
   Ok(PrivateMutationsMinimal {
     nuc_subs: difference(&left.nuc_subs, &right.nuc_subs)
       .wrap_err("When calculating union of private nucleotide substitutions")?,
-    nuc_dels: difference(&left.nuc_dels, &right.nuc_dels)
-      .wrap_err("When calculating union of private nucleotide deletions")?,
     aa_muts: difference_of_aa_muts(&left.aa_muts, &right.aa_muts)
       .wrap_err("When calculating union of private aminoacid mutations")?,
   })

--- a/packages_rs/nextclade/src/tree/split_muts.rs
+++ b/packages_rs/nextclade/src/tree/split_muts.rs
@@ -1,7 +1,7 @@
 use crate::alphabet::letter::Letter;
 use crate::analyze::aa_sub::AaSub;
 use crate::analyze::abstract_mutation::{AbstractMutation, MutParams};
-use crate::analyze::find_private_nuc_mutations::PrivateMutationsMinimal;
+use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::coord::position::PositionLike;
 use crate::make_internal_error;
 use eyre::{Report, WrapErr};
@@ -13,16 +13,16 @@ use std::hash::Hash;
 
 #[derive(Debug, Clone)]
 pub struct SplitMutsResult {
-  pub left: PrivateMutationsMinimal,
-  pub shared: PrivateMutationsMinimal,
-  pub right: PrivateMutationsMinimal,
+  pub left: BranchMutations,
+  pub shared: BranchMutations,
+  pub right: BranchMutations,
 }
 
 /// Splits 2 sets of mutations (left and right), with respect to their positions, into 3 subsets:
 ///  - shared: mutations contained in both sets
 ///  - left: mutations contained only in the left set
 ///  - right: mutations contained only in the right set
-pub fn split_muts(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinimal) -> Result<SplitMutsResult, Report> {
+pub fn split_muts(left: &BranchMutations, right: &BranchMutations) -> Result<SplitMutsResult, Report> {
   let Split3WayResult {
     left: subs_left,
     shared: subs_shared,
@@ -36,15 +36,15 @@ pub fn split_muts(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinima
   } = split_aa_muts(&left.aa_muts, &right.aa_muts).wrap_err("When splitting private aminoacid mutations")?;
 
   Ok(SplitMutsResult {
-    left: PrivateMutationsMinimal {
+    left: BranchMutations {
       nuc_muts: subs_left,
       aa_muts: aa_muts_left,
     },
-    shared: PrivateMutationsMinimal {
+    shared: BranchMutations {
       nuc_muts: subs_shared,
       aa_muts: aa_muts_shared,
     },
-    right: PrivateMutationsMinimal {
+    right: BranchMutations {
       nuc_muts: subs_right,
       aa_muts: aa_muts_right,
     },
@@ -158,11 +158,8 @@ where
 }
 
 /// Calculates set-union of 2 sets of mutations, with respect to their positions.
-pub fn union_of_muts(
-  left: &PrivateMutationsMinimal,
-  right: &PrivateMutationsMinimal,
-) -> Result<PrivateMutationsMinimal, Report> {
-  Ok(PrivateMutationsMinimal {
+pub fn union_of_muts(left: &BranchMutations, right: &BranchMutations) -> Result<BranchMutations, Report> {
+  Ok(BranchMutations {
     nuc_muts: union(&left.nuc_muts, &right.nuc_muts)
       .wrap_err("When calculating union of private nucleotide substitutions")?,
     aa_muts: union_of_aa_muts(&left.aa_muts, &right.aa_muts)
@@ -244,11 +241,8 @@ where
 }
 
 /// Calculates set-difference of 2 sets of mutations, with respect to their positions.
-pub fn difference_of_muts(
-  left: &PrivateMutationsMinimal,
-  right: &PrivateMutationsMinimal,
-) -> Result<PrivateMutationsMinimal, Report> {
-  Ok(PrivateMutationsMinimal {
+pub fn difference_of_muts(left: &BranchMutations, right: &BranchMutations) -> Result<BranchMutations, Report> {
+  Ok(BranchMutations {
     nuc_muts: difference(&left.nuc_muts, &right.nuc_muts)
       .wrap_err("When calculating union of private nucleotide substitutions")?,
     aa_muts: difference_of_aa_muts(&left.aa_muts, &right.aa_muts)

--- a/packages_rs/nextclade/src/tree/split_muts2.rs
+++ b/packages_rs/nextclade/src/tree/split_muts2.rs
@@ -17,32 +17,32 @@ pub fn split_muts2(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinim
   let mut subs_right = Vec::<NucSub>::new();
   let mut i = 0;
   let mut j = 0;
-  while (i < left.nuc_subs.len()) && (j < right.nuc_subs.len()) {
-    if left.nuc_subs[i].pos == right.nuc_subs[j].pos {
+  while (i < left.nuc_muts.len()) && (j < right.nuc_muts.len()) {
+    if left.nuc_muts[i].pos == right.nuc_muts[j].pos {
       // Position is also mutated in node
-      if left.nuc_subs[i].ref_nuc == right.nuc_subs[j].ref_nuc && left.nuc_subs[i].qry_nuc == right.nuc_subs[j].qry_nuc
+      if left.nuc_muts[i].ref_nuc == right.nuc_muts[j].ref_nuc && left.nuc_muts[i].qry_nuc == right.nuc_muts[j].qry_nuc
       {
-        subs_shared.push(left.nuc_subs[i].clone()); // the exact mutation is shared between node and seq
+        subs_shared.push(left.nuc_muts[i].clone()); // the exact mutation is shared between node and seq
       } else {
-        subs_left.push(left.nuc_subs[i].clone());
-        subs_right.push(right.nuc_subs[j].clone());
+        subs_left.push(left.nuc_muts[i].clone());
+        subs_right.push(right.nuc_muts[j].clone());
       }
       i += 1;
       j += 1;
-    } else if left.nuc_subs[i].pos < right.nuc_subs[j].pos {
-      subs_left.push(left.nuc_subs[i].clone());
+    } else if left.nuc_muts[i].pos < right.nuc_muts[j].pos {
+      subs_left.push(left.nuc_muts[i].clone());
       i += 1;
     } else {
-      subs_right.push(right.nuc_subs[j].clone());
+      subs_right.push(right.nuc_muts[j].clone());
       j += 1;
     }
   }
-  while i < left.nuc_subs.len() {
-    subs_left.push(left.nuc_subs[i].clone());
+  while i < left.nuc_muts.len() {
+    subs_left.push(left.nuc_muts[i].clone());
     i += 1;
   }
-  while j < right.nuc_subs.len() {
-    subs_right.push(right.nuc_subs[j].clone());
+  while j < right.nuc_muts.len() {
+    subs_right.push(right.nuc_muts[j].clone());
     j += 1;
   }
 
@@ -119,15 +119,15 @@ pub fn split_muts2(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinim
 
   SplitMutsResult {
     left: PrivateMutationsMinimal {
-      nuc_subs: subs_left,
+      nuc_muts: subs_left,
       aa_muts: aa_subs_left,
     },
     shared: PrivateMutationsMinimal {
-      nuc_subs: subs_shared,
+      nuc_muts: subs_shared,
       aa_muts: aa_subs_shared,
     },
     right: PrivateMutationsMinimal {
-      nuc_subs: subs_right,
+      nuc_muts: subs_right,
       aa_muts: aa_subs_right,
     },
   }

--- a/packages_rs/nextclade/src/tree/split_muts2.rs
+++ b/packages_rs/nextclade/src/tree/split_muts2.rs
@@ -48,37 +48,6 @@ pub fn split_muts2(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinim
 
   ////////////////////////////////////////////////////////////////////////
 
-  let mut i = 0;
-  let mut j = 0;
-  let mut dels_shared = Vec::<NucDel>::new();
-  let mut dels_left = Vec::<NucDel>::new();
-  let mut dels_right = Vec::<NucDel>::new();
-
-  while (i < left.nuc_dels.len()) && (j < right.nuc_dels.len()) {
-    if left.nuc_dels[i].pos == right.nuc_dels[j].pos {
-      // Position is also a deletion in node
-      dels_shared.push(left.nuc_dels[i].clone()); // the exact mutation is shared between node and seq
-      i += 1;
-      j += 1;
-    } else if left.nuc_dels[i].pos < right.nuc_dels[j].pos {
-      dels_left.push(left.nuc_dels[i].clone());
-      i += 1;
-    } else {
-      dels_right.push(right.nuc_dels[j].clone());
-      j += 1;
-    }
-  }
-  while i < left.nuc_dels.len() {
-    dels_left.push(left.nuc_dels[i].clone());
-    i += 1;
-  }
-  while j < right.nuc_dels.len() {
-    dels_right.push(right.nuc_dels[j].clone());
-    j += 1;
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
   let mut aa_subs_shared = BTreeMap::<String, Vec<AaSub>>::new();
   let mut aa_subs_left = BTreeMap::<String, Vec<AaSub>>::new();
   let mut aa_subs_right = BTreeMap::<String, Vec<AaSub>>::new();
@@ -151,17 +120,14 @@ pub fn split_muts2(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinim
   SplitMutsResult {
     left: PrivateMutationsMinimal {
       nuc_subs: subs_left,
-      nuc_dels: dels_left,
       aa_muts: aa_subs_left,
     },
     shared: PrivateMutationsMinimal {
       nuc_subs: subs_shared,
-      nuc_dels: dels_shared,
       aa_muts: aa_subs_shared,
     },
     right: PrivateMutationsMinimal {
       nuc_subs: subs_right,
-      nuc_dels: dels_right,
       aa_muts: aa_subs_right,
     },
   }

--- a/packages_rs/nextclade/src/tree/split_muts2.rs
+++ b/packages_rs/nextclade/src/tree/split_muts2.rs
@@ -1,5 +1,5 @@
 use crate::analyze::aa_sub::AaSub;
-use crate::analyze::find_private_nuc_mutations::PrivateMutationsMinimal;
+use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::analyze::nuc_del::NucDel;
 use crate::analyze::nuc_sub::NucSub;
 use crate::tree::split_muts::SplitMutsResult;
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, HashSet};
 ///  - shared
 ///  - belonging only to left argument
 ///  - belonging only to the right argument
-pub fn split_muts2(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinimal) -> SplitMutsResult {
+pub fn split_muts2(left: &BranchMutations, right: &BranchMutations) -> SplitMutsResult {
   let mut subs_shared = Vec::<NucSub>::new();
   let mut subs_left = Vec::<NucSub>::new();
   let mut subs_right = Vec::<NucSub>::new();
@@ -118,15 +118,15 @@ pub fn split_muts2(left: &PrivateMutationsMinimal, right: &PrivateMutationsMinim
   ////////////////////////////////////////////////////////////////////////
 
   SplitMutsResult {
-    left: PrivateMutationsMinimal {
+    left: BranchMutations {
       nuc_muts: subs_left,
       aa_muts: aa_subs_left,
     },
-    shared: PrivateMutationsMinimal {
+    shared: BranchMutations {
       nuc_muts: subs_shared,
       aa_muts: aa_subs_shared,
     },
-    right: PrivateMutationsMinimal {
+    right: BranchMutations {
       nuc_muts: subs_right,
       aa_muts: aa_subs_right,
     },

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -1,6 +1,6 @@
 use crate::alphabet::aa::Aa;
 use crate::alphabet::nuc::Nuc;
-use crate::analyze::find_private_nuc_mutations::PrivateMutationsMinimal;
+use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::coord::position::{AaRefPosition, NucRefGlobalPosition};
 use crate::graph::edge::{Edge, GraphEdge};
 use crate::graph::graph::Graph;
@@ -192,7 +192,7 @@ pub struct TreeNodeAttrs {
 pub struct TreeNodeTempData {
   pub substitutions: BTreeMap<NucRefGlobalPosition, Nuc>,
   pub mutations: BTreeMap<NucRefGlobalPosition, Nuc>,
-  pub private_mutations: PrivateMutationsMinimal,
+  pub private_mutations: BranchMutations,
   pub aa_substitutions: BTreeMap<String, BTreeMap<AaRefPosition, Aa>>,
   pub aa_mutations: BTreeMap<String, BTreeMap<AaRefPosition, Aa>>,
 }

--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -1,4 +1,4 @@
-use crate::analyze::find_private_nuc_mutations::PrivateMutationsMinimal;
+use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::io::nextclade_csv::{
   format_failed_genes, format_missings, format_non_acgtns, format_nuc_deletions, format_pcr_primer_changes,
 };
@@ -15,7 +15,7 @@ use serde_json::json;
 
 pub fn create_new_auspice_node(
   result: &NextcladeOutputs,
-  new_private_mutations: &PrivateMutationsMinimal,
+  new_private_mutations: &BranchMutations,
   new_divergence: f64,
 ) -> AuspiceGraphNodePayload {
   let mutations = convert_private_mutations_to_node_branch_attrs(new_private_mutations);

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -1,6 +1,6 @@
 use crate::analyze::aa_del::AaDel;
 use crate::analyze::aa_sub::AaSub;
-use crate::analyze::divergence::calculate_branch_length;
+use crate::analyze::divergence::{calculate_branch_length, count_nuc_muts};
 use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::analyze::nuc_del::NucDel;
 use crate::analyze::nuc_sub::NucSub;
@@ -126,7 +126,7 @@ pub fn finetune_nearest_node(
           current_best_node.payload().name
         )
       })?;
-      let n_shared_muts = best_split_result.shared.n_nuc_muts();
+      let n_shared_muts = count_nuc_muts(&best_split_result.shared.nuc_muts);
       (best_split_result, n_shared_muts)
     };
 
@@ -138,7 +138,7 @@ pub fn finetune_nearest_node(
             child.payload().name
           )
         })?;
-      let tmp_n_shared_muts = tmp_split_result.shared.n_nuc_muts();
+      let tmp_n_shared_muts = count_nuc_muts(&tmp_split_result.shared.nuc_muts);
       if tmp_n_shared_muts > n_shared_muts {
         n_shared_muts = tmp_n_shared_muts;
         best_split_result = tmp_split_result;

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -65,10 +65,19 @@ pub fn graph_attach_new_node_in_place(
     private_aa_mutations.insert(key.clone(), value);
   }
 
+  let nuc_subs = concat_to_vec(
+    &result.private_nuc_mutations.private_substitutions,
+    &result
+      .private_nuc_mutations
+      .private_deletions
+      .iter()
+      .map(NucDel::to_sub)
+      .collect_vec(),
+  );
+
   // Check if new seq is in between nearest node and a neighbor of nearest node
   let mutations_seq = PrivateMutationsMinimal {
-    nuc_subs: result.private_nuc_mutations.private_substitutions.clone(),
-    nuc_dels: result.private_nuc_mutations.private_deletions.clone(),
+    nuc_subs,
     aa_muts: private_aa_mutations,
   };
 
@@ -224,12 +233,7 @@ pub fn convert_private_mutations_to_node_branch_attrs(
 ) -> BTreeMap<String, Vec<String>> {
   let mut branch_attrs = BTreeMap::<String, Vec<String>>::new();
 
-  let dels_as_subs = mutations.nuc_dels.iter().map(NucDel::to_sub).collect_vec();
-  let nuc_muts = concat_to_vec(&mutations.nuc_subs, &dels_as_subs)
-    .iter()
-    .sorted()
-    .map(NucSub::to_string)
-    .collect_vec();
+  let nuc_muts = mutations.nuc_subs.iter().sorted().map(NucSub::to_string).collect_vec();
   branch_attrs.insert("nuc".to_owned(), nuc_muts);
 
   for (gene_name, aa_muts) in &mutations.aa_muts {

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -126,7 +126,7 @@ pub fn finetune_nearest_node(
           current_best_node.payload().name
         )
       })?;
-      let n_shared_muts = best_split_result.shared.nuc_muts.len();
+      let n_shared_muts = best_split_result.shared.n_nuc_muts();
       (best_split_result, n_shared_muts)
     };
 
@@ -138,7 +138,7 @@ pub fn finetune_nearest_node(
             child.payload().name
           )
         })?;
-      let tmp_n_shared_muts = tmp_split_result.shared.nuc_muts.len();
+      let tmp_n_shared_muts = tmp_split_result.shared.n_nuc_muts();
       if tmp_n_shared_muts > n_shared_muts {
         n_shared_muts = tmp_n_shared_muts;
         best_split_result = tmp_split_result;

--- a/packages_rs/nextclade/src/tree/tree_preprocess.rs
+++ b/packages_rs/nextclade/src/tree/tree_preprocess.rs
@@ -86,7 +86,7 @@ pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<Pri
   let mut aa_sub = BTreeMap::<String, Vec<AaSub>>::new();
   match node.branch_attrs.mutations.get("nuc") {
     None => Ok(PrivateMutationsMinimal {
-      nuc_subs: nuc_sub,
+      nuc_muts: nuc_sub,
       aa_muts: aa_sub,
     }),
     Some(mutations) => {
@@ -105,7 +105,7 @@ pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<Pri
         }
       }
       Ok(PrivateMutationsMinimal {
-        nuc_subs: nuc_sub,
+        nuc_muts: nuc_sub,
         aa_muts: aa_sub,
       })
     }

--- a/packages_rs/nextclade/src/tree/tree_preprocess.rs
+++ b/packages_rs/nextclade/src/tree/tree_preprocess.rs
@@ -83,26 +83,16 @@ pub fn graph_preprocess_in_place_recursive(
 
 pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<PrivateMutationsMinimal, Report> {
   let mut nuc_sub = Vec::<NucSub>::new();
-  let mut nuc_del = Vec::<NucDel>::new();
   let mut aa_sub = BTreeMap::<String, Vec<AaSub>>::new();
   match node.branch_attrs.mutations.get("nuc") {
     None => Ok(PrivateMutationsMinimal {
       nuc_subs: nuc_sub,
-      nuc_dels: nuc_del,
       aa_muts: aa_sub,
     }),
     Some(mutations) => {
       for mutation_str in mutations {
         let mutation = NucSub::from_str(mutation_str)?;
-        if mutation.is_del() {
-          let del = NucDel {
-            ref_nuc: mutation.ref_nuc,
-            pos: mutation.pos,
-          };
-          nuc_del.push(del);
-        } else {
-          nuc_sub.push(mutation);
-        }
+        nuc_sub.push(mutation);
       }
       for (gene, muts) in &node.branch_attrs.mutations {
         if gene != "nuc" {
@@ -116,7 +106,6 @@ pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<Pri
       }
       Ok(PrivateMutationsMinimal {
         nuc_subs: nuc_sub,
-        nuc_dels: nuc_del,
         aa_muts: aa_sub,
       })
     }

--- a/packages_rs/nextclade/src/tree/tree_preprocess.rs
+++ b/packages_rs/nextclade/src/tree/tree_preprocess.rs
@@ -2,7 +2,7 @@ use crate::alphabet::aa::Aa;
 use crate::alphabet::letter::Letter;
 use crate::alphabet::nuc::Nuc;
 use crate::analyze::aa_sub::AaSub;
-use crate::analyze::find_private_nuc_mutations::PrivateMutationsMinimal;
+use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::analyze::nuc_del::NucDel;
 use crate::analyze::nuc_sub::NucSub;
 use crate::coord::position::{AaRefPosition, NucRefGlobalPosition, PositionLike};
@@ -81,11 +81,11 @@ pub fn graph_preprocess_in_place_recursive(
   Ok(graph_node_key)
 }
 
-pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<PrivateMutationsMinimal, Report> {
+pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<BranchMutations, Report> {
   let mut nuc_sub = Vec::<NucSub>::new();
   let mut aa_sub = BTreeMap::<String, Vec<AaSub>>::new();
   match node.branch_attrs.mutations.get("nuc") {
-    None => Ok(PrivateMutationsMinimal {
+    None => Ok(BranchMutations {
       nuc_muts: nuc_sub,
       aa_muts: aa_sub,
     }),
@@ -104,7 +104,7 @@ pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<Pri
           aa_sub.insert(gene.to_string(), aa_sub_vec);
         }
       }
-      Ok(PrivateMutationsMinimal {
+      Ok(BranchMutations {
         nuc_muts: nuc_sub,
         aa_muts: aa_sub,
       })

--- a/packages_rs/nextclade/src/tree/tree_preprocess.rs
+++ b/packages_rs/nextclade/src/tree/tree_preprocess.rs
@@ -82,34 +82,29 @@ pub fn graph_preprocess_in_place_recursive(
 }
 
 pub fn calc_node_private_mutations(node: &AuspiceGraphNodePayload) -> Result<BranchMutations, Report> {
-  let mut nuc_sub = Vec::<NucSub>::new();
-  let mut aa_sub = BTreeMap::<String, Vec<AaSub>>::new();
-  match node.branch_attrs.mutations.get("nuc") {
-    None => Ok(BranchMutations {
-      nuc_muts: nuc_sub,
-      aa_muts: aa_sub,
-    }),
-    Some(mutations) => {
-      for mutation_str in mutations {
-        let mutation = NucSub::from_str(mutation_str)?;
-        nuc_sub.push(mutation);
-      }
-      for (gene, muts) in &node.branch_attrs.mutations {
-        if gene != "nuc" {
-          let mut aa_sub_vec = Vec::<AaSub>::new();
-          for mutation_str in muts {
-            let mutation = AaSub::from_str(&format!("{gene}:{mutation_str}"))?;
-            aa_sub_vec.push(mutation);
-          }
-          aa_sub.insert(gene.to_string(), aa_sub_vec);
-        }
-      }
-      Ok(BranchMutations {
-        nuc_muts: nuc_sub,
-        aa_muts: aa_sub,
-      })
-    }
-  }
+  let nuc_muts = node
+    .branch_attrs
+    .mutations
+    .get("nuc")
+    .iter()
+    .flat_map(|mutations| mutations.iter().map(|m| NucSub::from_str(m)))
+    .collect::<Result<Vec<NucSub>, Report>>()?;
+
+  let aa_muts = node
+    .branch_attrs
+    .mutations
+    .iter()
+    .filter(|(cds_name, _)| cds_name != &"nuc")
+    .map(|(cds_name, muts)| {
+      let muts = muts
+        .iter()
+        .map(|m| AaSub::from_str(&format!("{cds_name}:{m}")))
+        .collect::<Result<Vec<AaSub>, Report>>()?;
+      Ok((cds_name.clone(), muts))
+    })
+    .collect::<Result<BTreeMap<String, Vec<AaSub>>, Report>>()?;
+
+  Ok(BranchMutations { nuc_muts, aa_muts })
 }
 
 fn map_nuc_muts(


### PR DESCRIPTION
When running on HIV, I encountered problems with inconsistent nucleotide sequence state on the tree.  When a position mutated along one branch (`A1C`) and the corresponding nucleotide was deleted along a sister branch (`A1-`), we ran into problems. These were due to two separate issues

 * `split_mutations`, `union`, `difference` considered subs and dels independently. This is problematic and can result in inconsistent sequence state on the tree. Say we took the difference of `A1C` and `C1-`, the correct result would be `A1-`, but the previous implementation would treat the deletion and substitution separately and include both `A1C` and `C1-` in the union of mutations and deletions, resulting in inconsistent changes. 
 * `invert` didn't invert gaps. `NucDel` only allow `Gap` at the qry position. But for the purposes on the tree, deletion and substitutions are equivalent and and `Gap` just acts as another character.  

The solution to both of these was to remove the `nuc_dels` field in `PrivateMutationsMinimal` and instead used the concatenation of `subs` and `dels`. It also removes quite a bit of code.

In addition, I renamed the variables (in two separate commits)

* `nuc_subs` -> `nuc_muts` in analogy to `aa_muts`
* `PrivateMutationsMinimal`  to `BranchMutations` -- this is what the structure is used for: describe changes to the sequence that happens along a branch in the tree. 


