### PR TITLE
fix(web): tree styles

### DIFF
--- a/packages_rs/nextclade-web/src/components/Layout/Footer.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/Footer.tsx
@@ -19,7 +19,6 @@ const Container = styled.footer`
   bottom: 0;
   padding: 6px 10px;
   box-shadow: ${(props) => props.theme.shadows.large};
-  z-index: 1000;
   background-color: ${(props) => props.theme.white};
   opacity: 1;
 `

--- a/packages_rs/nextclade-web/src/components/Layout/Layout.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/Layout.tsx
@@ -16,6 +16,7 @@ const Container = styled.div`
 
 const HeaderWrapper = styled.header`
   height: 45px;
+  z-index: 1001;
 `
 
 const MainInner = styled.main`
@@ -38,7 +39,9 @@ const MainOuter = styled.main`
   margin: 0;
 `
 
-const FooterWrapper = styled.footer``
+const FooterWrapper = styled.footer`
+  z-index: 1001;
+`
 
 export function Layout({ children }: PropsWithChildren<HTMLProps<HTMLDivElement>>) {
   return (

--- a/packages_rs/nextclade-web/src/components/Tree/TreePageContent.tsx
+++ b/packages_rs/nextclade-web/src/components/Tree/TreePageContent.tsx
@@ -51,6 +51,7 @@ const TreeTopPanel = styled.div`
 
 const FiltersSummaryWrapper = styled.div`
   flex: 1 1 100%;
+  padding-left: 1rem;
 `
 
 const LogoGisaidWrapper = styled.div`


### PR DESCRIPTION
Adds small padding for tree filter text, increases z-index of header and footer so that their shadow is always above the tree page svg components.

