### PR TITLE
feat(cli): invert --include-community and --include-experimental flags

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -137,40 +137,34 @@ pub struct NextcladeDatasetListArgs {
   pub tag: Option<String>,
 
   /// Include dataset versions that are incompatible with this version of Nextclade CLI.
-  ///
-  /// By default the incompatible versions are omitted.
   #[clap(long)]
   pub include_incompatible: bool,
 
   /// Include deprecated datasets.
   ///
-  /// By default the deprecated datasets are omitted.
-  ///
   /// Authors can mark a dataset as deprecated to express that the dataset will no longer be updated and/or supported. Reach out to dataset authors for concrete details.
   #[clap(long)]
   pub include_deprecated: bool,
 
-  /// Include experimental datasets.
-  ///
-  /// By default the experimental datasets are omitted.
+  /// Exclude experimental datasets.
   ///
   /// Authors can mark a dataset as experimental when development of the dataset is still in progress, or if the dataset is incomplete or of lower quality than usual. Use at own risk. Reach out to dataset authors if interested in further development and stabilizing of a particular dataset, and consider contributing.
   #[clap(long)]
-  pub include_experimental: bool,
+  pub no_experimental: bool,
 
-  /// Include community datasets.
-  ///
-  /// By default the community datasets are omitted.
+  /// Exclude community datasets and only show official datasets.
   ///
   /// Community datasets are the datasets provided by the members of the broader Nextclade community. These datasets may vary in quality and completeness. Depending on authors' goals, these datasets may be created for specific purposes, rather than for general use. Nextclade team is unable to verify correctness of these datasets and does not provide support for them. For all questions regarding a concrete community dataset, please read its documentation and reach out to its authors.
   #[clap(long)]
-  pub include_community: bool,
+  pub no_community: bool,
 
   /// Print output in JSON format.
+  ///
+  /// This is useful for automated processing. However, at this time, we cannot guarantee stability of the format. Use at own risk.
   #[clap(long)]
   pub json: bool,
 
-  /// Print only names of the datasets, without other details.
+  /// Print only names of the datasets, without any other details.
   #[clap(long)]
   pub only_names: bool,
 

--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use log::LevelFilter;
 use nextclade::io::dataset::{Dataset, DatasetsIndexJson};
 use nextclade::io::json::{json_stringify, JsonPretty};
-use nextclade::make_error;
 use nextclade::utils::info::this_package_version;
 
 pub fn nextclade_dataset_list(
@@ -16,8 +15,8 @@ pub fn nextclade_dataset_list(
     tag,
     include_incompatible,
     include_deprecated,
-    include_experimental,
-    include_community,
+    no_experimental,
+    no_community,
     json,
     only_names,
     server,
@@ -41,8 +40,8 @@ pub fn nextclade_dataset_list(
       } else {
         let is_compatible = include_incompatible || dataset.is_cli_compatible(this_package_version());
         let is_not_deprecated = include_deprecated || !dataset.is_deprecated();
-        let is_not_experimental = include_experimental || !dataset.is_experimental();
-        let is_not_community = include_community || !dataset.is_community();
+        let is_not_experimental = !no_experimental || !dataset.is_experimental();
+        let is_not_community = !no_community || !dataset.is_community();
         is_compatible && is_not_deprecated && is_not_experimental && is_not_community
       }
     })

--- a/tests/run-smoke-tests
+++ b/tests/run-smoke-tests
@@ -217,7 +217,7 @@ export -f download_and_run_single_dataset
 
 
 if [ -z "${INPUT_DATASETS_DIR}" ]; then
-  all_datasets=$(${NEXTCLADE_BIN} dataset list --include-experimental --include-community --include-deprecated --only-names)
+  all_datasets=$(${NEXTCLADE_BIN} dataset list --include-deprecated --only-names)
   parallel --keep-order --jobs=+0 download_and_run_single_dataset ::: "${all_datasets}"
 else
   find "${INPUT_DATASETS_DIR}" -iname "pathogen.json" -exec dirname '{}' \; |  parallel --keep-order --jobs=+0 run_single_dataset


### PR DESCRIPTION
Let's invert the boolean flags `--include-community` and `--include-experimental` to --no-community and `--no-experimental` in `dataset list` command.

This way community and experimental will be shown by default, additionally promoting their use, increase probability of user feedback and improvements.

