### PR TITLE
fix(web): improve long text fit in the ui

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/DatasetInfo.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetInfo.tsx
@@ -30,20 +30,18 @@ export const FlexRight = styled.div`
   display: flex;
   flex-direction: column;
   margin-left: 1rem;
-  width: 10px;
+  width: 0;
 `
 
 export const DatasetName = styled.h4`
-  flex: 1;
+  margin-bottom: 0;
   font-weight: bold;
-
-  overflow: hidden;
+  overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `
 
 export const DatasetInfoLine = styled.span`
-  flex: 1;
   font-size: 0.9rem;
   padding: 0;
   margin: 0;
@@ -84,6 +82,11 @@ export function DatasetInfo({ dataset, showSuggestions }: DatasetInfoProps) {
     return updatedAt
   }, [t, version?.tag, version?.updatedAt])
 
+  const datasetName = attrStrMaybe(attributes, 'name') ?? path
+  const datasetRef = t('Reference: {{ ref }}', { ref: formatReference(attributes) })
+  const datasetUpdatedAt = t('Updated at: {{updated}}', { updated: updatedAt })
+  const datasetPath = t('Dataset name: {{name}}', { name: path })
+
   return (
     <Container>
       <FlexLeft>
@@ -91,9 +94,7 @@ export function DatasetInfo({ dataset, showSuggestions }: DatasetInfoProps) {
       </FlexLeft>
 
       <FlexRight>
-        <DatasetName>
-          <span>{attrStrMaybe(attributes, 'name') ?? path}</span>
-        </DatasetName>
+        <DatasetName title={datasetName}>{datasetName}</DatasetName>
 
         <DatasetInfoBadgeContainer>
           <span className="d-flex ml-auto">
@@ -144,9 +145,9 @@ export function DatasetInfo({ dataset, showSuggestions }: DatasetInfoProps) {
           </span>
         </DatasetInfoBadgeContainer>
 
-        <DatasetInfoLine>{t('Reference: {{ ref }}', { ref: formatReference(attributes) })}</DatasetInfoLine>
-        <DatasetInfoLine>{t('Updated at: {{updated}}', { updated: updatedAt })}</DatasetInfoLine>
-        <DatasetInfoLine>{t('Dataset name: {{name}}', { name: path })}</DatasetInfoLine>
+        <DatasetInfoLine title={datasetRef}>{datasetRef}</DatasetInfoLine>
+        <DatasetInfoLine title={datasetUpdatedAt}>{datasetUpdatedAt}</DatasetInfoLine>
+        <DatasetInfoLine title={datasetPath}>{datasetPath}</DatasetInfoLine>
       </FlexRight>
     </Container>
   )

--- a/packages_rs/nextclade-web/src/components/Main/DatasetInfo.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/DatasetInfo.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components'
 
 export const Container = styled.div`
   display: flex;
+  flex: 1;
   margin: 0;
 `
 
@@ -29,25 +30,36 @@ export const FlexRight = styled.div`
   display: flex;
   flex-direction: column;
   margin-left: 1rem;
+  width: 10px;
 `
 
 export const DatasetName = styled.h4`
-  display: flex;
+  flex: 1;
   font-weight: bold;
-  margin: 0;
-  padding: 0;
-  height: 100%;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
-export const DatasetInfoLine = styled.p`
+export const DatasetInfoLine = styled.span`
+  flex: 1;
   font-size: 0.9rem;
   padding: 0;
   margin: 0;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &:after {
     content: ' ';
     white-space: pre;
   }
+`
+
+const DatasetInfoBadgeContainer = styled.div`
+  margin: 0.25rem 0;
 `
 
 const DatasetInfoBadge = styled(Badge)`
