### PR TITLE
Add dataset name shortcuts

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_get.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_get.rs
@@ -64,7 +64,7 @@ pub fn dataset_http_get(http: &mut HttpClient, name: impl AsRef<str>, tag: &Opti
     })
     // Filter by name
     .filter(|dataset| {
-      dataset.path == name
+      dataset.path == name || dataset.shortcuts.contains(&String::from(name))
     })
     .collect_vec();
 

--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -46,7 +46,7 @@ pub fn nextclade_dataset_list(
     })
     .filter(|dataset| {
       if let Some(name) = &name {
-        name == &dataset.path
+        name == &dataset.path || dataset.shortcuts.contains(name)
       } else {
         true
       }

--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -53,14 +53,7 @@ pub fn nextclade_dataset_list(
     })
     .filter(|dataset| {
       if let Some(search) = &search {
-        [
-          Some(dataset.path.as_str()),
-          dataset.name(),
-          dataset.ref_name(),
-          dataset.ref_accession(),
-        ]
-        .iter()
-        .any(|candidate| candidate.unwrap_or_default().contains(search))
+        dataset.search_strings().any(|candidate| candidate.contains(search))
       } else {
         true
       }

--- a/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
@@ -220,6 +220,7 @@ pub fn dataset_individual_files_load(
           VirusProperties {
             schema_version: "".to_owned(),
             attributes: BTreeMap::default(),
+            shortcuts: vec![],
             meta: DatasetMeta::default(),
             files: DatasetFiles {
               reference: "".to_owned(),

--- a/packages_rs/nextclade-web/src/components/Main/DatasetSelectorList.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetSelectorList.tsx
@@ -38,7 +38,7 @@ export function DatasetSelectorList({
       attrStrMaybe(dataset.attributes, 'name') ?? '',
       attrStrMaybe(dataset.attributes, 'reference name') ?? '',
       attrStrMaybe(dataset.attributes, 'reference accession') ?? '',
-      dataset.path,
+      ...(dataset.shortcuts ?? []),
     ])
   }, [datasetsActive, datasetsInactive, searchTerm])
 

--- a/packages_rs/nextclade-web/src/io/fetchDatasetsIndex.ts
+++ b/packages_rs/nextclade-web/src/io/fetchDatasetsIndex.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios'
-import { get, head, mapValues, sortBy, sortedUniq } from 'lodash'
+import { get, head, isNil, mapValues, sortBy, sortedUniq } from 'lodash'
 import semver from 'semver'
 import { takeFirstMaybe } from 'src/helpers/takeFirstMaybe'
 import urljoin from 'url-join'
@@ -47,7 +47,7 @@ export function findDataset(datasets: Dataset[], name?: string, tag?: string) {
 /** Find the datasets given name, ref and tag */
 export function filterDatasets(datasets: Dataset[], name?: string, tag?: string) {
   return datasets.filter((dataset) => {
-    let isMatch = dataset.path === name
+    let isMatch = !isNil(name) && (dataset.path === name || !!dataset.shortcuts?.includes(name))
 
     if (tag) {
       isMatch = isMatch && dataset.version?.tag === tag

--- a/packages_rs/nextclade/src/analyze/virus_properties.rs
+++ b/packages_rs/nextclade/src/analyze/virus_properties.rs
@@ -33,6 +33,9 @@ pub struct VirusProperties {
   #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
   pub attributes: BTreeMap<String, AnyType>,
 
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub shortcuts: Vec<String>,
+
   #[serde(default, skip_serializing_if = "DatasetMeta::is_default")]
   pub meta: DatasetMeta,
 

--- a/packages_rs/nextclade/src/io/dataset.rs
+++ b/packages_rs/nextclade/src/io/dataset.rs
@@ -3,7 +3,7 @@ use crate::io::schema_version::{SchemaVersion, SchemaVersionParams};
 use crate::o;
 use crate::utils::any::AnyType;
 use eyre::Report;
-use itertools::Itertools;
+use itertools::{chain, Itertools};
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,20 @@ impl Dataset {
     self.attributes.get("name").and_then(AnyType::as_str_maybe)
   }
 
+  pub fn search_strings(&self) -> impl Iterator<Item = &str> {
+    let names = [
+      Some(self.path.as_str()),
+      self.name(),
+      self.ref_name(),
+      self.ref_accession(),
+    ]
+    .into_iter()
+    .flatten();
+
+    let shortcuts = self.shortcuts.iter().map(String::as_str);
+
+    chain!(names, shortcuts)
+  }
   pub fn ref_name(&self) -> Option<&str> {
     self.attributes.get("reference name").and_then(AnyType::as_str_maybe)
   }

--- a/packages_rs/nextclade/src/io/dataset.rs
+++ b/packages_rs/nextclade/src/io/dataset.rs
@@ -57,6 +57,9 @@ pub struct DatasetCollection {
 pub struct Dataset {
   pub path: String,
 
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub shortcuts: Vec<String>,
+
   #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
   pub attributes: BTreeMap<String, AnyType>,
 


### PR DESCRIPTION
Sibling PR in data: https://github.com/nextstrain/nextclade_data/pull/116 (can be merged independently; no breakage)

This allows to use shortcuts instead of full paths for datasets containing `shortcuts` array in their `pathogen.json`:

CLI example:

```bash
nextclade run --dataset-name='sc2'
nextclade dataset list --name='sc2'
nextclade dataset list --search='sc2'
nextclade dataset get --name='sc2'
```

Web example:

https://nextclade-git-feat-dataset-name-shortcuts-nextstrain.vercel.app/?dataset-name=sc2

(these examples assume that there is a dataset which defines a shortcut `sc2`; in PR https://github.com/nextstrain/nextclade_data/pull/116 this is `nextstrain/sars-cov-2/MN908947`)


