### PR TITLE
feat: detect if duplicate cds name present in annotation

### DIFF
--- a/packages_rs/nextclade/src/gene/gene_map.rs
+++ b/packages_rs/nextclade/src/gene/gene_map.rs
@@ -155,6 +155,20 @@ impl GeneMap {
       })
     })?;
 
+    //Error loudly if non-unique CDS names, as otherwise it will be hard to debug for the user
+    let duplicate_cds_names = self
+      .iter_cdses()
+      .map(|cds| cds.name.clone())
+      .group_by(Clone::clone)
+      .into_iter()
+      .filter_map(|(cds_name, group)| group.count().gt(&1).then_some(cds_name))
+      .join(", ");
+    if !duplicate_cds_names.is_empty() {
+      return Err(eyre!(
+        "Nextclade expects CDS names to be unique, but the following CDS names are duplicated: {duplicate_cds_names}"
+      ));
+    }
+
     Ok(())
   }
 }


### PR DESCRIPTION
If there's a duplicate cds name, we randomly choose one
of the cdses for translations, which would be confusing
to users. So better to error.

Test with:

```
##sequence-region NC_063383.1 1 197209
##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=10244
##NC_063383.1	RefSeq	region	1	197209	.	+	.	ID=NC_063383.1:1..197209;Dbxref=taxon:10244;collection-date=2018-08;country=Nigeria: Rivers State;gbkey=Src;genome=genomic;genotype=West African clade;isolate=MPXV-M5312_HM12_Rivers;mol_type=genomic DNA;nat-host=Homo sapiens
## Required edit of above line for augur translate
NC_063383.1	RefSeq	source	1	197209	.	+	.	gene_name=nuc;ID=NC_063383.1:1..197209;Dbxref=taxon:10244;collection-date=2018-08;country=Nigeria: Rivers State;gbkey=Src;genome=genomic;genotype=West African clade;isolate=MPXV-M5312_HM12_Rivers;mol_type=genomic DNA;nat-host=Homo sapiens
NC_063383.1	RefSeq	gene	835	1575	.	-	.	ID=gene-NBT03_gp001;Dbxref=GeneID:72551607;Name=OPG001;gbkey=Gene;gene_name=OPG001;gene_biotype=protein_coding;locus_tag=NBT03_gp001;old_locus_tag=MPXV-M5312_HM12_Rivers-001
NC_063383.1	RefSeq	CDS	835	1575	.	-	0	ID=cds-YP_010377002.1;Parent=gene-NBT03_gp001;Dbxref=Genbank:YP_010377002.1,GeneID:72551607;name=YP_010377002.1;Note=J1L%3B similar to Vaccinia virus strain Copenhagen C23L%3B most abundant secreted protein%3B CC-chemokine binding;gbkey=CDS;Name=OPG001;locus_tag=NBT03_gp001;product=MPXVgp001;protein_id=YP_010377002.1
NC_063383.1	RefSeq	CDS	1500	2000	.	-	0	ID=cds-YP_010377003.1;Parent=gene-NBT03_gp001;Dbxref=Genbank:YP_010377002.1,GeneID:72551607;name=YP_010377002.1;Note=J1L%3B similar to Vaccinia virus strain Copenhagen C23L%3B most abundant secreted protein%3B CC-chemokine binding;gbkey=CDS;Name=OPG001;locus_tag=NBT03_gp001;product=MPXVgp001;protein_id=YP_010377002.1
```

Which should output:

```txt
Error: 
    0: When downloading dataset 'nextstrain/sars-cov-2/MN908947'
    1: When reading genome annotation from dataset
    2: Nextclade expects CDS names to be unique, but the following CDS names are duplicated: OPG001
```