### PR TITLE
fix(web): don't start another run of autosuggest if already running

### DIFF
--- a/packages_rs/nextclade-web/src/components/Main/MainInputForm.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/MainInputForm.tsx
@@ -5,6 +5,7 @@ import { Col, Row } from 'reactstrap'
 import { useRecoilState, useRecoilValue } from 'recoil'
 import styled from 'styled-components'
 import { SuggestionAlertMainPage } from 'src/components/Main/SuggestionAlertMainPage'
+import { AutodetectRunState, autodetectRunStateAtom } from 'src/state/autodetect.state'
 import { datasetCurrentAtom } from 'src/state/dataset.state'
 import { hasRequiredInputsAtom } from 'src/state/inputs.state'
 import { shouldSuggestDatasetsOnDatasetPageAtom } from 'src/state/settings.state'
@@ -71,16 +72,17 @@ export function Landing() {
   const runAutodetect = useRunSeqAutodetect()
   const hasRequiredInputs = useRecoilValue(hasRequiredInputsAtom)
   const shouldSuggestDatasets = useRecoilValue(shouldSuggestDatasetsOnDatasetPageAtom)
+  const autodetectRunState = useRecoilValue(autodetectRunStateAtom)
 
   const toDatasetSelection = useCallback(() => {
     // eslint-disable-next-line no-void
     void push('/dataset').then(() => {
-      if (shouldSuggestDatasets && hasRequiredInputs) {
+      if (shouldSuggestDatasets && hasRequiredInputs && autodetectRunState !== AutodetectRunState.Started) {
         runAutodetect()
       }
       return undefined
     })
-  }, [hasRequiredInputs, push, runAutodetect, shouldSuggestDatasets])
+  }, [autodetectRunState, hasRequiredInputs, push, runAutodetect, shouldSuggestDatasets])
 
   return (
     <ContainerFixed>


### PR DESCRIPTION
This avoids second redundant run of dataset auto-suggest when navigating to dataset page and when auto-suggest is already running