@@ -83,7 +95,7 @@ export function DatasetInfo({ dataset, showSuggestions }: DatasetInfoProps) {
           <span>{attrStrMaybe(attributes, 'name') ?? path}</span>
         </DatasetName>
 
-        <div>
+        <DatasetInfoBadgeContainer>
           <span className="d-flex ml-auto">
             {path.startsWith('nextstrain') ? (
               <DatasetInfoBadge
@@ -130,7 +142,7 @@ export function DatasetInfo({ dataset, showSuggestions }: DatasetInfoProps) {
               </DatasetInfoBadge>
             )}
           </span>
-        </div>
+        </DatasetInfoBadgeContainer>
 
         <DatasetInfoLine>{t('Reference: {{ ref }}', { ref: formatReference(attributes) })}</DatasetInfoLine>
         <DatasetInfoLine>{t('Updated at: {{updated}}', { updated: updatedAt })}</DatasetInfoLine>
@@ -148,48 +160,6 @@ function formatReference(attributes: Record<string, AnyType> | undefined) {
   }
   return name
 }
-
-export function DatasetAutodetectInfo({ dataset }: { dataset: Dataset }) {
-  const { t } = useTranslationSafe()
-
-  return (
-    <ContainerFixed>
-      <FlexLeft>
-        <DatasetInfoAutodetectProgressCircle dataset={dataset} />
-      </FlexLeft>
-
-      <FlexRight>
-        <DatasetName>
-          <span>{t('Autodetect')}</span>
-        </DatasetName>
-        <DatasetInfoLine>{t('Detect pathogen automatically from sequences')}</DatasetInfoLine>
-        <DatasetInfoLine>{'\u00A0'}</DatasetInfoLine>
-        <DatasetInfoLine>{'\u00A0'}</DatasetInfoLine>
-        <DatasetInfoLine>{'\u00A0'}</DatasetInfoLine>
-      </FlexRight>
-    </ContainerFixed>
-  )
-}
-
-export function DatasetUndetectedInfo() {
-  const { t } = useTranslationSafe()
-
-  return (
-    <ContainerFixed>
-      <DatasetName>
-        <span>{t('Not detected')}</span>
-      </DatasetName>
-      <DatasetInfoLine>{t('Unable to deduce dataset')}</DatasetInfoLine>
-      <DatasetInfoLine>{'\u00A0'}</DatasetInfoLine>
-      <DatasetInfoLine>{'\u00A0'}</DatasetInfoLine>
-      <DatasetInfoLine>{'\u00A0'}</DatasetInfoLine>
-    </ContainerFixed>
-  )
-}
-
-const ContainerFixed = styled(Container)`
-  height: 127px;
-`
 
 export interface DatasetInfoCircleProps {
   dataset: Dataset

--- a/packages_rs/nextclade-web/src/components/Main/MainInputForm.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/MainInputForm.tsx
@@ -91,12 +91,12 @@ export function Landing() {
       <Main className="mt-4 mb-2">
         <ContainerColumns className="w-100">
           <Row className="w-100">
-            <Col className="d-flex flex-column h-100">
+            <Col md={6} className="d-flex flex-column h-100">
               <QuerySequenceFilePicker />
               <QuerySequenceList />
             </Col>
 
-            <Col>
+            <Col md={6}>
               <DatasetCurrentOrSelectButton toDatasetSelection={toDatasetSelection} />
             </Col>
           </Row>

--- a/packages_rs/nextclade-web/src/components/Main/QuerySequenceList.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/QuerySequenceList.tsx
@@ -95,7 +95,7 @@ export function InputFileInfo({ input, index }: InputFileInfoProps) {
 
   return (
     <Container>
-      <InputName>{input.description}</InputName>
+      <InputName title={input.description}>{input.description}</InputName>
       <ButtonTransparent title={t(' Remove this input')} onClick={onRemoveClicked}>
         <ImCross color={theme.gray500} />
       </ButtonTransparent>

--- a/packages_rs/nextclade-web/src/components/Main/QuerySequenceList.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/QuerySequenceList.tsx
@@ -71,6 +71,15 @@ export const Li = styled.li`
   border-radius: 5px !important;
 `
 
+export const InputName = styled.p`
+  flex: 1;
+  margin: auto 5px;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
 export interface InputFileInfoProps {
   input: AlgorithmInput
   index: number
@@ -86,7 +95,7 @@ export function InputFileInfo({ input, index }: InputFileInfoProps) {
 
   return (
     <Container>
-      <h6 className="flex-grow-1 my-auto">{input.description}</h6>
+      <InputName>{input.description}</InputName>
       <ButtonTransparent title={t(' Remove this input')} onClick={onRemoveClicked}>
         <ImCross color={theme.gray500} />
       </ButtonTransparent>


### PR DESCRIPTION
Prevents text on main page from overflowing when datasets contain excessively long field values.