### PR TITLE
Consistent usage of gene vs CDS in the interface

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -816,7 +816,7 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
 
     if output_selection.contains(&NextcladeOutputSelection::Translations) {
       let output_translations_path =
-        default_output_file_path.with_file_name(format!("{output_basename}_gene_{{gene}}"));
+        default_output_file_path.with_file_name(format!("{output_basename}_cds_{{cds}}"));
       let output_translations_path = add_extension(output_translations_path, "translation.fasta");
 
       let output_translations_template = output_translations_path

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -350,7 +350,7 @@ pub struct NextcladeRunInputArgs {
   /// not be translated, amino acid sequences will not be output, amino acid mutations will not be detected and nucleotide sequence
   /// alignment will not be informed by codon boundaries
   ///
-  /// List of genes can be restricted using `--genes` flag. Otherwise all genes found in the genome annotation will be used.
+  /// List of genes can be restricted using `--genes` flag. Otherwise, all genes found in the genome annotation will be used.
   ///
   /// Overrides genome annotation provided by the dataset (`--input-dataset` or `--dataset-name`).
   ///
@@ -362,11 +362,12 @@ pub struct NextcladeRunInputArgs {
   #[clap(value_hint = ValueHint::FilePath)]
   pub input_annotation: Option<PathBuf>,
 
-  /// Comma-separated list of names of genes to use.
+  /// Comma-separated list of names of coding sequences (CDSes) to use.
   ///
   /// This defines which peptides will be written into outputs, and which genes will be taken into account during
-  /// codon-aware alignment and aminoacid mutations detection. Must only contain gene names present in the genome annotation. If
-  /// this flag is not supplied or its value is an empty string, then all genes found in the genome annotation will be used.
+  /// codon-aware alignment and aminoacid mutations detection. Must only contain CDS names present in the genome annotation.
+  ///
+  /// If this flag is not supplied or its value is an empty string, then all CDSes found in the genome annotation will be used.
   ///
   /// Requires `--input-annotation` to be specified.
   #[clap(
@@ -376,7 +377,7 @@ pub struct NextcladeRunInputArgs {
     use_value_delimiter = true
   )]
   #[clap(value_hint = ValueHint::FilePath)]
-  pub genes: Option<Vec<String>>,
+  pub cdses: Option<Vec<String>>,
 
   /// Use custom dataset server
   #[clap(long)]

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -816,7 +816,7 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
 
     if output_selection.contains(&NextcladeOutputSelection::Translations) {
       let output_translations_path =
-        default_output_file_path.with_file_name(format!("{output_basename}_cds_{{cds}}"));
+        default_output_file_path.with_file_name(format!("{output_basename}.cds_translation.{{cds}}.fasta"));
       let output_translations_path = add_extension(output_translations_path, "translation.fasta");
 
       let output_translations_template = output_translations_path

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -494,7 +494,7 @@ pub struct NextcladeRunOutputArgs {
   ///
   /// Example for bash shell:
   ///
-  ///   --output-translations='output_dir/gene_{gene}.translation.fasta'
+  ///   --output-translations='output_dir/cds_{cds}.translation.fasta'
   #[clap(long, short = 'P')]
   #[clap(value_hint = ValueHint::AnyPath)]
   pub output_translations: Option<String>,
@@ -853,17 +853,17 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
   }
 
   if let Some(output_translations) = output_translations {
-    if !output_translations.contains("{gene}") {
+    if !output_translations.contains("{cds}") {
       return make_error!(
         r#"
-Expected `--output-translations` argument to contain a template string containing template variable {{gene}} (with curly braces), but received:
+Expected `--output-translations` argument to contain a template string containing template variable {{cds}} (with curly braces), but received:
 
   {output_translations}
 
 Make sure the variable is not substituted by your shell, programming language or workflow manager. Apply proper escaping as needed.
 Example for bash shell:
 
-  --output-translations='output_dir/gene_{{gene}}.translation.fasta'
+  --output-translations='output_dir/cds_{{cds}}.translation.fasta'
 
       "#
       );

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -377,7 +377,7 @@ pub struct NextcladeRunInputArgs {
     use_value_delimiter = true
   )]
   #[clap(value_hint = ValueHint::FilePath)]
-  pub cdses: Option<Vec<String>>,
+  pub cds_selection: Option<Vec<String>>,
 
   /// Use custom dataset server
   #[clap(long)]

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -26,7 +26,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
 
   let NextcladeRunArgs {
     inputs: NextcladeRunInputArgs {
-      input_fastas, cdses, ..
+      input_fastas, cds_selection: cdses, ..
     },
     outputs:
       NextcladeRunOutputArgs {

--- a/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_loop.rs
@@ -26,7 +26,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
 
   let NextcladeRunArgs {
     inputs: NextcladeRunInputArgs {
-      input_fastas, genes, ..
+      input_fastas, cdses, ..
     },
     outputs:
       NextcladeRunOutputArgs {
@@ -40,7 +40,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
     other_params: NextcladeRunOtherParams { jobs },
   } = run_args.clone();
 
-  let inputs = nextclade_get_inputs(&run_args, &genes)?;
+  let inputs = nextclade_get_inputs(&run_args, &cdses)?;
   let nextclade = Nextclade::new(inputs, &params)?;
 
   let should_write_tree = output_tree.is_some() || output_tree_nwk.is_some() || output_graph.is_some();

--- a/packages_rs/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages_rs/nextclade-web/src/hooks/useExportResults.ts
@@ -41,7 +41,7 @@ export const DEFAULT_EXPORT_PARAMS: ExportParams = {
   filenameTreeNwk: 'nextclade.nwk',
   filenameFasta: 'nextclade.aligned.fasta',
   filenamePeptidesZip: 'nextclade.peptides.fasta.zip',
-  filenamePeptidesTemplate: 'nextclade.peptide.{{GENE}}.fasta',
+  filenamePeptidesTemplate: 'nextclade.peptide.{{cds}}.fasta',
 }
 
 function useResultsExport(exportFn: (filename: string, snapshot: Snapshot, worker: ExportWorker) => Promise<void>) {
@@ -215,7 +215,7 @@ async function preparePeptideFiles(snapshot: Snapshot) {
           file.data = `${file.data}${fastaEntry}`
         } else {
           let filename = DEFAULT_EXPORT_PARAMS.filenamePeptidesTemplate
-          filename = filename.replace('{{GENE}}', name)
+          filename = filename.replace('{{cds}}', name)
           filesMap.set(name, { filename, data: fastaEntry })
         }
       }

--- a/packages_rs/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages_rs/nextclade-web/src/hooks/useExportResults.ts
@@ -41,7 +41,7 @@ export const DEFAULT_EXPORT_PARAMS: ExportParams = {
   filenameTreeNwk: 'nextclade.nwk',
   filenameFasta: 'nextclade.aligned.fasta',
   filenamePeptidesZip: 'nextclade.peptides.fasta.zip',
-  filenamePeptidesTemplate: 'nextclade.peptide.{{cds}}.fasta',
+  filenamePeptidesTemplate: 'nextclade.cds_translation.{{cds}}.fasta',
 }
 
 function useResultsExport(exportFn: (filename: string, snapshot: Snapshot, worker: ExportWorker) => Promise<void>) {

--- a/packages_rs/nextclade/src/gene/gene_map.rs
+++ b/packages_rs/nextclade/src/gene/gene_map.rs
@@ -160,19 +160,17 @@ impl GeneMap {
 }
 
 /// Filters genome annotation according to the list of requested genes.
-pub fn filter_gene_map(gene_map: GeneMap, genes: &Option<Vec<String>>) -> GeneMap {
-  if let Some(genes) = genes {
+pub fn filter_gene_map(gene_map: GeneMap, cdses: &Option<Vec<String>>) -> GeneMap {
+  if let Some(cdses) = cdses {
     let gene_map: BTreeMap<String, Gene> = gene_map
       .into_iter_genes()
-      .filter(|(gene_name, ..)| genes.contains(gene_name))
+      .filter(|(gene_name, ..)| cdses.contains(gene_name))
       .collect();
 
-    let requested_genes_not_in_genemap = get_requested_genes_not_in_genemap(&gene_map, genes);
-    if !requested_genes_not_in_genemap.is_empty() {
+    let requested_but_not_found = get_requested_cdses_not_in_genemap(&gene_map, cdses);
+    if !requested_but_not_found.is_empty() {
       warn!(
-        "The following genes were requested through `--genes` \
-           but not found in the genome annotation: \
-           `{requested_genes_not_in_genemap}`",
+        "The following genes were requested through `--cdses` but not found in the genome annotation: {requested_but_not_found}",
       );
     }
     return GeneMap::from_genes(gene_map);
@@ -180,11 +178,12 @@ pub fn filter_gene_map(gene_map: GeneMap, genes: &Option<Vec<String>>) -> GeneMa
   gene_map
 }
 
-fn get_requested_genes_not_in_genemap(gene_map: &BTreeMap<String, Gene>, genes: &[String]) -> String {
-  genes
+fn get_requested_cdses_not_in_genemap(gene_map: &BTreeMap<String, Gene>, cdses: &[String]) -> String {
+  cdses
     .iter()
-    .filter(|&gene_name| !gene_map.contains_key(gene_name))
-    .join("`, `")
+    .filter(|&cds_name| !gene_map.contains_key(cds_name))
+    .map(|name| format!("'{name}'"))
+    .join(", ")
 }
 
 pub fn convert_feature_tree_to_gene_map(feature_tree: &FeatureTree) -> Result<GeneMap, Report> {

--- a/packages_rs/nextclade/src/io/fasta.rs
+++ b/packages_rs/nextclade/src/io/fasta.rs
@@ -197,7 +197,7 @@ impl FastaWriter {
 
 #[derive(Clone, Debug, Serialize)]
 struct OutputTranslationsTemplateContext<'a> {
-  gene: &'a str,
+  cds: &'a str,
 }
 
 pub type FastaPeptideWritersMap = BTreeMap<String, FastaWriter>;
@@ -218,7 +218,7 @@ impl FastaPeptideWriter {
     let writers = gene_map
       .iter_cdses()
       .map(|cds| -> Result<_, Report> {
-        let template_context = OutputTranslationsTemplateContext { gene: &cds.name };
+        let template_context = OutputTranslationsTemplateContext { cds: &cds.name };
         let rendered_path = tt
           .render("output_translations", &template_context)
           .wrap_err_with(|| format!("When rendering output translations path template: '{output_translations}', using context: {template_context:?}"))?;

--- a/tests/run-smoke-tests
+++ b/tests/run-smoke-tests
@@ -41,7 +41,7 @@ function run_with_dataset_dir() {
 
   ${NEXTCLADE_BIN} run --quiet --in-order --include-reference \
     --input-dataset="${dataset_dir}" \
-    --output-translations="${out_dir}/translations/gene_{gene}.translation.fasta" \
+    --output-translations="${out_dir}/translations/{cds}.translation.fasta" \
     --output-all="${out_dir}" \
     "${sequences}"
 }
@@ -56,7 +56,7 @@ function run_with_dataset_zip() {
 
   ${NEXTCLADE_BIN} run --quiet --in-order --include-reference \
     --input-dataset="${dataset_dir}/dataset.zip" \
-    --output-translations="${out_dir}/translations/gene_{gene}.translation.fasta" \
+    --output-translations="${out_dir}/translations/{cds}.translation.fasta" \
     --output-all="${out_dir}" \
     "${sequences}"
 }
@@ -71,7 +71,7 @@ function run_with_ref_only() {
 
   ${NEXTCLADE_BIN} run --quiet --in-order --include-reference \
     --input-ref="${dataset_dir}/reference.fasta" \
-    --output-translations="${out_dir}/translations/gene_{gene}.translation.fasta" \
+    --output-translations="${out_dir}/translations/{cds}.translation.fasta" \
     --output-all="${out_dir}" \
     "${sequences}"
 }
@@ -89,7 +89,7 @@ function run_with_ref_and_annotation() {
   ${NEXTCLADE_BIN} run --quiet --in-order --include-reference \
     --input-ref="${dataset_dir}/reference.fasta" \
     --input-annotation="${dataset_dir}/genome_annotation.gff3" \
-    --output-translations="${out_dir}/translations/gene_{gene}.translation.fasta" \
+    --output-translations="${out_dir}/translations/{cds}.translation.fasta" \
     --output-all="${out_dir}" \
     "${sequences}"
 }
@@ -107,7 +107,7 @@ function run_with_ref_and_tree() {
   ${NEXTCLADE_BIN} run --quiet --in-order --include-reference \
     --input-ref="${dataset_dir}/reference.fasta" \
     --input-tree="${dataset_dir}/tree.json" \
-    --output-translations="${out_dir}/translations/gene_{gene}.translation.fasta" \
+    --output-translations="${out_dir}/translations/{cds}.translation.fasta" \
     --output-all="${out_dir}" \
     "${sequences}"
 }
@@ -127,7 +127,7 @@ function run_with_ref_and_annotation_and_tree() {
     --input-ref="${dataset_dir}/reference.fasta" \
     --input-annotation="${dataset_dir}/genome_annotation.gff3" \
     --input-tree="${dataset_dir}/tree.json" \
-    --output-translations="${out_dir}/translations/gene_{gene}.translation.fasta" \
+    --output-translations="${out_dir}/translations/{cds}.translation.fasta" \
     --output-all="${out_dir}" \
     "${sequences}"
 }


### PR DESCRIPTION
Attempts to remove inconsistencies in naming and handling of genes and CDSes, to reflect changes in how genome annotations are handled in v3.

In Nextclade v2 there were only genes, so in Nextclade CLI `--genes` argument and `{gene}` placeholder in `--output-translations` make sense.

In Nextclade v3 there are genes and CDSes involved and CDSes have central place - they are now what's need to be selected by the `--gene` arguments and the CDS name needs to be substituted where the `{gene}` variable was.

So in this PR, at the very minimum, I did:

 - rename `--genes` to `--cds-selection` (initially `--cdses`, but Richard suggested `--cds-selection`)
 - rename `{gene}` to `{cds}` in `--output-translations` template string
 - change default value for `--output-translations` template string from `nextclade_gene_{gene}.translation.fasta` to `nextclade_cds_{cds}.translation.fasta` (breaking, because there is a word "gene" changed to "cds". Not the variable, it disappears when substututed, but the hardcoded word - it stays).
 - change template string in Nextclade Web from `nextclade.peptide.{gene}.fasta` to `nextclade.peptide.{cds}.fasta` (transparent to users)

This is a breaking change and involves changes to CLI arguments and to default output filenames.

#### Open questions:
 - Whether referring to CDSes by name only is sufficient. In general case, in GFF3, there could be multiple CDS with the same name. They can be nested under different genes or not.
 - If it's not sufficient, then we might consider a different design, where both gene name and CDS name are involved. For example, `--cdses` can accept a hierarchical name in `{gene}/{cds}` format and `--output-translations` would allow both `{gene}` and `{cds}` placeholders. Both can be optional features - you can omit `{gene}`.
 - Alternative design is separate `--cdses` and `--genes` flag, but then linking of the two lists of values is impossible in order to resolve potential duplicate names.
 - The root of the problem is that the GFF3 format identifies features by index of the row, and we are trying to resolve features by name. And in case of `--output-translations`, filesystems require filenames to be unique . This is similar to the problem of resolving sequences by sequence names in fasta (solved by using index in the fasta file instead). This is a problem for downstream users as well, because in case of ambiguity of names, it's impossible to find the required output file.
 - If we want to take into account the order, we might add variables which denote index of gene and cds, e.g.  `{i_gene}`, `{i_cds}`. Indices to GFF3 rows are guaranteed to be unique. This would allow users to also tie output translations with annotation or with mutations.
 - Indices is how I initially wanted to keep track of GFF3 features internally, but unfortunately our parser library does not provide row indices of features. We can fork the code though.
 - Our mutation notation only contain CDS now: `{cds}:{ref}{pos}{qry}`. In case of non-unique CDS names it's impossible to tell which one the mutation belongs to. To solve this we could use hierarchical notation as well: `{gene}/{cds}:{ref}{pos}{qry}` and perhaps simplify the notation automatically if CDS and gene have the same name, e.g. avoid `S/S:`. Can also be made configurable on runtime. But this variable format will be fun to parse in downstream applications. I cannot see how indices can be used here - technically they could be used, but in practice this will be very hard to read.
 - CDS selector dropdown currently can list CDSes with non-unique names, but only if they are nested under genes with different names.
 - Difficulty of the problem increases, if/when we add proteins (`--proteins`? `{protein}`?)
