### PR TITLE
Fix reading fasta without trailing newline

### DIFF
--- a/packages_rs/nextclade/src/io/concat.rs
+++ b/packages_rs/nextclade/src/io/concat.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 /// concat.rs
 ///
 /// Taken with modifications from
@@ -10,14 +11,6 @@
 /// concatenation of the items' contents.
 use std::io::{Read, Result};
 
-pub fn concat<I>(iter: I) -> Concat<I>
-where
-  I: Iterator,
-  <I as Iterator>::Item: Read,
-{
-  Concat::<I>::from(iter)
-}
-
 pub struct Concat<I>
 where
   I: Iterator,
@@ -25,6 +18,25 @@ where
 {
   iter: I,
   curr: Option<<I as Iterator>::Item>,
+  delimiter: Option<Vec<u8>>,
+}
+
+impl<I> Concat<I>
+where
+  I: Iterator,
+  <I as Iterator>::Item: Read,
+{
+  /// Concatenate readers into a single reader
+  pub fn from(iter: I) -> Concat<I> {
+    Self::with_delimiter(iter, None)
+  }
+
+  /// Concatenate readers into a single reader, alternating them with the provided delimiter,
+  /// i.e. inserting this sequence of bytes between adjacent readers.
+  pub fn with_delimiter(mut iter: I, delimiter: Option<Vec<u8>>) -> Concat<I> {
+    let curr = iter.next();
+    Concat { iter, curr, delimiter }
+  }
 }
 
 impl<I> Concat<I>
@@ -39,18 +51,6 @@ where
   #[inline]
   pub const fn current(&self) -> Option<&<I as Iterator>::Item> {
     self.curr.as_ref()
-  }
-}
-
-impl<I> From<I> for Concat<I>
-where
-  I: Iterator,
-  <I as Iterator>::Item: Read,
-{
-  fn from(mut iter: I) -> Concat<I> {
-    let curr = iter.next();
-
-    Concat { iter, curr }
   }
 }
 
@@ -70,7 +70,41 @@ where
     } else {
       // The current reader reached the end so we have to advance the iterator and try again.
       self.curr = self.iter.next();
-      self.read(buf)
+
+      // Before moving to the next reader, insert delimiter, if requested
+      let n_bytes_inserted = if let Some(delimiter) = &self.delimiter {
+        let n_bytes_inserted = min(delimiter.len(), buf.len());
+        buf[..n_bytes_inserted].copy_from_slice(delimiter);
+        n_bytes_inserted
+      } else {
+        0
+      };
+
+      let n_bytes_read = self.read(&mut buf[n_bytes_inserted..])?;
+      Ok(n_bytes_read + n_bytes_inserted)
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  #[rstest]
+  fn concatenates_readers_with_delimiter() {
+    // The idea is that readers (e.g. files) don't contain newline at the end, making line parsing incorrect on reader
+    // boundaries.
+    // It is expected that the newline delimiter will be inserted between readers, to compensate for that.
+
+    let r1: &[u8] = b"No\ntrailing\nnewline";
+    let r2: &[u8] = b"And\nneither\nhere";
+
+    let mut concat = Concat::with_delimiter([r1, r2].into_iter(), Some(b"\n".to_vec()));
+    let mut result = String::new();
+    concat.read_to_string(&mut result).unwrap();
+
+    assert_eq!(result, "No\ntrailing\nnewline\nAnd\nneither\nhere\n");
   }
 }

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -2,7 +2,7 @@ use crate::alphabet::aa::from_aa_seq;
 use crate::constants::REVERSE_COMPLEMENT_SUFFIX;
 use crate::gene::gene_map::GeneMap;
 use crate::io::compression::Decompressor;
-use crate::io::concat::concat;
+use crate::io::concat::Concat;
 use crate::io::file::{create_file_or_stdout, open_file_or_stdin, open_stdin};
 use crate::translate::translate_genes::CdsTranslation;
 use crate::{make_error, make_internal_error};
@@ -86,7 +86,7 @@ impl<'a> FastaReader<'a> {
       .map(|filepath| -> Result<Box<dyn BufRead + 'a>, Report> { open_file_or_stdin(&Some(filepath)) })
       .collect::<Result<Vec<Box<dyn BufRead + 'a>>, Report>>()?;
 
-    let concat = concat(readers.into_iter());
+    let concat = Concat::with_delimiter(readers.into_iter(), Some(b"\n".to_vec()));
     let concat_buf = BufReader::new(concat);
 
     Ok(Self::new(Box::new(concat_buf)))


### PR DESCRIPTION
It was reported that when multiple fasta files are provided to Nextclade CLI, if some of the the files don't contain trailing newlines, the sequences aren't read correctly.

The issue comes from the fact that the `Concat` struct concatenates readers (e.g. files in this case) seamlessly, and last sequence of previous reader transitions immediately into the first sequence of the next reader. Then line parsing with `BufRead` cannot split these sequences, because there is no newline character between them.

To address this, here I modify `Concat` struct, adding an additional parameter `delimiter`. When provided, readers are concatenated by alternating with given delimiter bytes. In fasta reader this allows to force insertion of a "\n" character between readers.

If files contain newlines and/or carriage returns, this might end up in multiple newline characters. But this is not a problem for fasta reader, because these get stripped away later.

