### PR TITLE
fix(web): fix html nesting error in nav menu

### DIFF
--- a/packages_rs/nextclade-web/src/components/Layout/NavigationMenu.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/NavigationMenu.tsx
@@ -52,8 +52,13 @@ const DropdownMenu = styled(DropdownMenuBase)`
   width: 200px;
 `
 
-const DropdownMenuListWrapper = styled.div`
+const DropdownMenuListWrapper = styled.ul`
   max-height: calc(80vh - 150px);
   min-height: 100px;
   overflow-y: auto;
+  padding: 0;
+
+  > li {
+    list-style: none;
+  }
 `


### PR DESCRIPTION
The error was:

> `li` cannot be child of `li`

this was due to a missing wrapper `ul` in the menu,

