### PR TITLE
fix: zero length branches can still have aa mutations even without nu…

### DIFF
--- a/packages_rs/nextclade/src/analyze/divergence.rs
+++ b/packages_rs/nextclade/src/analyze/divergence.rs
@@ -1,4 +1,6 @@
 use crate::analyze::nuc_sub::NucSub;
+use crate::coord::range::NucRefGlobalRange;
+use crate::tree::params::TreeBuilderParams;
 use crate::tree::tree::DivergenceUnits;
 
 /// Calculate number of nuc muts, only considering ACGT characters
@@ -23,4 +25,18 @@ pub fn calculate_branch_length(
   }
 
   this_div
+}
+
+/// Calculate nuc mut score
+pub fn score_nuc_muts(nuc_muts: &[NucSub], masked_ranges: &[NucRefGlobalRange], params: &TreeBuilderParams) -> f64 {
+  // Only consider ACGT characters
+  let nuc_muts = nuc_muts.iter().filter(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt());
+
+  // Split away masked mutations
+  let (masked_muts, muts): (Vec<_>, Vec<_>) =
+    nuc_muts.partition(|m| masked_ranges.iter().any(|range| range.contains(m.pos)));
+
+  let n_muts = muts.len() as f64;
+  let n_masked_muts = masked_muts.len() as f64;
+  n_muts + n_masked_muts * params.masked_muts_weight
 }

--- a/packages_rs/nextclade/src/run/nextclade_wasm.rs
+++ b/packages_rs/nextclade/src/run/nextclade_wasm.rs
@@ -257,7 +257,7 @@ impl Nextclade {
 
   pub fn get_output_trees(&mut self, results: Vec<NextcladeOutputs>) -> Result<Option<OutputTrees>, Report> {
     if let Some(graph) = &mut self.graph {
-      graph_attach_new_nodes_in_place(graph, results, self.ref_seq.len(), &self.params.tree_builder)?;
+      graph_attach_new_nodes_in_place(graph, results, self.ref_seq.len(),  &self.params.tree_builder)?;
       let auspice = convert_graph_to_auspice_tree(graph)?;
       let nwk = convert_graph_to_nwk_string(graph)?;
       Ok(Some(OutputTrees { auspice, nwk }))

--- a/packages_rs/nextclade/src/tree/params.rs
+++ b/packages_rs/nextclade/src/tree/params.rs
@@ -14,6 +14,9 @@ pub struct TreeBuilderParams {
   #[clap(long)]
   #[clap(num_args=0..=1, default_missing_value = "true")]
   pub without_greedy_tree_builder: bool,
+
+  #[clap(long)]
+  pub masked_muts_weight: f64,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -21,6 +24,7 @@ impl Default for TreeBuilderParams {
   fn default() -> Self {
     Self {
       without_greedy_tree_builder: false,
+      masked_muts_weight: 0.05,
     }
   }
 }

--- a/packages_rs/nextclade/src/tree/split_muts.rs
+++ b/packages_rs/nextclade/src/tree/split_muts.rs
@@ -244,9 +244,9 @@ where
 pub fn difference_of_muts(left: &BranchMutations, right: &BranchMutations) -> Result<BranchMutations, Report> {
   Ok(BranchMutations {
     nuc_muts: difference(&left.nuc_muts, &right.nuc_muts)
-      .wrap_err("When calculating union of private nucleotide substitutions")?,
+      .wrap_err("When calculating difference of private nucleotide substitutions")?,
     aa_muts: difference_of_aa_muts(&left.aa_muts, &right.aa_muts)
-      .wrap_err("When calculating union of private aminoacid mutations")?,
+      .wrap_err("When calculating difference of private aminoacid mutations")?,
   })
 }
 

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -193,6 +193,12 @@ pub fn finetune_nearest_node(
           current_best_node.payload().name
         )
       })?;
+      private_mutations = union_of_muts(&private_mutations, &best_split_result.left.invert()).wrap_err_with(|| {
+        format!(
+          "When calculating union of mutations between query sequence and the candidate child node '{}'",
+          graph.get_node(best_node.key()).expect("Node not found").payload().name
+        )
+      })?;
       current_best_node = graph
         .parent_of_by_key(best_node.key())
         .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?;

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -185,7 +185,7 @@ pub fn finetune_nearest_node(
       private_mutations = union_of_muts(&private_mutations, &best_split_result.left.invert()).wrap_err_with(|| {
         format!(
           "When calculating union of mutations between query sequence and the candidate child node '{}'",
-          graph.get_node(best_node.key()).expect("Node not found").payload().name
+          best_node.payload().name
         )
       })?;
     } else if current_best_node.is_leaf()
@@ -206,7 +206,7 @@ pub fn finetune_nearest_node(
       private_mutations = union_of_muts(&private_mutations, &best_split_result.left.invert()).wrap_err_with(|| {
         format!(
           "When calculating union of mutations between the query sequence and the zero-length parent node '{}'",
-          graph.get_node(best_node.key()).expect("Node not found").payload().name
+          best_node.payload().name
         )
       })?;
       current_best_node = graph

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -195,7 +195,7 @@ pub fn finetune_nearest_node(
       })?;
       private_mutations = union_of_muts(&private_mutations, &best_split_result.left.invert()).wrap_err_with(|| {
         format!(
-          "When calculating union of mutations between query sequence and the candidate child node '{}'",
+          "When calculating union of mutations between query sequence the zero-length parent node '{}'",
           graph.get_node(best_node.key()).expect("Node not found").payload().name
         )
       })?;


### PR DESCRIPTION
…c muts

This problem arose when we are moving the attachment point across a branch of a node that had aa mutations that didn't correspond to any nucleotide mutations. The problem arose only in the specific case when the branch length of a terminal node is zero. 



