### PR TITLE
feat(gff): pick gene/cds/protein preferentially from "nextclade_name"

### DIFF
--- a/packages_rs/nextclade/src/io/gff3.rs
+++ b/packages_rs/nextclade/src/io/gff3.rs
@@ -15,6 +15,7 @@ use std::io::Read;
 
 /// Possible keys for name attribute (in order of preference!)
 pub const NAME_ATTRS_GENE: &[&str] = &[
+  "nextclade_name",
   "Gene",
   "gene",
   "gene_name",
@@ -35,6 +36,7 @@ pub const NAME_ATTRS_GENE: &[&str] = &[
 ];
 
 pub const NAME_ATTRS_CDS: &[&str] = &[
+  "nextclade_name",
   "Name",
   "name",
   "Alias",
@@ -55,6 +57,7 @@ pub const NAME_ATTRS_CDS: &[&str] = &[
 ];
 
 pub const NAME_ATTRS_PROTEIN: &[&str] = &[
+  "nextclade_name",
   "product",
   "protein_id",
   "gene_synonym",


### PR DESCRIPTION
This change means that we don't need to communicate the exact complicated order of preference
for gene/cds/protein name to end users

Instead, we can simply say:
"If you want to have nextclade show a particular gene/cds/protein name, set the "nextclade_name" attribute
