### PR TITLE
feat: warn user about `--genes` -> `--cdses` renaming

### DIFF
--- a/docs/user/nextclade-cli/reference.md
+++ b/docs/user/nextclade-cli/reference.md
@@ -98,9 +98,10 @@ For short help type: `nextclade -h`, for extended help type: `nextclade --help`.
 * `-r`, `--input-ref <INPUT_REF>` — Path to a FASTA file containing reference sequence. This file should contain exactly 1 sequence
 * `-a`, `--input-tree <INPUT_TREE>` — Path to Auspice JSON v2 file containing reference tree
 * `-p`, `--input-pathogen-json <INPUT_PATHOGEN_JSON>` — Path to a JSON file containing configuration and data specific to a pathogen
-* `-m`, `--input-annotation <INPUT_ANNOTATION>` — Path to a GFF3 file containing (genome annotation)
+* `-m`, `--input-annotation <INPUT_ANNOTATION>` — Path to a file containing genome annotation in GFF3 format
 * `-g`, `--cds-selection <CDS_SELECTION>` — Comma-separated list of names of coding sequences (CDSes) to use
 * `--server <SERVER>` — Use custom dataset server
+
 
 
 

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -359,13 +359,12 @@ pub struct NextcladeRunInputArgs {
   #[clap(value_hint = ValueHint::FilePath)]
   pub input_pathogen_json: Option<PathBuf>,
 
-  /// Path to a GFF3 file containing (genome annotation).
+  /// Path to a file containing genome annotation in GFF3 format.
   ///
   /// Genome annotation is used to find coding regions. If not supplied, coding regions will
-  /// not be translated, amino acid sequences will not be output, amino acid mutations will not be detected and nucleotide sequence
-  /// alignment will not be informed by codon boundaries
+  /// not be translated, amino acid sequences will not be output, amino acid mutations will not be detected and nucleotide sequence alignment will not be informed by codon boundaries.
   ///
-  /// List of genes can be restricted using `--genes` flag. Otherwise, all genes found in the genome annotation will be used.
+  /// List of CDSes can be restricted using `--cds-selection` argument. Otherwise, all CDSes found in the genome annotation will be used.
   ///
   /// Overrides genome annotation provided by the dataset (`--input-dataset` or `--dataset-name`).
   ///
@@ -379,12 +378,10 @@ pub struct NextcladeRunInputArgs {
 
   /// Comma-separated list of names of coding sequences (CDSes) to use.
   ///
-  /// This defines which peptides will be written into outputs, and which genes will be taken into account during
+  /// This defines which peptides will be written into outputs, and which CDS will be taken into account during
   /// codon-aware alignment and aminoacid mutations detection. Must only contain CDS names present in the genome annotation.
   ///
   /// If this flag is not supplied or its value is an empty string, then all CDSes found in the genome annotation will be used.
-  ///
-  /// Requires `--input-annotation` to be specified.
   #[clap(
     long,
     short = 'g',
@@ -436,7 +433,7 @@ pub struct NextcladeRunInputArgs {
   #[clap(hide_long_help = true, hide_short_help = true)]
   pub genemap: Option<String>,
 
-  /// RENAMED to `--cds-selection`
+  /// REMOVED in favor of `--cds-selection`
   #[clap(long)]
   #[clap(hide_long_help = true, hide_short_help = true)]
   pub genes: Option<Vec<String>>,
@@ -941,7 +938,10 @@ const ERROR_MSG_INPUT_ROOT_SEQ_REMOVED: &str =
 const ERROR_MSG_INPUT_GENE_MAP_RENAMED: &str =
   r#"The argument `--input-gene-map` (alias `--genemap`) is renamed to `--input-annotation`."#;
 
-const ERROR_MSG_GENES_RENAMED: &str = r#"The argument `--genes` is renamed to `--cds-selection`."#;
+const ERROR_MSG_GENES_RENAMED: &str = r#"The argument `--genes` is removed in favor of `--cds-selection`.
+
+Nextclade now relies on features of type "CDS" rather than "gene" in genome annotation. Please take a note of CDS features in the genome annotation file and use `--cds-selection` argument to select CDS features you want Nextclade to take into account during the analysis. Alternatively, remove the argument to analyze all CDS features present in genome annotation.
+"#;
 
 const ERROR_MSG_OUTPUT_DIR_REMOVED: &str = r#"The argument `--output-dir` is removed in favor of `--output-all`.
 

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -435,6 +435,11 @@ pub struct NextcladeRunInputArgs {
   #[clap(long)]
   #[clap(hide_long_help = true, hide_short_help = true)]
   pub genemap: Option<String>,
+
+  /// RENAMED to `--cds-selection`
+  #[clap(long)]
+  #[clap(hide_long_help = true, hide_short_help = true)]
+  pub genes: Option<Vec<String>>,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -936,6 +941,8 @@ const ERROR_MSG_INPUT_ROOT_SEQ_REMOVED: &str =
 const ERROR_MSG_INPUT_GENE_MAP_RENAMED: &str =
   r#"The argument `--input-gene-map` (alias `--genemap`) is renamed to `--input-annotation`."#;
 
+const ERROR_MSG_GENES_RENAMED: &str = r#"The argument `--genes` is renamed to `--cds-selection`."#;
+
 const ERROR_MSG_OUTPUT_DIR_REMOVED: &str = r#"The argument `--output-dir` is removed in favor of `--output-all`.
 
 When provided, `--output-all` allows to write all possible outputs into a directory.
@@ -997,6 +1004,10 @@ pub fn nextclade_check_removed_args(run_args: &NextcladeRunArgs) -> Result<(), R
 
   if run_args.inputs.input_pcr_primers.is_some() {
     return make_error!("{ERROR_MSG_INPUT_PCR_PRIMERS_REMOVED}{MSG_READ_RUN_DOCS}");
+  }
+
+  if run_args.inputs.genes.is_some() {
+    return make_error!("{ERROR_MSG_GENES_RENAMED}{MSG_READ_RUN_DOCS}");
   }
 
   if run_args.outputs.output_dir.is_some() {


### PR DESCRIPTION
Follow-up of #1298

Came across when I used `--genes` and got a wrong suggestion from clap (`--genemap`).

Tested:
```
./bin/nextclade run             results/all-clades/filtered.fasta             --retry-reverse-complement             --input-ref resources/all-clades/reference.fasta             --excess-bandwidth 100             --terminal-bandwidth 300             --allowed-mismatches 8             --window-size 40             --min-seed-cover 0.1             --input-annotation resources/genome_annotation.gff3             --gap-alignment-side left             --output-fasta results/all-clades/aligned.fasta             --include-reference             --genes NBT03_gp052,NBT03_gp174,NBT03_gp175,OPG001_dup,OPG002_dup,OPG003_dup,OPG001,OPG002,OPG003,OPG005,OPG015,OPG019,OPG021,OPG022,OPG023,OPG024,OPG025,OPG027,OPG029,OPG030,OPG031,OPG034,OPG035,OPG036,OPG037,OPG038,OPG039,OPG040,OPG042,OPG043,OPG044,OPG045,OPG046,OPG047,OPG048,OPG049,OPG050,OPG051,OPG052,OPG053,OPG054,OPG055,OPG056,OPG057,OPG058,OPG059,OPG060,OPG061,OPG062,OPG063,OPG064,OPG065,OPG066,OPG068,OPG069,OPG070,OPG071,OPG072,OPG074,OPG075,OPG076,OPG077,OPG078,OPG079,OPG080,OPG081,OPG082,OPG083,OPG084,OPG085,OPG086,OPG087,OPG088,OPG089,OPG090,OPG091,OPG092,OPG093,OPG094,OPG095,OPG096,OPG097,OPG098,OPG099,OPG100,OPG101,OPG102,OPG103,OPG104,OPG105,OPG106,OPG107,OPG108,OPG109,OPG110,OPG111,OPG112,OPG113,OPG114,OPG115,OPG116,OPG117,OPG118,OPG119,OPG120,OPG121,OPG122,OPG123,OPG124,OPG125,OPG126,OPG127,OPG128,OPG129,OPG130,OPG131,OPG132,OPG133,OPG134,OPG135,OPG136,OPG137,OPG138,OPG139,OPG140,OPG141,OPG142,OPG143,OPG144,OPG145,OPG146,OPG147,OPG148,OPG149,OPG150,OPG151,OPG153,OPG154,OPG155,OPG156,OPG157,OPG158,OPG159,OPG160,OPG161,OPG162,OPG163,OPG164,OPG165,OPG167,OPG170,OPG171,OPG172,OPG173,OPG174,OPG175,OPG176,OPG178,OPG180,OPG181,OPG185,OPG187,OPG188,OPG189,OPG190,OPG191,OPG192,OPG193,OPG195,OPG197,OPG198,OPG199,OPG200,OPG204,OPG205,OPG208,OPG209,OPG210             --output-translations results/all-clades/translations/{gene}.fasta
Error: 
   0: The argument `--genes` is renamed to `--cds-selection`.

      For more information, type

        nextclade run --help

      Read Nextclade documentation at:

        https://docs.nextstrain.org/projects/nextclade/en/stable

Location:
   packages_rs/nextclade-cli/src/cli/nextclade_cli.rs:1010

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.

```
