### PR TITLE
fix(web): prevent tree page from showing blank screen

### DIFF
--- a/packages_rs/nextclade-web/src/components/Tree/TreePage.tsx
+++ b/packages_rs/nextclade-web/src/components/Tree/TreePage.tsx
@@ -1,117 +1,20 @@
-import React, { useMemo } from 'react'
-import styled from 'styled-components'
-import { I18nextProvider } from 'react-i18next'
-import { connect } from 'react-redux'
-import { AuspiceMetadata } from 'auspice'
-import type { State } from 'src/state/reducer'
-import i18nAuspice from 'src/i18n/i18n.auspice'
-import FiltersSummary from 'auspice/src/components/info/filtersSummary'
+import React from 'react'
+import dynamic from 'next/dynamic'
 import { Layout } from 'src/components/Layout/Layout'
-import { LogoGisaid as LogoGisaidBase } from 'src/components/Common/LogoGisaid'
-import { Tree } from 'src/components/Tree/Tree'
-import { Sidebar } from 'src/components/Tree/Sidebar'
+import { LOADING } from 'src/components/Loading/Loading'
 
-export const Container = styled.div`
-  flex: 1;
-  flex-basis: 100%;
-  width: 100%;
-  height: 100%;
-  min-width: 1080px;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-`
-
-const MainContent = styled.main`
-  flex: 1;
-  flex-basis: 100%;
-  overflow-y: hidden;
-`
-
-const AuspiceContainer = styled.div`
-  display: flex;
-  flex: 1;
-  flex-basis: 99%;
-  height: 100%;
-`
-
-const SidebarContainer = styled.div`
-  flex: 0 0 260px;
-  background-color: #30353f;
-  overflow-y: auto;
-`
-
-const TreeContainer = styled.div`
-  flex: 1 1;
-  overflow-y: scroll;
-`
-
-const TreeTopPanel = styled.div`
-  display: flex;
-`
-
-const FiltersSummaryWrapper = styled.div`
-  flex: 1 1 100%;
-`
-
-const LogoGisaidWrapper = styled.div`
-  display: flex;
-  flex: 0 0 auto;
-  margin: 0 auto;
-  margin-right: 2.25rem;
-  margin-top: 10px;
-`
-
-const LogoGisaid = styled(LogoGisaidBase)`
-  margin-top: auto;
-`
-
-export interface TreePageProps {
-  treeMeta?: AuspiceMetadata
-}
-
-const mapStateToProps = (state: State) => ({
-  treeMeta: state.metadata,
+const TreePageContent = dynamic(() => import('src/components/Tree/TreePageContent'), {
+  ssr: false,
+  loading() {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <>{LOADING}</>
+  },
 })
 
-export const TreePage = connect(mapStateToProps, null)(TreePageDisconnected)
-
-function TreePageDisconnected({ treeMeta }: TreePageProps) {
-  const isDataFromGisaid = useMemo(
-    () => treeMeta?.dataProvenance?.some((provenance) => provenance.name?.toLowerCase() === 'gisaid'),
-    [treeMeta],
-  )
-
+export function TreePage() {
   return (
     <Layout>
-      <Container>
-        <MainContent>
-          <AuspiceContainer>
-            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-            {/* @ts-ignore */}
-            <I18nextProvider i18n={i18nAuspice}>
-              <SidebarContainer>
-                <Sidebar />
-              </SidebarContainer>
-              <TreeContainer>
-                <TreeTopPanel>
-                  <FiltersSummaryWrapper>
-                    <FiltersSummary />
-                  </FiltersSummaryWrapper>
-                  {isDataFromGisaid && (
-                    <LogoGisaidWrapper>
-                      <LogoGisaid />
-                    </LogoGisaidWrapper>
-                  )}
-                </TreeTopPanel>
-                <Tree />
-              </TreeContainer>
-            </I18nextProvider>
-          </AuspiceContainer>
-        </MainContent>
-      </Container>
+      <TreePageContent />
     </Layout>
   )
 }
-
-export default TreePage

--- a/packages_rs/nextclade-web/src/components/Tree/TreePageContent.tsx
+++ b/packages_rs/nextclade-web/src/components/Tree/TreePageContent.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { I18nextProvider } from 'react-i18next'
+import { connect } from 'react-redux'
+import { AuspiceMetadata } from 'auspice'
+import type { State } from 'src/state/reducer'
+import i18nAuspice from 'src/i18n/i18n.auspice'
+import FiltersSummary from 'auspice/src/components/info/filtersSummary'
+import { LogoGisaid as LogoGisaidBase } from 'src/components/Common/LogoGisaid'
+import { Tree } from 'src/components/Tree/Tree'
+import { Sidebar } from 'src/components/Tree/Sidebar'
+
+export const Container = styled.div`
+  flex: 1;
+  flex-basis: 100%;
+  width: 100%;
+  height: 100%;
+  min-width: 1080px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+`
+
+const MainContent = styled.main`
+  flex: 1;
+  flex-basis: 100%;
+  overflow-y: hidden;
+`
+
+const AuspiceContainer = styled.div`
+  display: flex;
+  flex: 1;
+  flex-basis: 99%;
+  height: 100%;
+`
+
+const SidebarContainer = styled.div`
+  flex: 0 0 260px;
+  background-color: #30353f;
+  overflow-y: auto;
+`
+
+const TreeContainer = styled.div`
+  flex: 1 1;
+  overflow-y: scroll;
+`
+
+const TreeTopPanel = styled.div`
+  display: flex;
+`
+
+const FiltersSummaryWrapper = styled.div`
+  flex: 1 1 100%;
+`
+
+const LogoGisaidWrapper = styled.div`
+  display: flex;
+  flex: 0 0 auto;
+  margin: 0 auto;
+  margin-right: 2.25rem;
+  margin-top: 10px;
+`
+
+const LogoGisaid = styled(LogoGisaidBase)`
+  margin-top: auto;
+`
+
+export interface TreePageProps {
+  treeMeta?: AuspiceMetadata
+}
+
+const mapStateToProps = (state: State) => ({
+  treeMeta: state.metadata,
+})
+
+const TreePageContent = connect(mapStateToProps, null)(TreePageContentDisconnected)
+export default TreePageContent
+
+function TreePageContentDisconnected({ treeMeta }: TreePageProps) {
+  const isDataFromGisaid = useMemo(
+    () => treeMeta?.dataProvenance?.some((provenance) => provenance.name?.toLowerCase() === 'gisaid'),
+    [treeMeta],
+  )
+
+  return (
+    <Container>
+      <MainContent>
+        <AuspiceContainer>
+          {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+          {/* @ts-ignore */}
+          <I18nextProvider i18n={i18nAuspice}>
+            <SidebarContainer>
+              <Sidebar />
+            </SidebarContainer>
+            <TreeContainer>
+              <TreeTopPanel>
+                <FiltersSummaryWrapper>
+                  <FiltersSummary />
+                </FiltersSummaryWrapper>
+                {isDataFromGisaid && (
+                  <LogoGisaidWrapper>
+                    <LogoGisaid />
+                  </LogoGisaidWrapper>
+                )}
+              </TreeTopPanel>
+              <Tree />
+            </TreeContainer>
+          </I18nextProvider>
+        </AuspiceContainer>
+      </MainContent>
+    </Container>
+  )
+}

--- a/packages_rs/nextclade-web/src/pages/tree.tsx
+++ b/packages_rs/nextclade-web/src/pages/tree.tsx
@@ -1,5 +1,1 @@
-import dynamic from 'next/dynamic'
-
-const TreePage = dynamic(() => import('src/components/Tree/TreePage'), { ssr: false })
-
-export default TreePage
+export { TreePage as default } from 'src/components/Tree/TreePage'


### PR DESCRIPTION
When loading for the first time the `/tree` page  shows blank space without even navbar and footer. This is due to dynamic loading of the page content.

Here I:
 - bubble the `Layout` component from tree page one level up, out of dynamically loaded chunk, so that navbar and footer are static and displayed at all times
 -  add `loading` parameter to `dynamic()` call, such that the loading spinner is displayed during page fetching

The page still freezes after fetching, while the tree is rendered. I believe this is due to the sheer amount of things being rendered in Auspice, but might also be perf problems on Nextclade side. I don't currently know a way to handle this or how to display loading indicator there, because React rendering is still synchronous and blocks main thread.

