### PR TITLE
Fix issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,1 @@
-vers
 blank_issues_enabled: false


### PR DESCRIPTION
## Description

"vers" was added in a81376c09cba730024f399e9b7e21d6605fb5ff0, I'm assuming in error since it is not a documented value for the config file¹.

¹ https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

## Checklist

- [ ] Post-merge: [issue chooser](https://github.com/nextstrain/nextclade/issues/new/choose) no longer has the option to open a blank issue.