### PR TITLE
fix(web): adjust typography

### DIFF
--- a/packages_rs/nextclade-web/src/styles/_variables.scss
+++ b/packages_rs/nextclade-web/src/styles/_variables.scss
@@ -36,6 +36,9 @@ $font-family-default: $font-family-sans-serif;
 $font-family-base: $font-family-default;
 $font-size-base: 1rem;
 
+$line-height-base: 1.25;
+$headings-line-height: 1;
+
 $white: #ffffff;
 $gray-100: #f8f9fa; // stylelint-disable-line plugin/stylelint-no-indistinguishable-colors
 $gray-150: #eff1f3;


### PR DESCRIPTION
Adjust bootstrap theme's line weight for all text and separately for headings to match the currently used font.

This prevents headings from having additional spacing (non-margin, non-padding) at the bottom, due to excessive line height, and makes alignment of neighboring inline elements easier.