### PR TITLE
fix: remove extra "translations.fasta" in default output translation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## _NEXT_
+
+### CLI
+
+#### Bug fixes
+
+- Fixed a bug introduce in v3.0.0 which caused the default path for translations to be incorrect. This affected only users who used `--output-all` without passing a custom path template via `--output-translations`. The new default path is `nextclade.cds_translation.{cds}.fasta` where `{cds}` gets replaced with the name of the CDS, e.g. `nextclade.cds_translation.S.fasta` for SARS-CoV-2's spike protein.
+
+#### Documentation
+
+- Added a section to the v3 migration guide about the renamed default path for translations, a breaking change. The new default output path for translations is `nextclade.cds_translation.{cds}.fasta`. Before v3, the default path was `nextclade_gene_{gene}.translation.fasta`. You can emulate the old (default) behavior by passing `--output-translations="nextclade_gene_{cds}.translation.fasta"` to `nextclade3`.
+
 ## 3.0.1
 
 ### Nextclade Web

--- a/docs/user/migration-v3.md
+++ b/docs/user/migration-v3.md
@@ -14,7 +14,7 @@ If you encounter problems during migration, or breaking changes not mentioned in
 - [Nextclade Web v2](https://v2.clades.nextstrain.org) - if you need the old version
 - [Nextclade CLI releases](https://github.com/nextstrain/nextclade/releases) - all versions
 - [Nextclade user documentation](https://docs.nextstrain.org/projects/nextclade/en/stable/index.html) - for detailed instructions on how to use Nextclade Web and Nextclade CLI
-- [Nextclade dataset curation guide](https://github.com/nextstrain/nextclade_data/blob/master/docs/dataset-curation-guide%2Emd)  - if you have a custom Nextclade dataset or want to create one
+- [Nextclade dataset curation guide](https://github.com/nextstrain/nextclade_data/blob/master/docs/dataset-curation-guide%2Emd) - if you have a custom Nextclade dataset or want to create one
 - [Nextclade source code repository](https://github.com/nextstrain/nextclade) - for contributors to Nextclade software (code, bug reports, feature requests etc.)
 - [Nextclade data repository](https://github.com/nextstrain/nextclade_data) - for contributors to Nextclade datasets (new pathogens, bug reports, etc.)
 - [Nextclade software GitHub issues](https://github.com/nextstrain/nextclade/issues) - to report bugs and ask questions about Nextclade software
@@ -40,7 +40,7 @@ Existing Nextclade CLI v2 or Nextalign CLI v2 downloads and installations will c
 
 - if you are using Docker images, use a specific docker tag:
 
-  ```bash 
+  ```bash
   docker pull nextstrain/nextclade:2.14.0
   ```
 
@@ -48,7 +48,7 @@ Existing Nextclade CLI v2 or Nextalign CLI v2 downloads and installations will c
 
   ```bash
   conda install nextclade=2.14.0
-  ````
+  ```
 
 Please note that staying on Nextclade v2 is not recommended long-term. Nextclade v2 will not be receiving any software updates and will not receive any new dataset updates, so eventually you will end up with outdated analysis results.
 
@@ -215,7 +215,7 @@ Nextclade now uses "CDS" features from genome annotations instead of "gene" feat
 
 The following fields are renamed in the input `pathogen.json` (previously `virus_properties.json` and `qc.json`):
 
-```
+```text
 From: aaMotifs[].includeGenes[].gene
 To:   aaMotifs[].includeCdses[].cds
 
@@ -233,21 +233,21 @@ To:   qc.stopCodons.ignoredStopCodons[].cdsName
 
 The following fields are renamed in the output `nextclade.json`/`nextclade.ndjson`:
 
-```
+```text
 From: results[].missingGenes
 To:   results[].missingCdses
 ```
 
 The following columns are renamed in the output `nextclade.tsv`/`nextclade.csv`:
 
-```
+```text
 From: failedGenes
 To:   failedCdses
 ```
 
 The following fields are renamed in the output `nextclade.tree.json`:
 
-```
+```text
 From: node_atts.missing_genes
 To:   node_atts.missing_cdses
 ```

--- a/docs/user/migration-v3.md
+++ b/docs/user/migration-v3.md
@@ -209,8 +209,7 @@ Due to changes in the dataset format and in input files, the following changes i
 
 ## 9. CDS instead of genes
 
-Nextclade now uses "CDS" features from genome annotations instead of "gene" features. Certain fields in input and output files have been modified to reflect that.
-
+Nextclade now uses "CDS" features from genome annotations instead of "gene" features. Certain fields in input and output files have been modified to reflect that. Certain CLI arguments have been renamed.
 
 #### Modified input files
 
@@ -246,7 +245,6 @@ From: failedGenes
 To:   failedCdses
 ```
 
-
 The following fields are renamed in the output `nextclade.tree.json`:
 
 ```
@@ -254,6 +252,13 @@ From: node_atts.missing_genes
 To:   node_atts.missing_cdses
 ```
 
+#### Modified CLI arguments and template strings
+
+The following CLI argument is renamed: `-g, --genes` -> `-g, --cds-selection`
+
+The template string expected by `-P, --output-translations` now requires a literal `{cds}` instead of `{gene}`.
+
+The default path of output translations requested through `--output-all` is renamed to `nextclade.cds_translation.{cds}.fasta` (previously: `nextclade_gene_{gene}.translation.fasta`).
 
 ### Migration paths
 
@@ -261,3 +266,8 @@ When creating or modifying `pathogen.json` file in the dataset make sure to use 
 
 When using output files, make sure to use the new names of the mentioned fields and columns.
 
+Use the new CLI argument `-g, --cds-selection` instead of `-g, --genes`. The values passed should be unchanged (i.e. SARS-CoV-2 spike `S` is still `S`).
+
+Replace `{gene}` with `{cds}` in the template string passed to `-P, --output-translations`.
+
+You can emulate the old (default) behavior by passing `--output-translations="nextclade_gene_{cds}.translation.fasta"` to `nextclade3` when `--output-all` is used.

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -835,7 +835,6 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
     if output_selection.contains(&NextcladeOutputSelection::Translations) {
       let output_translations_path =
         default_output_file_path.with_file_name(format!("{output_basename}.cds_translation.{{cds}}.fasta"));
-      let output_translations_path = add_extension(output_translations_path, "translation.fasta");
 
       let output_translations_template = output_translations_path
         .to_str()

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -834,7 +834,8 @@ pub fn nextclade_get_output_filenames(run_args: &mut NextcladeRunArgs) -> Result
 
     if output_selection.contains(&NextcladeOutputSelection::Translations) {
       let output_translations_path =
-        default_output_file_path.with_file_name(format!("{output_basename}.cds_translation.{{cds}}.fasta"));
+        default_output_file_path.with_file_name(format!("{output_basename}.cds_translation.{{cds}}"));
+      let output_translations_path = add_extension(output_translations_path, "fasta");
 
       let output_translations_template = output_translations_path
         .to_str()


### PR DESCRIPTION
It seems that this line should have been removed in https://github.com/nextstrain/nextclade/pull/1298
but this was forgotten.

The default path will now be `nextclade.cds_translation.{cds}.fasta` as Richard suggested in
https://github.com/nextstrain/nextclade/pull/1298#issuecomment-1786602733

Before this PR it was (wrongly) `nextclade.cds_translation.{cds}.fasta.translation.fasta` since v3 release.

The default output path rename is a v3 breaking change that we don't seem to have documented yet. How shall we best do this given that v3.0.0 is already out? Post hoc editing changelog and adding to migration docs? Or do you prefer something else @ivan-aksamentov?