### PR TITLE
feat(web): default to official repo and path when omitted from url param

### DIFF
--- a/packages_rs/nextclade-web/src/constants.ts
+++ b/packages_rs/nextclade-web/src/constants.ts
@@ -33,6 +33,9 @@ export const URL_CLADE_SCHEMA_REPO = 'https://github.com/nextstrain/ncov-clades-
 export const URL_CLADE_SCHEMA_SVG = 'https://raw.githubusercontent.com/nextstrain/ncov-clades-schema/master/clades.svg'
 
 export const URL_GITHUB_DATA_RAW = 'https://raw.githubusercontent.com/nextstrain/nextclade_data' as const
+export const DEFAULT_DATA_OWNER = 'nextstrain' as const
+export const DEFAULT_DATA_REPO = 'nextclade_data' as const
+export const DEFAULT_DATA_REPO_PATH = '/data_output' as const
 
 export const SUPPORT_EMAIL = 'hello@nextstrain.org'
 

--- a/packages_rs/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasets.ts
@@ -90,7 +90,7 @@ export async function getDatasetServerUrl(urlQuery: ParsedUrlQuery) {
 
   // If requested to try GitHub-hosted datasets either using `DATA_TRY_GITHUB_BRANCH` env var (e.g. from
   // `.env` file), or using `&dataset-server=gh` or `&dataset-server=github` URL parameters, then check if the
-  // corresponding branch in the default data repo on GitHub contains an `index.json` file. And and if yes, use it.
+  // corresponding branch in the default data repo on GitHub contains an `index.json` file. And if yes, use it.
   const datasetServerTryGithubBranch =
     (isNil(datasetServerUrl) && process.env.DATA_TRY_GITHUB_BRANCH === '1') ||
     (datasetServerUrl && ['gh', 'github'].includes(datasetServerUrl))


### PR DESCRIPTION
This allows to use GitHub shortcuts with only branch specified:

```
?dataset-server=gh:@my-branch@
```

In this case, it assumes official data repo (`nextstrain/nextclade_data`) and the default path (`/data_output`) in it.

