### PR TITLE
fix(web): make URL parameter `dataset-url` work again

### DIFF
--- a/packages_rs/nextclade-web/src/io/fetchSingleDatasetFromUrl.ts
+++ b/packages_rs/nextclade-web/src/io/fetchSingleDatasetFromUrl.ts
@@ -1,6 +1,7 @@
 import urljoin from 'url-join'
+import { mapValues } from 'lodash'
 import { concurrent } from 'fasy'
-import { attrStrMaybe, Dataset, VirusProperties } from 'src/types'
+import { attrStrMaybe, Dataset, DatasetFiles, VirusProperties } from 'src/types'
 import { removeTrailingSlash } from 'src/io/url'
 import { axiosFetch, axiosHead } from 'src/io/axiosFetch'
 import { sanitizeError } from 'src/helpers/sanitizeError'
@@ -19,6 +20,7 @@ export async function fetchSingleDatasetFromUrl(
       qc: [],
     },
     ...pathogen,
+    files: mapValues(pathogen.files, (file) => (file ? urljoin(datasetRootUrl, file) : file)) as DatasetFiles,
   }
 
   const datasets = [currentDataset]
@@ -42,7 +44,7 @@ export async function fetchSingleDatasetFromUrl(
         })
       }
     },
-    Object.entries(currentDataset.files).filter(([filename, _]) => !['tag.json', 'sequences.fasta'].includes(filename)),
+    Object.entries(currentDataset.files).filter(([filename, _]) => !['sequences.fasta'].includes(filename)),
   )
 
   return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }


### PR DESCRIPTION
Examples:

- Local server: https://nextclade-git-fix-web-dataset-url-nextstrain.vercel.app/?dataset-url=http://localhost:3001&input-fasta=example
- GitHub full URL: https://nextclade-git-fix-web-dataset-url-nextstrain.vercel.app/?dataset-url=https://github.com/nextstrain/nextclade_data/tree/master/data/nextstrain/zika/KX369547.1&input-fasta=example
- GitHub shortcut: https://nextclade-git-fix-web-dataset-url-nextstrain.vercel.app/?dataset-url=gh:nextstrain/nextclade_data/data/nextstrain/zika/KX369547.1&input-fasta=example

