### PR TITLE
feat: rename old concepts

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -301,7 +301,7 @@ pub struct NextcladeRunInputArgs {
   ///
   /// See `nextclade dataset --help` on how to obtain datasets.
   ///
-  /// If this flag is not provided, no dataset will be loaded and individual input files have to be provided instead. In this case  `--input-ref` is required and `--input-gene-map`, `--input-tree` and `--input-pathogen-json` are optional.
+  /// If this flag is not provided, no dataset will be loaded and individual input files have to be provided instead. In this case  `--input-ref` is required and `--input-annotation, `--input-tree` and `--input-pathogen-json` are optional.
   ///
   /// If both the `--input-dataset` and individual `--input-*` flags are provided, each individual flag overrides the
   /// corresponding file in the dataset.
@@ -328,9 +328,14 @@ pub struct NextcladeRunInputArgs {
   /// Overrides path to `reference.fasta` in the dataset (`--input-dataset`).
   ///
   /// Supports the following compression formats: "gz", "bz2", "xz", "zst". Use "-" to read uncompressed data from standard input (stdin).
-  #[clap(long, short = 'r', visible_alias("reference"), visible_alias("input-root-seq"))]
+  #[clap(long, short = 'r', visible_alias("reference"))]
   #[clap(value_hint = ValueHint::FilePath)]
   pub input_ref: Option<PathBuf>,
+
+  /// REMOVED. Use --input-ref instead
+  #[clap(long)]
+  #[clap(hide_long_help = true, hide_short_help = true)]
+  pub input_root_seq: Option<String>,
 
   /// Path to Auspice JSON v2 file containing reference tree.
   ///
@@ -351,7 +356,7 @@ pub struct NextcladeRunInputArgs {
 
   /// Path to a JSON file containing configuration and data specific to a pathogen.
   ///
-  /// Overrides path to `virus_properties.json` in the dataset (`--input-dataset`).
+  /// Overrides path to `pathogen.json` in the dataset (`--input-dataset`).
   ///
   /// Supports the following compression formats: "gz", "bz2", "xz", "zst". Use "-" to read uncompressed data from standard input (stdin).
   #[clap(long, short = 'R')]
@@ -388,7 +393,7 @@ pub struct NextcladeRunInputArgs {
   /// codon-aware alignment and aminoacid mutations detection. Must only contain gene names present in the genome annotation. If
   /// this flag is not supplied or its value is an empty string, then all genes found in the genome annotation will be used.
   ///
-  /// Requires `--input-gene-map` to be specified.
+  /// Requires `--input-annotation` to be specified.
   #[clap(
     long,
     short = 'g',
@@ -900,6 +905,12 @@ For more information, type:
 
   nextclade run --help"#;
 
+const ERROR_MSG_INPUT_ROOT_SEQ_REMOVED: &str = r#"The argument `--input-root-seq` is removed in favor of `--input-ref`.
+
+For more information, type
+
+  nextclade run --help"#;
+
 const ERROR_MSG_OUTPUT_DIR_REMOVED: &str = r#"The argument `--output-dir` is removed in favor of `--output-all`.
 
 When provided, `--output-all` allows to write all possible outputs into a directory.
@@ -963,6 +974,10 @@ Read Nextclade documentation at:
 pub fn nextclade_check_removed_args(run_args: &NextcladeRunArgs) -> Result<(), Report> {
   if run_args.inputs.input_fasta.is_some() {
     return make_error!("{ERROR_MSG_INPUT_FASTA_REMOVED}");
+  }
+
+  if run_args.inputs.input_root_seq.is_some() {
+    return make_error!("{ERROR_MSG_INPUT_ROOT_SEQ_REMOVED}");
   }
 
   if run_args.inputs.input_qc_config.is_some() {

--- a/packages_rs/nextclade-web/src/components/FilePicker/FilePickerAdvanced.tsx
+++ b/packages_rs/nextclade-web/src/components/FilePicker/FilePickerAdvanced.tsx
@@ -42,7 +42,7 @@ export function FilePickerAdvanced() {
           icon={iconJson}
           title={t('Reference tree')}
           exampleUrl="https://example.com/tree.json"
-          pasteInstructions={t('Enter tree data in Auspice JSON v2 format')}
+          pasteInstructions={t('Enter reference tree in Auspice JSON v2 format')}
           input={refTree}
           error={refTreeError}
           onRemove={resetRefTree}
@@ -53,9 +53,9 @@ export function FilePickerAdvanced() {
           className="my-3"
           compact
           icon={iconFasta}
-          title={t('Root sequence')}
+          title={t('Reference sequence')}
           exampleUrl="https://example.com/root_seq.fasta"
-          pasteInstructions={t('Enter root sequence data in FASTA format')}
+          pasteInstructions={t('Enter reference sequence in FASTA format')}
           input={refSeq}
           error={refSeqError}
           onRemove={resetRefSeq}
@@ -66,9 +66,9 @@ export function FilePickerAdvanced() {
           className="my-3"
           compact
           icon={iconJson}
-          title={t('Virus properties')}
-          exampleUrl="https://example.com/virus_properties.json"
-          pasteInstructions={t('Enter Virus attributes in JSON format')}
+          title={t('Pathogen JSON')}
+          exampleUrl="https://example.com/pathogen.json"
+          pasteInstructions={t('Enter pathogen description in JSON format')}
           input={virusProperties}
           error={virusPropertiesError}
           onRemove={resetVirusProperties}
@@ -79,9 +79,9 @@ export function FilePickerAdvanced() {
           className="my-3"
           compact
           icon={iconGff}
-          title={t('Gene map')}
-          exampleUrl="https://example.com/gene_map.json"
-          pasteInstructions={t('Enter gene map data in JSON format')}
+          title={t('Genome annotation')}
+          exampleUrl="https://example.com/genome_annotation.gff3"
+          pasteInstructions={t('Enter genome annotation in GFF3 format')}
           input={geneMap}
           error={geneMapError}
           onRemove={resetGeneMap}

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
@@ -82,7 +82,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
   if (!cds) {
     return (
       <SequenceViewWrapper>
-        {t('CDS {{geneName}} is missing in gene map', { geneName: viewedGene })}
+        {t('CDS {{geneName}} is missing in genome annotation', { geneName: viewedGene })}
       </SequenceViewWrapper>
     )
   }

--- a/packages_rs/nextclade/src/align/align.rs
+++ b/packages_rs/nextclade/src/align/align.rs
@@ -76,7 +76,7 @@ pub fn align_nuc(
     minimal_bandwidth,
   );
   if band_area > max_band_area {
-    return make_error!("Alignment matrix size {band_area} exceeds maximum value {max_band_area}. The threshold can be adjusted using CLI flag '--max-band-area' or using 'maxBandArea' field in the dataset's virus_properties.json");
+    return make_error!("Alignment matrix size {band_area} exceeds maximum value {max_band_area}. The threshold can be adjusted using CLI flag '--max-band-area' or using 'maxBandArea' field in the dataset's pathogen.json");
   }
 
   let mut alignment = align_pairwise(&qry_seq, ref_seq, gap_open_close, params, &stripes);

--- a/packages_rs/nextclade/src/run/nextclade_wasm.rs
+++ b/packages_rs/nextclade/src/run/nextclade_wasm.rs
@@ -39,7 +39,7 @@ pub struct NextcladeParams {
 impl NextcladeParams {
   pub fn from_raw(raw: NextcladeParamsRaw) -> Result<Self, Report> {
     let virus_properties =
-      VirusProperties::from_str(&raw.virus_properties).wrap_err("When parsing virus properties JSON")?;
+      VirusProperties::from_str(&raw.virus_properties).wrap_err("When parsing pathogen JSON")?;
 
     let ref_record = read_one_fasta_str(&raw.ref_seq).wrap_err("When parsing reference sequence")?;
 


### PR DESCRIPTION
Renames the following concepts in the visible parts of the software: strings in the UI, text messages, CLI args etc.

- genemap -> genome annotation
- virus properties -> pathogen.json
- root sequence -> reference sequence

Note that project code (e.g. types and variable names) still largely contains old names. This would be a large refactor and might introduce bugs, so I see no immediate advantage there.

