### PR TITLE
Feat/maximal alignment area

### DIFF
--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -22,8 +22,6 @@ fn align_pairwise<T: Letter<T>>(
 ) -> AlignmentOutput<T> {
   trace!("Align pairwise: started. Params: {params:?}");
 
-  let max_indel = params.max_indel;
-
   let ScoreMatrixResult { scores, paths } = score_matrix(qry_seq, ref_seq, gap_open_close, stripes, params);
 
   backtrace(qry_seq, ref_seq, &scores, &paths)

--- a/packages_rs/nextclade/src/align/seed_alignment.rs
+++ b/packages_rs/nextclade/src/align/seed_alignment.rs
@@ -339,7 +339,11 @@ pub fn create_stripes(
   let (regularized_stripes, band_area) = regularize_stripes(stripes, qry_len as usize);
   let CLI_PARAM_MAXIMAL_BAND_AREA = 500_000_000;
   if band_area > CLI_PARAM_MAXIMAL_BAND_AREA {
-    make_error!("Alignment matrix size {band_area} exceeds maximal value {CLI_PARAM_MAXIMAL_BAND_AREA}. Can be set via flag '--maximal-band-area'!")
+    return make_error!(
+      "Alignment matrix size {} exceeds maximal value {}. Can be set via flag '--maximal-band-area'!",
+      band_area,
+      CLI_PARAM_MAXIMAL_BAND_AREA
+    );
   }
 
   Ok(regularized_stripes)


### PR DESCRIPTION
This PR stubs out a check that the sum of the stripes (the area of the band) is smaller than a value to be provided by the command line (could be something 100_000_000 by default, each entry requires one `i32` and one `i8`). 

a commandline flag `--max-band-area` would replace `--max-indel` we used to have.