### PR TITLE
feat: separate undeletions from reversion substitutions

### DIFF
--- a/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_nuc_mutations.rs
@@ -103,7 +103,7 @@ pub fn find_private_nuc_mutations(
     process_seq_deletions(node_mut_map, deletions, ref_seq, &mut seq_positions_mutated_or_deleted);
 
   // Iterate over node substitutions and deletions and find reversions
-  let reversion_substitutions = find_reversions(
+  let reversion_substitutions_undeletions = find_reversions(
     node_mut_map,
     missing,
     alignment_range,
@@ -112,6 +112,9 @@ pub fn find_private_nuc_mutations(
     &mut seq_positions_mutated_or_deleted,
   );
 
+  let (undeletions, reversion_substitutions) = reversion_substitutions_undeletions
+    .into_iter()
+    .partition::<Vec<NucSub>, _>(|sub| sub.ref_nuc.is_gap());
   let (labeled_substitutions, unlabeled_substitutions) = label_private_mutations(
     &non_reversion_substitutions,
     &virus_properties.mut_labels.nuc_mut_label_map,
@@ -131,6 +134,8 @@ pub fn find_private_nuc_mutations(
   let total_reversion_substitutions = reversion_substitutions.len();
   let total_labeled_substitutions = labeled_substitutions.len();
   let total_unlabeled_substitutions = unlabeled_substitutions.len();
+
+  // TODO: Do something with the undeletions, they are not returned from this function
 
   PrivateNucMutations {
     private_substitutions,


### PR DESCRIPTION
In v2, we ignored undeletions (i.e. ref is gap, qry is ref)
Until now, in v3, we treat them as reversion substitutions
A single stretch 20 bps undeleted results in 20 reversion substitutions which results in unexpectedly large QC penalties (some penalty is ok but it's too large as is)

In this PR, I split undeletions from ordinary substitutions

Currently, nothing is done with the undeletions ranges, but we could surface them into TSV/web UI at a later point. We could also count each stretch/range towards QC as a single unit of a reversion (and analogously treat each private deletion stretch as a single private mutation).

We also don't seem to surface private deletions at the moment, so this could be done as a package.

Stripped down version of #1296 without aggregation of undeletions into ranges
