### PR TITLE
Refactor and cleanup tree finetuning code

### DIFF
--- a/packages_rs/nextclade/src/analyze/divergence.rs
+++ b/packages_rs/nextclade/src/analyze/divergence.rs
@@ -1,4 +1,6 @@
 use crate::analyze::nuc_sub::NucSub;
+use crate::coord::range::NucRefGlobalRange;
+use crate::tree::params::TreeBuilderParams;
 use crate::tree::tree::DivergenceUnits;
 
 /// Calculate number of nuc muts, only considering ACGT characters
@@ -23,4 +25,18 @@ pub fn calculate_branch_length(
   }
 
   this_div
+}
+
+/// Calculate nuc mut score
+pub fn score_nuc_muts(nuc_muts: &[NucSub], masked_ranges: &[NucRefGlobalRange], params: &TreeBuilderParams) -> f64 {
+  // Only consider ACGT characters
+  let nuc_muts = nuc_muts.iter().filter(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt());
+
+  // Split away masked mutations
+  let (masked_muts, muts): (Vec<_>, Vec<_>) =
+    nuc_muts.partition(|m| masked_ranges.iter().any(|range| range.contains(m.pos)));
+
+  let n_muts = muts.len() as f64;
+  let n_masked_muts = masked_muts.len() as f64;
+  n_muts + n_masked_muts * params.masked_muts_weight
 }

