### PR TITLE
feat: rename 'gene' to 'cds' in code and public interfaces

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -133,9 +133,6 @@ impl NextcladeOrderedWriter {
       }) => {
         let NextcladeOutputs {
           warnings,
-          insertions,
-          aa_insertions,
-          missing_genes,
           is_reverse_complement,
           ..
         } = &analysis_result;

--- a/packages_rs/nextclade-web/src/components/Results/ColumnAaMotifs.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnAaMotifs.tsx
@@ -244,15 +244,15 @@ export function ListOfAaMotifMutations({ motifs }: ListOfAaMotifMutationsProps) 
 
     const aaMotifsTruncated = motifs.slice(0, 20)
 
-    const tbody = aaMotifsTruncated.map(({ gene, position, refSeq, qrySeq }) => {
-      const cdsObj = cdses.find((cds) => cds.name === gene)
+    const tbody = aaMotifsTruncated.map(({ cds, position, refSeq, qrySeq }) => {
+      const cdsObj = cdses.find((cds1) => cds1.name === cds)
       const bg = cdsObj?.color ?? theme.gray400
       const fg = theme.gray200
       return (
-        <Tr key={`${gene}-${position}`}>
+        <Tr key={`${cds}-${position}`}>
           <TdNormal>
             <GeneText $background={bg} $color={fg}>
-              {gene}
+              {cds}
             </GeneText>
           </TdNormal>
           <TdNormal className="text-center">{position + 1}</TdNormal>

--- a/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ColumnNameTooltip.tsx
@@ -68,7 +68,7 @@ export function ColumnNameTooltip({ index }: ColumnNameTooltipProps) {
 
   const warningComponents = useMemo(() => {
     return (result?.analysisResult?.warnings ?? []).map((warning) => (
-      <Alert key={`${warning.geneName}: ${warning.warning}`} color="warning" fade={false} className="px-2 py-1 my-1">
+      <Alert key={`${warning.cdsName}: ${warning.warning}`} color="warning" fade={false} className="px-2 py-1 my-1">
         <WarningIcon />
         {warning.warning}
       </Alert>

--- a/packages_rs/nextclade-web/src/components/Results/ListOfFrameShifts.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ListOfFrameShifts.tsx
@@ -12,7 +12,7 @@ export function FrameShiftRows({ frameShifts }: FrameShiftRowsProps) {
   return (
     <ul>
       {frameShifts.map((fs) => (
-        <li key={`${fs.geneName}_${fs.codon.begin}`}>{formatFrameShift(fs)}</li>
+        <li key={`${fs.cdsName}_${fs.codon.begin}`}>{formatFrameShift(fs)}</li>
       ))}
     </ul>
   )

--- a/packages_rs/nextclade-web/src/components/Results/ListOfInsertions.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ListOfInsertions.tsx
@@ -177,7 +177,7 @@ export function ListOfInsertionsAa({ insertions }: ListOfInsertionsAaProps) {
   const { thead, tbody } = useMemo(() => {
     const thead = (
       <tr>
-        <ThNormal className="text-center">{t('Gene.')}</ThNormal>
+        <ThNormal className="text-center">{t('CDS')}</ThNormal>
         <ThNormal className="text-center">{t('After ref pos.')}</ThNormal>
         <ThNormal className="text-center">{t('Length')}</ThNormal>
         <ThFragment className="text-center">{t('Inserted fragment')}</ThFragment>
@@ -185,9 +185,9 @@ export function ListOfInsertionsAa({ insertions }: ListOfInsertionsAaProps) {
     )
 
     const insertionsTruncated = insertions.slice(0, 20)
-    const tbody = insertionsTruncated.map(({ pos, ins, gene }) => (
+    const tbody = insertionsTruncated.map(({ pos, ins, cds }) => (
       <tr key={pos}>
-        <TdNormal className="text-center">{gene}</TdNormal>
+        <TdNormal className="text-center">{cds}</TdNormal>
         <TdNormal className="text-center">{pos + 1}</TdNormal>
         <TdNormal className="text-center">{ins.length}</TdNormal>
         <TdFragment className="text-left">

--- a/packages_rs/nextclade-web/src/components/Results/ListOfStopCodons.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ListOfStopCodons.tsx
@@ -12,7 +12,7 @@ export function StopCodonsItems({ stopCodons }: StopCodonsRowsProps) {
   return (
     <ul>
       {stopCodons.map((sc) => (
-        <li key={`${sc.geneName}_${sc.codon}`}>{formatStopCodon(sc)}</li>
+        <li key={`${sc.cdsName}_${sc.codon}`}>{formatStopCodon(sc)}</li>
       ))}
     </ul>
   )

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideMarkerFrameShift.tsx
@@ -34,10 +34,10 @@ function PeptideMarkerFrameShiftUnmemoed({
   const onMouseEnter = useCallback(() => setShowTooltip(true), [])
   const onMouseLeave = useCallback(() => setShowTooltip(false), [])
 
-  const { geneName, nucAbs, codon, gapsLeading, gapsTrailing } = frameShift
+  const { cdsName, nucAbs, codon, gapsLeading, gapsTrailing } = frameShift
   const id = getSafeId('frame-shift-aa-marker', { index, seqName, ...frameShift })
 
-  const cds = useRecoilValue(cdsAtom(geneName))
+  const cds = useRecoilValue(cdsAtom(cdsName))
   if (!cds) {
     return null
   }
@@ -92,8 +92,8 @@ function PeptideMarkerFrameShiftUnmemoed({
               </tr>
 
               <tr>
-                <td>{t('Gene')}</td>
-                <td>{geneName}</td>
+                <td>{t('CDS')}</td>
+                <td>{cdsName}</td>
               </tr>
 
               <tr>

--- a/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/PeptideView.tsx
@@ -50,7 +50,7 @@ export function PeptideViewMissing({ geneName, reasons }: PeptideViewMissingProp
       <Tooltip wide fullWidth target={id} isOpen={showTooltip} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <p>{t('This gene is missing due to the following errors during analysis: ')}</p>
         {reasons.map((warn) => (
-          <Alert key={warn.geneName} color="warning" fade={false} className="px-2 py-1 my-1">
+          <Alert key={warn.cdsName} color="warning" fade={false} className="px-2 py-1 my-1">
             <WarningIcon />
             {warn.warning}
           </Alert>
@@ -87,7 +87,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
     )
   }
 
-  const warningsForThisGene = (warnings ?? []).filter((warn) => warn.geneName === viewedGene)
+  const warningsForThisGene = (warnings ?? []).filter((warn) => warn.cdsName === viewedGene)
   if (warningsForThisGene.length > 0) {
     return (
       <SequenceViewWrapper>
@@ -101,11 +101,11 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
   const pixelsPerAa = width / Math.round(cdsLength)
   const groups = aaChangesGroups.filter((group) => group.name === viewedGene)
 
-  const unknownAaRangesForGene = unknownAaRanges.find((range) => range.geneName === viewedGene)
+  const unknownAaRangesForGene = unknownAaRanges.find((range) => range.cdsName === viewedGene)
   const unsequencedRanges = aaUnsequencedRanges[viewedGene] ?? []
 
   const frameShiftMarkers = frameShifts
-    .filter((frameShift) => frameShift.geneName === cds.name)
+    .filter((frameShift) => frameShift.cdsName === cds.name)
     .map((frameShift) => {
       const id = getSafeId('frame-shift-aa-marker', { ...frameShift })
       return (
@@ -120,7 +120,7 @@ export function PeptideViewUnsized({ width, sequence, warnings, viewedGene }: Pe
     })
 
   const insertionMarkers = aaInsertions
-    .filter((ins) => ins.gene === viewedGene)
+    .filter((ins) => ins.cds === viewedGene)
     .map((insertion) => {
       return (
         <PeptideMarkerInsertion

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceMarkerFrameShift.tsx
@@ -23,7 +23,7 @@ export interface FrameShiftMarkerProps extends SVGProps<SVGRectElement> {
 export const SequenceMarkerFrameShift = React.memo(SequenceMarkerFrameShiftUnmemoed)
 
 function SequenceMarkerFrameShiftUnmemoed({ index, seqName, frameShift, pixelsPerBase }: FrameShiftMarkerProps) {
-  const { geneName, nucAbs, codon, gapsTrailing, gapsLeading } = frameShift
+  const { cdsName, nucAbs, codon, gapsTrailing, gapsLeading } = frameShift
 
   const frameShiftSegments = useMemo(
     () =>
@@ -43,7 +43,7 @@ function SequenceMarkerFrameShiftUnmemoed({ index, seqName, frameShift, pixelsPe
             key={id}
             identifier={id}
             index={index}
-            geneName={geneName}
+            geneName={cdsName}
             codon={codon}
             nucAbs={nucAbs}
             gapsTrailing={gapsTrailing}
@@ -52,7 +52,7 @@ function SequenceMarkerFrameShiftUnmemoed({ index, seqName, frameShift, pixelsPe
           />
         )
       }),
-    [codon, gapsLeading, gapsTrailing, geneName, index, nucAbs, pixelsPerBase, seqName],
+    [codon, gapsLeading, gapsTrailing, cdsName, index, nucAbs, pixelsPerBase, seqName],
   )
 
   // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
+++ b/packages_rs/nextclade-web/src/components/SequenceView/SequenceView.tsx
@@ -132,7 +132,7 @@ export function SequenceViewUnsized({ sequence, width }: SequenceViewProps) {
 
   const frameShiftMarkers = frameShifts.map((frameShift) => (
     <SequenceMarkerFrameShift
-      key={`${frameShift.geneName}_${frameShift.nucAbs.map((na) => na.begin).join('-')}`}
+      key={`${frameShift.cdsName}_${frameShift.nucAbs.map((na) => na.begin).join('-')}`}
       index={index}
       seqName={seqName}
       frameShift={frameShift}

--- a/packages_rs/nextclade-web/src/helpers/formatFrameShift.ts
+++ b/packages_rs/nextclade-web/src/helpers/formatFrameShift.ts
@@ -1,6 +1,6 @@
 import type { FrameShift } from 'src/types'
 import { formatRange } from 'src/helpers/formatRange'
 
-export function formatFrameShift({ geneName, codon }: FrameShift) {
-  return `${geneName}:${formatRange(codon)}`
+export function formatFrameShift({ cdsName, codon }: FrameShift) {
+  return `${cdsName}:${formatRange(codon)}`
 }

--- a/packages_rs/nextclade-web/src/helpers/formatMutation.ts
+++ b/packages_rs/nextclade-web/src/helpers/formatMutation.ts
@@ -24,8 +24,8 @@ export function formatAADeletion({ cdsName, refAa, pos }: AaDel) {
   return `${cdsName}:${notation}`
 }
 
-export function formatStopCodon({ geneName, codon }: StopCodonLocation) {
+export function formatStopCodon({ cdsName, codon }: StopCodonLocation) {
   // NOTE: by convention, codons are numbered starting from 1, however our arrays are 0-based
   const codonOneBased = codon + 1
-  return `${geneName}:${codonOneBased}`
+  return `${cdsName}:${codonOneBased}`
 }

--- a/packages_rs/nextclade-web/src/helpers/formatQCStopCodons.ts
+++ b/packages_rs/nextclade-web/src/helpers/formatQCStopCodons.ts
@@ -13,7 +13,7 @@ export function formatQCStopCodons<TFunction extends TFunctionInterface>(
 
   const { score, stopCodons, totalStopCodons } = qcStopCodons
 
-  const geneList = uniq(stopCodons.map((sc) => sc.geneName)).join(', ')
+  const geneList = uniq(stopCodons.map((sc) => sc.cdsName)).join(', ')
 
   return t(
     '{{totalStopCodons}} misplaced stop codon(s) detected. Affected gene(s): {{geneList}}. QC score: {{score}}',

--- a/packages_rs/nextclade/src/align/insertions_strip.rs
+++ b/packages_rs/nextclade/src/align/insertions_strip.rs
@@ -105,7 +105,7 @@ pub fn insertions_strip<T: Letter<T>>(qry_seq: &[T], ref_seq: &[T]) -> StripInse
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AaIns {
-  pub gene: String,
+  pub cds: String,
   pub pos: i32,
 
   #[schemars(with = "String")]
@@ -117,7 +117,7 @@ pub struct AaIns {
 /// Order amino acid insertions by gene, position, then length
 impl Ord for AaIns {
   fn cmp(&self, other: &Self) -> Ordering {
-    (&self.gene, self.pos, self.ins.len()).cmp(&(&other.gene, other.pos, other.ins.len()))
+    (&self.cds, self.pos, self.ins.len()).cmp(&(&other.cds, other.pos, other.ins.len()))
   }
 }
 
@@ -132,7 +132,7 @@ pub fn get_aa_insertions(translation: &Translation) -> Vec<AaIns> {
     .iter_cdses()
     .flat_map(|(cds_name, cds_tr)| {
       cds_tr.insertions.iter().map(|Insertion::<Aa> { pos, ins }| AaIns {
-        gene: cds_name.clone(),
+        cds: cds_name.clone(),
         pos: *pos,
         ins: ins.clone(),
       })

--- a/packages_rs/nextclade/src/analyze/find_aa_motifs.rs
+++ b/packages_rs/nextclade/src/analyze/find_aa_motifs.rs
@@ -1,6 +1,6 @@
 use crate::alphabet::aa::from_aa_seq;
 use crate::analyze::find_aa_motifs_changes::AaMotifsMap;
-use crate::analyze::virus_properties::{AaMotifsDesc, CountAaMotifsGeneDesc};
+use crate::analyze::virus_properties::{AaMotifsDesc, CountAaMotifsCdsDesc};
 use crate::coord::position::AaRefPosition;
 use crate::coord::range::{intersect_or_none, AaRefRange};
 use crate::translate::translate_genes::{CdsTranslation, Translation};
@@ -53,7 +53,7 @@ fn process_one_aa_motifs_desc(
   let AaMotifsDesc {
     name,
     motifs,
-    include_genes,
+    include_cdses: include_genes,
     ..
   } = aa_motifs_desc;
 
@@ -61,8 +61,8 @@ fn process_one_aa_motifs_desc(
   let include_genes = if include_genes.is_empty() {
     translation
       .cdses()
-      .map(|translation| CountAaMotifsGeneDesc {
-        gene: translation.name.clone(),
+      .map(|translation| CountAaMotifsCdsDesc {
+        cds: translation.name.clone(),
         ranges: vec![],
       })
       .collect_vec()
@@ -72,10 +72,10 @@ fn process_one_aa_motifs_desc(
 
   include_genes
     .iter()
-    .flat_map(|CountAaMotifsGeneDesc { gene, ranges }| {
+    .flat_map(|CountAaMotifsCdsDesc { cds, ranges }| {
       translation
         .cdses()
-        .filter(|CdsTranslation { name, .. }| name == gene)
+        .filter(|CdsTranslation { name, .. }| name == cds)
         .flat_map(|translation| process_one_translation(translation, name, motifs, ranges))
         .collect_vec()
     })

--- a/packages_rs/nextclade/src/analyze/find_aa_motifs_changes.rs
+++ b/packages_rs/nextclade/src/analyze/find_aa_motifs_changes.rs
@@ -27,7 +27,7 @@ pub struct AaMotifChanges {
 #[serde(rename_all = "camelCase")]
 pub struct AaMotifMutation {
   pub name: String,
-  pub gene: String,
+  pub cds: String,
   pub position: AaRefPosition,
   pub ref_seq: String,
   pub qry_seq: String,
@@ -99,7 +99,7 @@ fn find_aa_motifs_changes_one(
     Zip::from((kept_ref, kept_qry))
       .map(|(motif_ref, motif_qry)| AaMotifMutation {
         name: motif_ref.name,
-        gene: motif_ref.cds,
+        cds: motif_ref.cds,
         position: motif_ref.position,
         ref_seq: motif_ref.seq,
         qry_seq: motif_qry.seq,
@@ -129,7 +129,7 @@ fn add_ref_seq(motif: &AaMotif, ref_translation: &Translation) -> Result<AaMotif
 
   Ok(AaMotifMutation {
     name: motif.name.clone(),
-    gene: motif.cds.clone(),
+    cds: motif.cds.clone(),
     position: motif.position,
     ref_seq,
     qry_seq: motif.seq.clone(),
@@ -149,7 +149,7 @@ fn add_qry_seq(motif: &AaMotif, qry_translation: &Translation) -> Option<AaMotif
         let qry_seq = from_aa_seq(&tr.seq[sequenced_motif_range.to_std()]);
         Some(AaMotifMutation {
           name: motif.name.clone(),
-          gene: motif.cds.clone(),
+          cds: motif.cds.clone(),
           position: motif.position,
           ref_seq: motif.seq.clone(),
           qry_seq,

--- a/packages_rs/nextclade/src/analyze/find_private_aa_mutations.rs
+++ b/packages_rs/nextclade/src/analyze/find_private_aa_mutations.rs
@@ -3,7 +3,7 @@ use crate::alphabet::letter::Letter;
 use crate::analyze::aa_del::AaDel;
 use crate::analyze::aa_sub::AaSub;
 use crate::analyze::is_sequenced::is_aa_sequenced;
-use crate::analyze::letter_ranges::GeneAaRange;
+use crate::analyze::letter_ranges::CdsAaRange;
 use crate::coord::position::{AaRefPosition, PositionLike};
 use crate::coord::range::AaRefRange;
 use crate::gene::cds::Cds;
@@ -33,7 +33,7 @@ pub fn find_private_aa_mutations(
   node: &AuspiceGraphNodePayload,
   aa_substitutions: &[AaSub],
   aa_deletions: &[AaDel],
-  aa_unknowns: &[GeneAaRange],
+  aa_unknowns: &[CdsAaRange],
   aa_unsequenced_ranges: &BTreeMap<String, Vec<AaRefRange>>,
   ref_peptides: &Translation,
   gene_map: &GeneMap,
@@ -56,7 +56,7 @@ pub fn find_private_aa_mutations(
 
         let aa_deletions = aa_deletions.iter().filter(|del| del.cds_name == cds.name).collect_vec();
 
-        let aa_unknowns = aa_unknowns.iter().filter(|unk| unk.gene_name == cds.name).collect_vec();
+        let aa_unknowns = aa_unknowns.iter().filter(|unk| unk.cds_name == cds.name).collect_vec();
 
         let private_aa_mutations = find_private_aa_mutations_for_one_gene(
           cds,
@@ -79,7 +79,7 @@ pub fn find_private_aa_mutations_for_one_gene(
   node_mut_map: &BTreeMap<AaRefPosition, Aa>,
   aa_substitutions: &[&AaSub],
   aa_deletions: &[&AaDel],
-  aa_unknowns: &[&GeneAaRange],
+  aa_unknowns: &[&CdsAaRange],
   aa_unsequenced_ranges: &[AaRefRange],
   ref_peptide: &[Aa],
 ) -> PrivateAaMutations {
@@ -246,7 +246,7 @@ fn process_seq_deletions(
 fn find_reversions(
   cds: &Cds,
   node_mut_map: &BTreeMap<AaRefPosition, Aa>,
-  aa_unknowns: &[&GeneAaRange],
+  aa_unknowns: &[&CdsAaRange],
   aa_unsequenced_ranges: &[AaRefRange],
   ref_peptide: &[Aa],
   seq_positions_mutated_or_deleted: &mut BTreeSet<AaRefPosition>,

--- a/packages_rs/nextclade/src/analyze/is_sequenced.rs
+++ b/packages_rs/nextclade/src/analyze/is_sequenced.rs
@@ -1,5 +1,5 @@
 use crate::alphabet::letter::Letter;
-use crate::analyze::letter_ranges::{GeneAaRange, NucRange};
+use crate::analyze::letter_ranges::{CdsAaRange, NucRange};
 use crate::coord::position::{AaRefPosition, NucRefGlobalPosition};
 use crate::coord::range::{AaRefRange, NucRefGlobalRange};
 use itertools::Itertools;
@@ -22,7 +22,7 @@ pub fn is_nuc_non_acgtn(pos: NucRefGlobalPosition, non_acgtns: &[NucRange]) -> b
 
 /// Decides whether a given position in peptide is considered "sequenced".
 /// The position is considered sequenced if it is not contained in any of the unknown of unsequenced regions
-pub fn is_aa_sequenced(pos: AaRefPosition, aa_unknowns: &[&GeneAaRange], aa_unsequenced_ranges: &[AaRefRange]) -> bool {
+pub fn is_aa_sequenced(pos: AaRefPosition, aa_unknowns: &[&CdsAaRange], aa_unsequenced_ranges: &[AaRefRange]) -> bool {
   let is_missing = aa_unknowns.iter().any(|missing| missing.contains_pos(pos));
   let is_unsequenced = aa_unsequenced_ranges
     .iter()

--- a/packages_rs/nextclade/src/analyze/letter_ranges.rs
+++ b/packages_rs/nextclade/src/analyze/letter_ranges.rs
@@ -99,29 +99,29 @@ pub fn find_letter_ranges<L: Letter<L>, P: PositionLike>(qry_aln: &[L], letter: 
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct GeneAaRange {
-  pub gene_name: String,
+pub struct CdsAaRange {
+  pub cds_name: String,
   #[serde(rename = "character")]
   pub letter: Aa,
   pub ranges: Vec<AaRange>,
   pub length: usize,
 }
 
-impl GeneAaRange {
+impl CdsAaRange {
   pub fn contains_pos(&self, pos: AaRefPosition) -> bool {
     self.ranges.iter().any(|range| range.contains_pos(pos))
   }
 }
 
 /// Finds contiguous ranges (segments) consisting of a given amino acid in the sequence.
-pub fn find_aa_letter_ranges(translation: &Translation, letter: Aa) -> Vec<GeneAaRange> {
+pub fn find_aa_letter_ranges(translation: &Translation, letter: Aa) -> Vec<CdsAaRange> {
   translation
     .cdses()
     .filter_map(|CdsTranslation { name, seq, .. }| {
       let ranges = find_letter_ranges_by(seq, |candidate| candidate == letter);
       let length = ranges.iter().map(LetterRange::len).sum();
-      (length > 0).then(|| GeneAaRange {
-        gene_name: name.clone(),
+      (length > 0).then(|| CdsAaRange {
+        cds_name: name.clone(),
         letter,
         ranges,
         length,

--- a/packages_rs/nextclade/src/analyze/phenotype.rs
+++ b/packages_rs/nextclade/src/analyze/phenotype.rs
@@ -6,7 +6,7 @@ use num_traits::real::Real;
 pub fn calculate_phenotype(phenotype_data: &PhenotypeData, aa_substitutions: &[AaSub]) -> f64 {
   let aa_substitutions = aa_substitutions
     .iter()
-    .filter_map(|sub| (sub.cds_name == phenotype_data.gene && phenotype_data.aa_range.contains(sub.pos)).then_some(sub))
+    .filter_map(|sub| (sub.cds_name == phenotype_data.cds && phenotype_data.aa_range.contains(sub.pos)).then_some(sub))
     .collect_vec();
 
   let phenotype: f64 = phenotype_data

--- a/packages_rs/nextclade/src/analyze/virus_properties.rs
+++ b/packages_rs/nextclade/src/analyze/virus_properties.rs
@@ -141,7 +141,7 @@ pub struct PhenotypeData {
   pub name: String,
   pub name_friendly: String,
   pub description: String,
-  pub gene: String,
+  pub cds: String,
   pub aa_range: AaRefRange,
   #[serde(default)]
   pub ignore: PhenotypeDataIgnore,
@@ -166,13 +166,13 @@ pub struct AaMotifsDesc {
   pub motifs: Vec<String>,
 
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
-  pub include_genes: Vec<CountAaMotifsGeneDesc>,
+  pub include_cdses: Vec<CountAaMotifsCdsDesc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
-pub struct CountAaMotifsGeneDesc {
-  pub gene: String,
+pub struct CountAaMotifsCdsDesc {
+  pub cds: String,
 
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub ranges: Vec<AaRefRange>,

--- a/packages_rs/nextclade/src/gene/gene_map.rs
+++ b/packages_rs/nextclade/src/gene/gene_map.rs
@@ -86,8 +86,8 @@ impl GeneMap {
   }
 
   #[must_use]
-  pub fn contains(&self, gene_name: &str) -> bool {
-    self.genes.iter().any(|gene| gene.name == gene_name)
+  pub fn contains(&self, name: &str) -> bool {
+    self.genes.iter().any(|gene| gene.name == name)
   }
 
   pub fn get(&self, gene_name: &str) -> Result<&Gene, Report> {
@@ -95,7 +95,7 @@ impl GeneMap {
       .genes
       .iter()
       .find(|gene| gene.name == gene_name)
-      .ok_or_else(|| make_internal_report!("Gene is expected to be present, but not found: '{gene_name}'"))
+      .ok_or_else(|| make_internal_report!("Gene '{gene_name}' is expected to be present, but not found"))
   }
 
   pub fn get_cds<S: AsRef<str>>(&self, cds_name: S) -> Result<&Cds, Report> {

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -4,7 +4,7 @@ use crate::alphabet::nuc::{from_nuc, from_nuc_seq, Nuc};
 use crate::analyze::aa_del::AaDel;
 use crate::analyze::aa_sub::AaSub;
 use crate::analyze::find_aa_motifs::AaMotif;
-use crate::analyze::letter_ranges::{GeneAaRange, NucRange};
+use crate::analyze::letter_ranges::{CdsAaRange, NucRange};
 use crate::analyze::nuc_del::NucDelRange;
 use crate::analyze::nuc_sub::{NucSub, NucSubLabeled};
 use crate::analyze::pcr_primer_changes::PcrPrimerChange;
@@ -718,22 +718,22 @@ pub fn format_aa_deletions(aa_dels: &[AaDel], delimiter: &str) -> String {
 pub fn format_aa_insertions(insertions: &[AaIns], delimiter: &str) -> String {
   insertions
     .iter()
-    .map(|AaIns { gene, ins, pos }: &AaIns| {
+    .map(|AaIns { cds, ins, pos }: &AaIns| {
       let ins_str = from_aa_seq(ins);
       let pos_one_based = pos + 1;
-      format!("{gene}:{pos_one_based}:{ins_str}")
+      format!("{cds}:{pos_one_based}:{ins_str}")
     })
     .join(delimiter)
 }
 
 #[inline]
-pub fn format_unknown_aa_ranges(unknown_aa_ranges: &[GeneAaRange], delimiter: &str) -> String {
+pub fn format_unknown_aa_ranges(unknown_aa_ranges: &[CdsAaRange], delimiter: &str) -> String {
   unknown_aa_ranges
     .iter()
-    .flat_map(|GeneAaRange { gene_name, ranges, .. }: &GeneAaRange| {
+    .flat_map(|CdsAaRange { cds_name, ranges, .. }: &CdsAaRange| {
       ranges.iter().map(move |range| {
         let range_str = range.range().to_string();
-        format!("{gene_name}:{range_str}")
+        format!("{cds_name}:{range_str}")
       })
     })
     .join(delimiter)
@@ -744,9 +744,9 @@ pub fn format_frame_shifts(frame_shifts: &[FrameShift], delimiter: &str) -> Stri
   frame_shifts
     .iter()
     .map(|frame_shift| {
-      let gene_name = &frame_shift.gene_name;
+      let cds_name = &frame_shift.cds_name;
       let range = &frame_shift.codon.to_string();
-      format!("{gene_name}:{range}")
+      format!("{cds_name}:{range}")
     })
     .join(delimiter)
 }
@@ -767,7 +767,7 @@ pub fn format_clustered_snps(snps: &[ClusteredSnp], delimiter: &str) -> String {
 pub fn format_stop_codons(stop_codons: &[StopCodonLocation], delimiter: &str) -> String {
   stop_codons
     .iter()
-    .map(|StopCodonLocation { gene_name, codon }| format!("{gene_name}:{codon}"))
+    .map(|StopCodonLocation { cds_name, codon }| format!("{cds_name}:{codon}"))
     .join(delimiter)
 }
 

--- a/packages_rs/nextclade/src/io/nextclade_csv.rs
+++ b/packages_rs/nextclade/src/io/nextclade_csv.rs
@@ -203,7 +203,7 @@ lazy_static! {
       o!("pcrPrimerChanges") => true,
     },
     CsvColumnCategory::ErrsWarns => indexmap! {
-      o!("failedGenes") => true,
+      o!("failedCdses") => true,
       o!("warnings") => true,
       o!("errors") => true,
     }
@@ -323,7 +323,7 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
       clade,
       private_nuc_mutations,
       // private_aa_mutations,
-      missing_genes,
+      missing_cdses,
       // divergence,
       coverage,
       phenotype_values,
@@ -546,7 +546,7 @@ impl<W: VecWriter> NextcladeResultsCsvWriter<W> {
       qc.stop_codons.as_ref().map(|sc| sc.status.to_string()),
     )?;
     self.add_entry("isReverseComplement", &is_reverse_complement.to_string())?;
-    self.add_entry("failedGenes", &format_failed_genes(missing_genes, ARRAY_ITEM_DELIMITER))?;
+    self.add_entry("failedCdses", &format_failed_cdses(missing_cdses, ARRAY_ITEM_DELIMITER))?;
     self.add_entry(
       "warnings",
       &warnings.iter().map(|PeptideWarning { warning, .. }| warning).join(";"),
@@ -772,8 +772,8 @@ pub fn format_stop_codons(stop_codons: &[StopCodonLocation], delimiter: &str) ->
 }
 
 #[inline]
-pub fn format_failed_genes(failed_genes: &[String], delimiter: &str) -> String {
-  failed_genes.join(delimiter)
+pub fn format_failed_cdses(failed_cdses: &[String], delimiter: &str) -> String {
+  failed_cdses.join(delimiter)
 }
 
 #[inline]

--- a/packages_rs/nextclade/src/qc/qc_config.rs
+++ b/packages_rs/nextclade/src/qc/qc_config.rs
@@ -70,7 +70,7 @@ pub struct QcRulesConfigSnpClusters {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct FrameShiftLocation {
-  pub gene_name: String,
+  pub cds_name: String,
   pub codon_range: AaRefRange,
 }
 
@@ -97,7 +97,7 @@ impl Default for QcRulesConfigFrameShifts {
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct StopCodonLocation {
-  pub gene_name: String,
+  pub cds_name: String,
   pub codon: usize,
 }
 

--- a/packages_rs/nextclade/src/qc/qc_rule_frame_shifts.rs
+++ b/packages_rs/nextclade/src/qc/qc_rule_frame_shifts.rs
@@ -9,7 +9,7 @@ pub fn is_frame_shift_ignored(frame_shift: &FrameShift, config: &QcRulesConfigFr
   config
     .ignored_frame_shifts
     .iter()
-    .any(|ignored| ignored.gene_name == frame_shift.gene_name && ignored.codon_range == frame_shift.codon)
+    .any(|ignored| ignored.cds_name == frame_shift.cds_name && ignored.codon_range == frame_shift.codon)
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, schemars::JsonSchema)]

--- a/packages_rs/nextclade/src/qc/qc_rule_stop_codons.rs
+++ b/packages_rs/nextclade/src/qc/qc_rule_stop_codons.rs
@@ -34,7 +34,7 @@ pub fn rule_stop_codons(translation: &Translation, config: &QcRulesConfigStopCod
     for (codon, aa) in peptide.iter().enumerate().take(len_minus_one) {
       if aa.is_stop() {
         let stop_codon = StopCodonLocation {
-          gene_name: name.clone(),
+          cds_name: name.clone(),
           codon,
         };
 

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -13,7 +13,7 @@ use crate::analyze::find_private_aa_mutations::{find_private_aa_mutations, Priva
 use crate::analyze::find_private_nuc_mutations::{find_private_nuc_mutations, PrivateNucMutations};
 use crate::analyze::letter_composition::get_letter_composition;
 use crate::analyze::letter_ranges::{
-  find_aa_letter_ranges, find_letter_ranges, find_letter_ranges_by, GeneAaRange, NucRange,
+  find_aa_letter_ranges, find_letter_ranges, find_letter_ranges_by, CdsAaRange, NucRange,
 };
 use crate::analyze::nuc_changes::{find_nuc_changes, FindNucChangesOutput};
 use crate::analyze::nuc_del::NucDelRange;
@@ -51,7 +51,7 @@ struct NextcladeResultWithAa {
   aa_insertions: Vec<AaIns>,
   frame_shifts: Vec<FrameShift>,
   total_frame_shifts: usize,
-  unknown_aa_ranges: Vec<GeneAaRange>,
+  unknown_aa_ranges: Vec<CdsAaRange>,
   total_unknown_aa: usize,
   aa_alignment_ranges: BTreeMap<String, Vec<AaRefRange>>,
   aa_unsequenced_ranges: BTreeMap<String, Vec<AaRefRange>>,
@@ -181,7 +181,7 @@ pub fn nextclade_run_one(
 
       if alignment.is_reverse_complement {
         warnings.push(PeptideWarning {
-            gene_name: "nuc".to_owned(),
+            cds_name: "nuc".to_owned(),
             warning: format!("When processing sequence #{index} '{seq_name}': Sequence is reverse-complemented: Seed matching failed for the original sequence, but succeeded for its reverse complement. Outputs will be derived from the reverse complement and 'reverse complement' suffix will be added to sequence ID.")
           });
       }
@@ -307,14 +307,14 @@ pub fn nextclade_run_one(
       phenotype_data
         .iter()
         .filter_map(|phenotype_data| {
-          let PhenotypeData { name, gene, ignore, .. } = phenotype_data;
+          let PhenotypeData { name, cds, ignore, .. } = phenotype_data;
           if ignore.clades.contains(&clade) {
             return None;
           }
           let phenotype = calculate_phenotype(phenotype_data, &aa_substitutions);
           Some(PhenotypeValue {
             name: name.clone(),
-            gene: gene.clone(),
+            cds: cds.clone(),
             value: phenotype,
           })
         })

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -391,7 +391,7 @@ pub fn nextclade_run_one(
       pcr_primer_changes,
       total_pcr_primer_changes,
       warnings,
-      missing_genes,
+      missing_cdses: missing_genes,
       coverage,
       aa_motifs,
       aa_motifs_changes,

--- a/packages_rs/nextclade/src/translate/frame_shifts_translate.rs
+++ b/packages_rs/nextclade/src/translate/frame_shifts_translate.rs
@@ -60,7 +60,7 @@ pub fn find_codon_mask_range(
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FrameShift {
-  pub gene_name: String,
+  pub cds_name: String,
   pub nuc_rel: NucAlnLocalRange,
   pub nuc_abs: Vec<NucRefGlobalRange>,
   pub codon: AaRefRange,
@@ -90,7 +90,7 @@ pub fn frame_shift_transform(
   let gaps_trailing = Range::new(codon.end, codon_mask.end);
 
   Ok(FrameShift {
-    gene_name: cds.name.clone(),
+    cds_name: cds.name.clone(),
     nuc_abs: nuc_ref_global,
     codon,
     nuc_rel: nuc_aln_local.clone(),

--- a/packages_rs/nextclade/src/translate/translate_genes.rs
+++ b/packages_rs/nextclade/src/translate/translate_genes.rs
@@ -329,7 +329,7 @@ pub fn translate_genes(
           ) {
             Ok(translation) => Either::Left((cds.name.clone(), translation)),
             Err(report) => Either::Right(PeptideWarning {
-              gene_name: cds.name.clone(),
+              cds_name: cds.name.clone(),
               warning: report_to_string(&report),
             }),
           }

--- a/packages_rs/nextclade/src/tree/split_muts2.rs
+++ b/packages_rs/nextclade/src/tree/split_muts2.rs
@@ -64,9 +64,9 @@ pub fn split_muts2(left: &BranchMutations, right: &BranchMutations) -> SplitMuts
   let mut shared_keys = keys_mut_left.intersection(&keys_mut_right).collect_vec();
   shared_keys.sort();
 
-  for gene_name in shared_keys.clone() {
-    let aa_muts_left = &left.aa_muts[gene_name];
-    let aa_muts_right = &right.aa_muts[gene_name];
+  for cds_name in shared_keys.clone() {
+    let aa_muts_left = &left.aa_muts[cds_name];
+    let aa_muts_right = &right.aa_muts[cds_name];
     let mut aa_subs_for_gene_shared = Vec::<AaSub>::new();
     let mut aa_subs_for_gene_left = Vec::<AaSub>::new();
     let mut aa_subs_for_gene_right = Vec::<AaSub>::new();
@@ -99,9 +99,9 @@ pub fn split_muts2(left: &BranchMutations, right: &BranchMutations) -> SplitMuts
       aa_subs_for_gene_right.push(aa_muts_right[j].clone());
       j += 1;
     }
-    aa_subs_shared.insert(gene_name.to_string(), aa_subs_for_gene_shared);
-    aa_subs_left.insert(gene_name.to_string(), aa_subs_for_gene_left);
-    aa_subs_right.insert(gene_name.to_string(), aa_subs_for_gene_right);
+    aa_subs_shared.insert(cds_name.to_string(), aa_subs_for_gene_shared);
+    aa_subs_left.insert(cds_name.to_string(), aa_subs_for_gene_left);
+    aa_subs_right.insert(cds_name.to_string(), aa_subs_for_gene_right);
   }
   for (k, v) in &left.aa_muts {
     if !shared_keys.contains(&k) {

--- a/packages_rs/nextclade/src/tree/tree.rs
+++ b/packages_rs/nextclade/src/tree/tree.rs
@@ -185,7 +185,7 @@ pub struct TreeNodeAttrs {
 
   #[serde(skip_serializing_if = "Option::is_none")]
   #[serde(rename = "Missing genes")]
-  pub missing_genes: Option<TreeNodeAttr>,
+  pub missing_cdses: Option<TreeNodeAttr>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,

--- a/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages_rs/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -1,6 +1,6 @@
 use crate::analyze::find_private_nuc_mutations::BranchMutations;
 use crate::io::nextclade_csv::{
-  format_failed_genes, format_missings, format_non_acgtns, format_nuc_deletions, format_pcr_primer_changes,
+  format_failed_cdses, format_missings, format_non_acgtns, format_nuc_deletions, format_pcr_primer_changes,
 };
 use crate::tree::tree::{
   AuspiceGraphNodePayload, TreeBranchAttrs, TreeBranchAttrsLabels, TreeNodeAttr, TreeNodeAttrs, TreeNodeTempData,
@@ -81,7 +81,7 @@ pub fn create_new_auspice_node(
       has_pcr_primer_changes,
       pcr_primer_changes,
       qc_status: Some(TreeNodeAttr::new(&result.qc.overall_status.to_string())),
-      missing_genes: Some(TreeNodeAttr::new(&format_failed_genes(&result.missing_genes, ", "))),
+      missing_cdses: Some(TreeNodeAttr::new(&format_failed_cdses(&result.missing_cdses, ", "))),
       other,
     },
     tmp: TreeNodeTempData::default(),

--- a/packages_rs/nextclade/src/tree/tree_builder.rs
+++ b/packages_rs/nextclade/src/tree/tree_builder.rs
@@ -258,10 +258,10 @@ pub fn convert_private_mutations_to_node_branch_attrs(mutations: &BranchMutation
   let nuc_muts = mutations.nuc_muts.iter().sorted().map(NucSub::to_string).collect_vec();
   branch_attrs.insert("nuc".to_owned(), nuc_muts);
 
-  for (gene_name, aa_muts) in &mutations.aa_muts {
+  for (cds_name, aa_muts) in &mutations.aa_muts {
     if !aa_muts.is_empty() {
       let aa_muts = aa_muts.iter().sorted().map(AaSub::to_string_without_gene).collect_vec();
-      branch_attrs.insert(gene_name.clone(), aa_muts);
+      branch_attrs.insert(cds_name.clone(), aa_muts);
     }
   }
 
@@ -272,9 +272,9 @@ pub fn convert_private_mutations_to_node_branch_attrs_aa_labels(aa_muts: &BTreeM
   aa_muts
     .iter()
     .filter(|(_, aa_muts)| !aa_muts.is_empty())
-    .map(|(gene_name, aa_muts)| {
+    .map(|(cds_name, aa_muts)| {
       let aa_muts = aa_muts.iter().sorted().map(AaSub::to_string_without_gene).join(", ");
-      format!("{gene_name}: {aa_muts}")
+      format!("{cds_name}: {aa_muts}")
     })
     .join("; ")
 }

--- a/packages_rs/nextclade/src/tree/tree_find_nearest_node.rs
+++ b/packages_rs/nextclade/src/tree/tree_find_nearest_node.rs
@@ -164,7 +164,7 @@ mod tests {
         has_pcr_primer_changes: None,
         pcr_primer_changes: None,
         qc_status: None,
-        missing_genes: None,
+        missing_cdses: None,
         other: serde_json::Value::default(),
       },
 

--- a/packages_rs/nextclade/src/tree/tree_preprocess.rs
+++ b/packages_rs/nextclade/src/tree/tree_preprocess.rs
@@ -176,7 +176,7 @@ fn map_aa_muts(
       let aa_muts = parent_aa_muts.get(&ref_cds_tr.name).unwrap_or(&empty);
       (
         ref_cds_tr.name.clone(),
-        map_aa_muts_for_one_gene(&ref_cds_tr.name, node, &ref_cds_tr.seq, aa_muts),
+        map_aa_muts_for_one_cds(&ref_cds_tr.name, node, &ref_cds_tr.seq, aa_muts),
       )
     })
     .map(|(name, muts)| -> Result<_, Report>  {
@@ -185,27 +185,27 @@ fn map_aa_muts(
     .collect()
 }
 
-fn map_aa_muts_for_one_gene(
-  gene_name: &str,
+fn map_aa_muts_for_one_cds(
+  cds_name: &str,
   node: &AuspiceGraphNodePayload,
   ref_peptide: &[Aa],
   parent_aa_muts: &BTreeMap<AaRefPosition, Aa>,
 ) -> Result<BTreeMap<AaRefPosition, Aa>, Report> {
   let mut aa_muts = parent_aa_muts.clone();
 
-  match node.branch_attrs.mutations.get(gene_name) {
+  match node.branch_attrs.mutations.get(cds_name) {
     None => Ok(aa_muts),
     Some(mutations) => {
       for mutation_str in mutations {
-        let mutation = AaSub::from_str_and_gene(mutation_str, gene_name)?;
+        let mutation = AaSub::from_str_and_gene(mutation_str, cds_name)?;
 
         if ref_peptide.len() < mutation.pos.as_usize() {
           return make_error!(
           "When preprocessing reference tree node {}: amino acid mutation {}:{} is outside of the peptide {} (length {}). This is likely an inconsistency between reference tree, reference sequence, and genome annotation in the Nextclade dataset",
           node.name,
-          gene_name,
+          cds_name,
           mutation.to_string_without_gene(),
-          gene_name,
+          cds_name,
           ref_peptide.len(),
         );
         }

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -6,7 +6,7 @@ use crate::analyze::aa_sub::AaSub;
 use crate::analyze::find_aa_motifs_changes::{AaMotifsChangesMap, AaMotifsMap};
 use crate::analyze::find_private_aa_mutations::PrivateAaMutations;
 use crate::analyze::find_private_nuc_mutations::PrivateNucMutations;
-use crate::analyze::letter_ranges::{GeneAaRange, NucRange};
+use crate::analyze::letter_ranges::{CdsAaRange, NucRange};
 use crate::analyze::nuc_del::NucDelRange;
 use crate::analyze::nuc_sub::NucSub;
 use crate::analyze::pcr_primer_changes::PcrPrimerChange;
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PeptideWarning {
-  pub gene_name: String,
+  pub cds_name: String,
   pub warning: String,
 }
 
@@ -30,7 +30,7 @@ pub struct PeptideWarning {
 #[serde(rename_all = "camelCase")]
 pub struct PhenotypeValue {
   pub name: String,
-  pub gene: String,
+  pub cds: String,
   pub value: f64,
 }
 
@@ -60,7 +60,7 @@ pub struct NextcladeOutputs {
   pub total_aminoacid_deletions: usize,
   pub aa_insertions: Vec<AaIns>,
   pub total_aminoacid_insertions: usize,
-  pub unknown_aa_ranges: Vec<GeneAaRange>,
+  pub unknown_aa_ranges: Vec<CdsAaRange>,
   pub total_unknown_aa: usize,
   pub aa_changes_groups: Vec<AaChangesGroup>,
   pub nuc_to_aa_muts: BTreeMap<String, Vec<AaSub>>,

--- a/packages_rs/nextclade/src/types/outputs.rs
+++ b/packages_rs/nextclade/src/types/outputs.rs
@@ -74,7 +74,7 @@ pub struct NextcladeOutputs {
   pub private_nuc_mutations: PrivateNucMutations,
   pub private_aa_mutations: BTreeMap<String, PrivateAaMutations>,
   pub warnings: Vec<PeptideWarning>,
-  pub missing_genes: Vec<String>,
+  pub missing_cdses: Vec<String>,
   pub divergence: f64,
   pub coverage: f64,
   pub qc: QcResult,


### PR DESCRIPTION
Sibling PR in data: https://github.com/nextstrain/nextclade_data/pull/125

### Modified input files

The following fields are renamed in the input `pathogen.json`:

```
From: aaMotifs[].includeGenes[].gene
To:   aaMotifs[].includeCdses[].cds

From: phenotypeData[].gene
To:   phenotypeData[].cds

From: qc.frameShifts.ignoredFrameShifts[].geneName
To:   qc.frameShifts.ignoredFrameShifts[].cdsName

From: qc.stopCodons.ignoredStopCodons[].geneName
To:   qc.stopCodons.ignoredStopCodons[].cdsName
```

### Modified output files

The following fields are renamed in the output `nextclade.json`/`nextclade.ndjson`:

```
From: results[].missingGenes
To:   results[].missingCdses
```

The following columns are renamed in the output `nextclade.tsv`/`nextclade.csv`:

```
From: failedGenes
To:   failedCdses
```


The following fields are renamed in the output `nextclade.tree.json`:

```
From: node_atts.missing_genes
To:   node_atts.missing_cdses
```
