### PR TITLE
feat(web): Support Safari >= 16.0 again

### DIFF
--- a/packages_rs/nextclade-web/src/components/Common/BrowserWarning.tsx
+++ b/packages_rs/nextclade-web/src/components/Common/BrowserWarning.tsx
@@ -19,6 +19,7 @@ export function BrowserWarning() {
       chrome: '>60',
       edge: '>79',
       firefox: '>52',
+      safari: '>=16',
     })
 
     if (isSupportedBrowser) {


### PR DESCRIPTION
The reason we deprecated Safari was that it didn't support shared web workers Since v16.0 shared web workers are supported so we no longer need to show the browser warning  Alternatively, we could discourage less loudly, saying that Safari is not tested (for >=16) while still erroring for lower versions.

