### PR TITLE
fix(cli): `dataset get` for datasets with multiple versions

### DIFF
--- a/packages_rs/nextclade-cli/src/cli/nextclade_dataset_get.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_dataset_get.rs
@@ -59,7 +59,7 @@ pub fn dataset_http_get(http: &mut HttpClient, name: impl AsRef<str>, tag: &Opti
       if let Some(tag) = tag.as_ref() {
         dataset.is_tag(tag)
       } else {
-        dataset.is_latest()
+        true
       }
     })
     // Filter by name

--- a/packages_rs/nextclade/src/io/dataset.rs
+++ b/packages_rs/nextclade/src/io/dataset.rs
@@ -151,13 +151,6 @@ impl Dataset {
       .map_or(true, |compat| compat.is_cli_compatible(cli_version))
   }
 
-  pub fn is_latest(&self) -> bool {
-    if self.version.tag == "unreleased" || self.version.tag == "latest" {
-      return true;
-    }
-    self.versions.iter().sorted().next() == Some(&self.version)
-  }
-
   pub fn is_tag(&self, tag: impl AsRef<str>) -> bool {
     let tag = tag.as_ref();
     self.version.tag == tag


### PR DESCRIPTION
This avoids `nextclade dataset get` failure reported here: https://github.com/nextstrain/nextclade_data/issues/136#issuecomment-1915476754

The meaningless check `.is_latest()` was left over from the time when each dataset version was a separate object. Now each datasets contain a list of all versions inside of it, so it does not make sense to filter latest datasets. Curiously, it was still working until now, when datasets has got than one version in the array (die to the second release of RSV datasets today).

