### PR TITLE
feat: Separate undeletions from reversion substitutions

### DIFF
--- a/packages_rs/nextclade/src/analyze/mod.rs
+++ b/packages_rs/nextclade/src/analyze/mod.rs
@@ -14,6 +14,7 @@ pub mod letter_ranges;
 pub mod nuc_changes;
 pub mod nuc_del;
 pub mod nuc_sub;
+pub mod nuc_undel;
 pub mod pcr_primer_changes;
 pub mod phenotype;
 pub mod virus_properties;

--- a/packages_rs/nextclade/src/analyze/nuc_undel.rs
+++ b/packages_rs/nextclade/src/analyze/nuc_undel.rs
@@ -1,0 +1,83 @@
+use crate::alphabet::nuc::Nuc;
+use crate::analyze::abstract_mutation::{AbstractMutation, MutParams, Pos, QryLetter, RefLetter};
+use crate::analyze::nuc_sub::NucSub;
+use crate::coord::position::NucRefGlobalPosition;
+use crate::coord::range::NucRefGlobalRange;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, schemars::JsonSchema, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct NucUndelRange {
+  range: NucRefGlobalRange,
+}
+
+impl NucUndelRange {
+  pub fn new(begin: NucRefGlobalPosition, end: NucRefGlobalPosition) -> Self {
+    Self {
+      range: NucRefGlobalRange::new(begin, end),
+    }
+  }
+
+  pub fn from_usize(begin: usize, end: usize) -> Self {
+    Self {
+      range: NucRefGlobalRange::from_usize(begin, end),
+    }
+  }
+
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.range.len()
+  }
+
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.range.is_empty()
+  }
+
+  #[inline]
+  pub const fn range(&self) -> &NucRefGlobalRange {
+    &self.range
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, schemars::JsonSchema, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct NucUndel {
+  pub pos: NucRefGlobalPosition,
+  pub qry_nuc: Nuc,
+}
+
+impl RefLetter<Nuc> for NucUndel {
+  fn ref_letter(&self) -> Nuc {
+    Nuc::Gap
+  }
+}
+impl QryLetter<Nuc> for NucUndel {
+  fn qry_letter(&self) -> Nuc {
+    self.qry_nuc
+  }
+}
+
+impl Pos<NucRefGlobalPosition> for NucUndel {
+  fn pos(&self) -> NucRefGlobalPosition {
+    self.pos
+  }
+}
+
+impl NucUndel {
+  pub const fn to_sub(&self) -> NucSub {
+    NucSub {
+      ref_nuc: Nuc::Gap,
+      pos: self.pos,
+      qry_nuc: self.qry_nuc,
+    }
+  }
+}
+
+impl Display for NucUndel {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    self.to_sub().fmt(f)
+  }
+}


### PR DESCRIPTION
In v2, we ignored undeletions (i.e. ref is gap, qry is ref)
Until now, in v3, we treat them as reversion substitutions
A single stretch 20 bps undeleted results in 20 reversion substitutions which results in unexpectedly large QC penalties (some penalty is ok but it's too large as is)

In this PR, I split undeletions from ordinary substitutions and then aggregate them into NucUndelRanges (Richard said you might have a function for that @ivan-aksamentov but I couldn't find one so I made one myself)

Currently, nothing is done with the undeletion ranges, but we could surface them into TSV/web UI at a later point. We could also count each stretch towards QC as a single unit of a reversion (and analogously treat each private deletion stretch as a single private mutation).

We also don't seem to surface private deletions at the moment, so this could be done as a package.
