### PR TITLE
fix(web): center logos in footer div

### DIFF
--- a/packages_rs/nextclade-web/src/components/Layout/Footer.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/Footer.tsx
@@ -34,7 +34,7 @@ const CopyrightText = styled.div`
 
 const LogoContainer = styled.div`
   flex-grow: 1;
-  text-align: right;
+  text-align: center;
 `
 
 const LogoLink = styled(LinkExternal)`


### PR DESCRIPTION
I noticed that the logos were not centered. This PR might fix that.

Before (black line is centered):
<img width="1765" alt="image" src="https://github.com/nextstrain/nextclade/assets/25161793/149bfd89-f6b6-4362-ac8a-5ae4fdafd88e">

After:
<img width="1757" alt="image" src="https://github.com/nextstrain/nextclade/assets/25161793/020eb8d9-1cd6-4bd0-88b1-d9f1397b4a35">

I think it's better
