### PR TITLE
fix: correct CLI links to point to new index.html

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -25,7 +25,7 @@ But this set of files is not sufficient to run Nextclade.
 
 Since Nextclade version 1.3.0, the full up-to-date data bundles for various pathogens are distributed in the form of so called "datasets". Please see:
 
-- [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html) documentation for example usage
+- [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html) documentation for example usage
 - [Nextclade Datasets](https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html) documentation for more details
 - [Input files](https://docs.nextstrain.org/projects/nextclade/en/stable/user/input-files.html) documentation, in order to better understand what each of these files represent and what it's used for
 

--- a/data/sars-cov-2/README.md
+++ b/data/sars-cov-2/README.md
@@ -25,7 +25,7 @@ But this set of files is not sufficient to run Nextclade.
 
 Since Nextclade version 1.3.0, the full up-to-date data bundles for various pathogens are distributed in the form of so called "datasets". Please see:
 
-- [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html) documentation for example usage
+- [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html) documentation for example usage
 - [Nextclade Datasets](https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html) documentation for more details
 - [Input files](https://docs.nextstrain.org/projects/nextclade/en/stable/user/input-files.html) documentation, in order to better understand what each of these files represent and what it's used for
 

--- a/packages_rs/nextclade-web/src/components/About/AboutContent.mdx
+++ b/packages_rs/nextclade-web/src/components/About/AboutContent.mdx
@@ -8,6 +8,6 @@ To analyze your data, drag a [FASTA](https://en.wikipedia.org/wiki/FASTA_format)
 
 The Nextclade app and algorithms are open-source. The code is available on [GitHub](https://github.com/nextstrain/nextclade).
 
-For large-scale analysis you can use a command line version - [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html).
+For large-scale analysis you can use a command line version - [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html).
 
 Read [user documentation](https://docs.nextstrain.org/projects/nextclade) for more details.

--- a/packages_rs/nextclade-web/src/components/Layout/NavigationBar.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/NavigationBar.tsx
@@ -198,7 +198,7 @@ export function NavigationBar() {
         content: <CitationButton />,
       },
       {
-        url: 'https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-web.html',
+        url: 'https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-web/index.html',
         title: t('Nextclade Web documentation'),
         content: t('Docs'),
       },

--- a/packages_rs/nextclade-web/src/components/Layout/NavigationBar.tsx
+++ b/packages_rs/nextclade-web/src/components/Layout/NavigationBar.tsx
@@ -203,7 +203,7 @@ export function NavigationBar() {
         content: t('Docs'),
       },
       {
-        url: 'https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html',
+        url: 'https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html',
         title: t('{{project}} documentation', { project: 'Nextclade CLI' }),
         content: 'CLI',
       },

--- a/packages_rs/nextclade-web/src/components/Main/Downloads.tsx
+++ b/packages_rs/nextclade-web/src/components/Main/Downloads.tsx
@@ -104,7 +104,7 @@ export function Downloads() {
                   <DownloadLink
                     Icon={iconBook}
                     text={t('Documentation')}
-                    url="https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html"
+                    url="https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html"
                   />
                 </DownloadLinkList>
               </CardBody>


### PR DESCRIPTION
Thanks to @Mike-Honey for reporting at https://discussion.nextstrain.org/t/cli-link-broken-from-clades-nextstrain-org/1528

Fixed with the following command (might be useful for similar renames):
```bash
OLD=https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html
NEW=https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/index.html
rg -l "$OLD" | xargs sed -i "s|$OLD|$NEW|g"
```