### PR TITLE
fix(web): handle `input-fasta` URL param when it's not a GH shortcut

### DIFF
--- a/packages_rs/nextclade-web/src/io/createInputFromUrlParamMaybe.ts
+++ b/packages_rs/nextclade-web/src/io/createInputFromUrlParamMaybe.ts
@@ -30,9 +30,12 @@ export async function createInputFastasFromUrlParam(
     if (url === 'example') {
       return dataset ? new AlgorithmInputDefault(dataset) : undefined
     }
-    if (isString(url) && isGithubUrlOrShortcut(url)) {
-      const { directUrl } = await parseGitHubRepoUrlOrShortcut(url)
-      return new AlgorithmInputUrl(directUrl)
+    if (isString(url)) {
+      if (isGithubUrlOrShortcut(url)) {
+        const { directUrl } = await parseGitHubRepoUrlOrShortcut(url)
+        return new AlgorithmInputUrl(directUrl)
+      }
+      return new AlgorithmInputUrl(url)
     }
     return undefined
   }, urls)


### PR DESCRIPTION
The code was missing a return statement for the default case when a raw URL is passed.

