### PR TITLE
feat(web): increment version in local storage key

### DIFF
--- a/packages_rs/nextclade-web/src/state/persist/localStorage.ts
+++ b/packages_rs/nextclade-web/src/state/persist/localStorage.ts
@@ -2,5 +2,5 @@ import { recoilPersist } from 'recoil-persist'
 import { PROJECT_NAME } from 'src/constants'
 
 export const { persistAtom } = recoilPersist({
-  key: `${PROJECT_NAME}-storage-v3`, // increment this version on breaking changes
+  key: `${PROJECT_NAME}-storage-v4`, // increment this version on breaking changes
 })


### PR DESCRIPTION
This is necessary to avoid format mismatch when loading Nextclade Web v3 in browsers having previously ran Nextclade v2 and having settings stored in local storage.

The release version of Nextclade Web v3 will be on the same domain as v2, so the stored values will stay and might cause unnecessary effects. Changing key name avoids this issue and everybody will  start over with a clean new storage.