--- a/packages_rs/nextclade/src/run/nextclade_wasm.rs
+++ b/packages_rs/nextclade/src/run/nextclade_wasm.rs
@@ -257,7 +257,7 @@ impl Nextclade {
 
   pub fn get_output_trees(&mut self, results: Vec<NextcladeOutputs>) -> Result<Option<OutputTrees>, Report> {
     if let Some(graph) = &mut self.graph {
-      graph_attach_new_nodes_in_place(graph, results, self.ref_seq.len(), &self.params.tree_builder)?;
+      graph_attach_new_nodes_in_place(graph, results, self.ref_seq.len(),  &self.params.tree_builder)?;
       let auspice = convert_graph_to_auspice_tree(graph)?;
       let nwk = convert_graph_to_nwk_string(graph)?;
       Ok(Some(OutputTrees { auspice, nwk }))

--- a/packages_rs/nextclade/src/tree/params.rs
+++ b/packages_rs/nextclade/src/tree/params.rs
@@ -14,6 +14,9 @@ pub struct TreeBuilderParams {
   #[clap(long)]
   #[clap(num_args=0..=1, default_missing_value = "true")]
   pub without_greedy_tree_builder: bool,
+
+  #[clap(long)]
+  pub masked_muts_weight: f64,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -21,6 +24,7 @@ impl Default for TreeBuilderParams {
   fn default() -> Self {
     Self {
       without_greedy_tree_builder: false,
+      masked_muts_weight: 0.05,
     }
   }
 }

--- a/packages_rs/nextclade/src/tree/split_muts.rs
+++ b/packages_rs/nextclade/src/tree/split_muts.rs
@@ -244,9 +244,9 @@ where
 pub fn difference_of_muts(left: &BranchMutations, right: &BranchMutations) -> Result<BranchMutations, Report> {
   Ok(BranchMutations {
     nuc_muts: difference(&left.nuc_muts, &right.nuc_muts)
-      .wrap_err("When calculating union of private nucleotide substitutions")?,
+      .wrap_err("When calculating difference of private nucleotide substitutions")?,
     aa_muts: difference_of_aa_muts(&left.aa_muts, &right.aa_muts)
-      .wrap_err("When calculating union of private aminoacid mutations")?,
+      .wrap_err("When calculating difference of private aminoacid mutations")?,
   })
 }
 

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -5,7 +5,6 @@ use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::analyze::nuc_del::NucDel;
 use crate::analyze::nuc_sub::NucSub;
 use crate::graph::node::{GraphNodeKey, Node};
-use crate::make_internal_report;
 use crate::tree::params::TreeBuilderParams;
 use crate::tree::split_muts::{difference_of_muts, split_muts, union_of_muts, SplitMutsResult};
 use crate::tree::tree::{AuspiceGraph, AuspiceGraphEdgePayload, AuspiceGraphNodePayload, TreeBranchAttrsLabels};
@@ -188,11 +187,10 @@ fn find_better_node_maybe<'g>(
 ) -> Result<Option<&'g Node<AuspiceGraphNodePayload>>, Report> {
   // if shared mutations are found, the current_best_node is updated
   Ok(if n_shared_muts > 0 {
-    if best_node.key() == current_best_node.key() && best_split_result.left.nuc_muts.is_empty() {
+    if best_node == current_best_node && best_split_result.left.nuc_muts.is_empty() {
       // Caveat: all mutations from the parent to the node are shared with private mutations. Move up to the parent.
-      // FIXME: what if there's no parent?
       graph.parent_of(best_node)
-    } else if best_node.key() == current_best_node.key() {
+    } else if best_node == current_best_node {
       // The best node is the current node. Break.
       None
     } else {

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -1,9 +1,10 @@
 use crate::analyze::aa_del::AaDel;
 use crate::analyze::aa_sub::AaSub;
-use crate::analyze::divergence::{calculate_branch_length, count_nuc_muts};
+use crate::analyze::divergence::{calculate_branch_length, count_nuc_muts, score_nuc_muts};
 use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::analyze::nuc_del::NucDel;
 use crate::analyze::nuc_sub::NucSub;
+use crate::coord::range::NucRefGlobalRange;
 use crate::graph::node::{GraphNodeKey, Node};
 use crate::tree::params::TreeBuilderParams;
 use crate::tree::split_muts::{difference_of_muts, split_muts, union_of_muts, SplitMutsResult};
@@ -86,7 +87,7 @@ pub fn graph_attach_new_node_in_place(
   } else {
     // for the attachment on the reference tree ('result') fine tune the position
     // on the updated graph to minimize the number of private mutations
-    finetune_nearest_node(graph, result.nearest_node_id, &mutations_seq)?
+    finetune_nearest_node(graph, result.nearest_node_id, &mutations_seq, params)?
   };
 
   // add the new node at the fine tuned position while accounting for shared mutations
@@ -106,14 +107,16 @@ pub fn finetune_nearest_node(
   graph: &AuspiceGraph,
   nearest_node_key: GraphNodeKey,
   seq_private_mutations: &BranchMutations,
+  params: &TreeBuilderParams,
 ) -> Result<(GraphNodeKey, BranchMutations), Report> {
+  let masked_ranges = graph.data.meta.placement_mask_ranges();
   let mut best_node = graph.get_node(nearest_node_key)?;
   let mut private_mutations = seq_private_mutations.clone();
 
   loop {
     // Check how many mutations are shared with the branch leading to the current_best_node or any of its children
-    let (candidate_node, candidate_split, n_shared_muts) = find_shared_muts(graph, best_node, &private_mutations)
-      .wrap_err_with(|| {
+    let (candidate_node, candidate_split, shared_muts_score) =
+      find_shared_muts(graph, best_node, &private_mutations, masked_ranges, params).wrap_err_with(|| {
         format!(
           "When calculating shared mutations against the current best node '{}'",
           best_node.payload().name
@@ -121,7 +124,8 @@ pub fn finetune_nearest_node(
       })?;
 
     // Check if the new candidate node is better than the current best
-    match find_better_node_maybe(graph, best_node, candidate_node, &candidate_split, n_shared_muts) {
+    let left_muts_score = score_nuc_muts(&candidate_split.left.nuc_muts, masked_ranges, params);
+    match find_better_node_maybe(graph, best_node, candidate_node, shared_muts_score, left_muts_score) {
       None => break,
       Some(better_node) => best_node = better_node,
     }
@@ -143,15 +147,17 @@ fn find_shared_muts<'g>(
   graph: &'g AuspiceGraph,
   best_node: &'g Node<AuspiceGraphNodePayload>,
   private_mutations: &BranchMutations,
-) -> Result<(&'g Node<AuspiceGraphNodePayload>, SplitMutsResult, usize), Report> {
-  let (mut candidate_split, mut n_shared_muts) = if best_node.is_root() {
+  masked_ranges: &[NucRefGlobalRange],
+  params: &TreeBuilderParams,
+) -> Result<(&'g Node<AuspiceGraphNodePayload>, SplitMutsResult, f64), Report> {
+  let (mut candidate_split, mut shared_muts_score) = if best_node.is_root() {
     // Don't include node if node is root as we don't attach nodes above the root
     let candidate_split = SplitMutsResult {
-      left: private_mutations.clone(),
-      right: BranchMutations::default(),
+      left: BranchMutations::default(),
+      right: private_mutations.clone(),
       shared: BranchMutations::default(),
     };
-    (candidate_split, 0)
+    (candidate_split, 0.0)
   } else {
     let candidate_split = split_muts(&best_node.payload().tmp.private_mutations.invert(), private_mutations)
       .wrap_err_with(|| {
@@ -160,8 +166,8 @@ fn find_shared_muts<'g>(
           best_node.payload().name
         )
       })?;
-    let n_shared_muts = count_nuc_muts(&candidate_split.shared.nuc_muts);
-    (candidate_split, n_shared_muts)
+    let shared_muts_score = score_nuc_muts(&candidate_split.shared.nuc_muts, masked_ranges, params);
+    (candidate_split, shared_muts_score)
   };
 
   // Check all child nodes for shared mutations
@@ -173,14 +179,14 @@ fn find_shared_muts<'g>(
         child.payload().name
       )
     })?;
-    let child_n_shared_muts = count_nuc_muts(&child_split.shared.nuc_muts);
-    if child_n_shared_muts > n_shared_muts {
-      n_shared_muts = child_n_shared_muts;
+    let child_shared_muts_score = score_nuc_muts(&child_split.shared.nuc_muts, masked_ranges, params);
+    if child_shared_muts_score > shared_muts_score {
+      shared_muts_score = child_shared_muts_score;
       candidate_split = child_split;
       candidate_node = child;
     }
   }
-  Ok((candidate_node, candidate_split, n_shared_muts))
+  Ok((candidate_node, candidate_split, shared_muts_score))
 }
 
 /// Find out if the candidate node is better than the current best (with caveats).
@@ -189,18 +195,18 @@ fn find_better_node_maybe<'g>(
   graph: &'g AuspiceGraph,
   best_node: &'g Node<AuspiceGraphNodePayload>,
   candidate_node: &'g Node<AuspiceGraphNodePayload>,
-  candidate_split: &SplitMutsResult,
-  n_shared_muts: usize,
+  shared_muts_score: f64,
+  left_muts_score: f64,
 ) -> Option<&'g Node<AuspiceGraphNodePayload>> {
   if candidate_node == best_node {
     // best node is the node itself. Move up the tree if all mutations between
     // the candidate node and its parent are also in the private mutations.
     // This covers the case where the candidate is a leaf with zero length branch
-    // as the  .left.nuc_muts is emtpy in that case
-    if candidate_split.left.nuc_muts.is_empty() {
+    // as the  .left.nuc_muts is empty in that case
+    if left_muts_score == 0.0 {
       return graph.parent_of(candidate_node);
     }
-  } else if n_shared_muts > 0 {
+  } else if shared_muts_score > 0.0 {
     // candidate node is child node, move to child node if there are shared mutations
     // this should always be the case if the candidate node != best_node
     return Some(candidate_node);

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -191,11 +191,7 @@ fn find_better_node_maybe<'g>(
     if best_node.key() == current_best_node.key() && best_split_result.left.nuc_muts.is_empty() {
       // Caveat: all mutations from the parent to the node are shared with private mutations. Move up to the parent.
       // FIXME: what if there's no parent?
-      Some(
-        graph
-          .parent_of(best_node)
-          .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?,
-      )
+      graph.parent_of(best_node)
     } else if best_node.key() == current_best_node.key() {
       // The best node is the current node. Break.
       None
@@ -207,11 +203,7 @@ fn find_better_node_maybe<'g>(
     && !current_best_node.is_root()
     && current_best_node.payload().tmp.private_mutations.nuc_muts.is_empty()
   {
-    Some(
-      graph
-        .parent_of(best_node)
-        .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?,
-    )
+    graph.parent_of(best_node)
   } else {
     None
   })

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -116,52 +116,17 @@ pub fn finetune_nearest_node(
     // the current_best_node or any of its children (loop further below).
     let (best_node, best_split_result, n_shared_muts) = find_shared_muts(graph, current_best_node, &private_mutations)?;
 
-    match find_better_node(graph, current_best_node, best_node, &best_split_result, n_shared_muts)? {
+    // Check if the new candidate node is better than the current best
+    match find_better_node_maybe(graph, current_best_node, best_node, &best_split_result, n_shared_muts)? {
       None => break,
       Some(better_node) => current_best_node = better_node,
     }
 
+    // Update query mutations to adjust for its new position
     private_mutations = update_private_mutations(&private_mutations, current_best_node, &best_split_result)?;
   }
-  Ok((current_best_node.key(), private_mutations))
-}
 
-fn find_better_node<'g>(
-  graph: &'g AuspiceGraph,
-  current_best_node: &'g Node<AuspiceGraphNodePayload>,
-  best_node: &'g Node<AuspiceGraphNodePayload>,
-  best_split_result: &SplitMutsResult,
-  n_shared_muts: usize,
-) -> Result<Option<&'g Node<AuspiceGraphNodePayload>>, Report> {
-  // if shared mutations are found, the current_best_node is updated
-  Ok(if n_shared_muts > 0 {
-    if best_node.key() == current_best_node.key() && best_split_result.left.nuc_muts.is_empty() {
-      // All mutations from the parent to the node are shared with private mutations. Move up to the parent.
-      // FIXME: what if there's no parent?
-      Some(
-        graph
-          .parent_of(best_node)
-          .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?,
-      )
-    } else if best_node.key() == current_best_node.key() {
-      // The best node is the current node. Break.
-      None
-    } else {
-      // The best node is child
-      Some(graph.get_node(best_node.key())?)
-    }
-  } else if current_best_node.is_leaf()
-    && !current_best_node.is_root()
-    && current_best_node.payload().tmp.private_mutations.nuc_muts.is_empty()
-  {
-    Some(
-      graph
-        .parent_of(best_node)
-        .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?,
-    )
-  } else {
-    None
-  })
+  Ok((current_best_node.key(), private_mutations))
 }
 
 fn find_shared_muts<'g>(
@@ -210,6 +175,46 @@ fn find_shared_muts<'g>(
     }
   }
   Ok((best_node, best_split_result, n_shared_muts))
+}
+
+/// Find out if the candidate node is better than the current best (with caveats)
+/// Return a better node or `None` (if the current best node is to be preserved).
+fn find_better_node_maybe<'g>(
+  graph: &'g AuspiceGraph,
+  current_best_node: &'g Node<AuspiceGraphNodePayload>,
+  best_node: &'g Node<AuspiceGraphNodePayload>,
+  best_split_result: &SplitMutsResult,
+  n_shared_muts: usize,
+) -> Result<Option<&'g Node<AuspiceGraphNodePayload>>, Report> {
+  // if shared mutations are found, the current_best_node is updated
+  Ok(if n_shared_muts > 0 {
+    if best_node.key() == current_best_node.key() && best_split_result.left.nuc_muts.is_empty() {
+      // Caveat: all mutations from the parent to the node are shared with private mutations. Move up to the parent.
+      // FIXME: what if there's no parent?
+      Some(
+        graph
+          .parent_of(best_node)
+          .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?,
+      )
+    } else if best_node.key() == current_best_node.key() {
+      // The best node is the current node. Break.
+      None
+    } else {
+      // The best node is child
+      Some(graph.get_node(best_node.key())?)
+    }
+  } else if current_best_node.is_leaf()
+    && !current_best_node.is_root()
+    && current_best_node.payload().tmp.private_mutations.nuc_muts.is_empty()
+  {
+    Some(
+      graph
+        .parent_of(best_node)
+        .ok_or_else(|| make_internal_report!("Parent node is expected, but not found"))?,
+    )
+  } else {
+    None
+  })
 }
 
 /// Update private mutations to match the new best_node


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/1249

Inspired by refactoring in [`15757ec` (#1249)](https://github.com/nextstrain/nextclade/pull/1249/commits/15757ece18f4e57931c27306e18c2ae229b2cfdb) I decided to continue, because the code in the `finetune_nearest_node()` can be clearly divided into independent functions.

Change of terminology, to clarify meaning of varables:

 - `current_best_node` -> `best_node` (this is the loop's external state)
 - `best_node` -> `candidate_node` 
 - `best_split_result` ->  `candidate_split`


I tried to make commits to contain only 1 minimal change which compiles and runs. Plus there is a few pink elephants I encountered  - reported in the PR comments below.
