### PR TITLE
feat(cli): bring back PCR primers

### DIFF
--- a/docs/user/nextclade-cli/reference.md
+++ b/docs/user/nextclade-cli/reference.md
@@ -100,8 +100,8 @@ For short help type: `nextclade -h`, for extended help type: `nextclade --help`.
 * `-p`, `--input-pathogen-json <INPUT_PATHOGEN_JSON>` — Path to a JSON file containing configuration and data specific to a pathogen
 * `-m`, `--input-annotation <INPUT_ANNOTATION>` — Path to a file containing genome annotation in GFF3 format
 * `-g`, `--cds-selection <CDS_SELECTION>` — Comma-separated list of names of coding sequences (CDSes) to use
+* `--input-pcr-primers <INPUT_PCR_PRIMERS>` — Path to a CSV file containing a list of custom PCR primer sites. This information is used to report mutations in these sites
 * `--server <SERVER>` — Use custom dataset server
-
 
 
 

--- a/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages_rs/nextclade-cli/src/cli/nextclade_cli.rs
@@ -391,6 +391,13 @@ pub struct NextcladeRunInputArgs {
   #[clap(value_hint = ValueHint::FilePath)]
   pub cds_selection: Option<Vec<String>>,
 
+  /// Path to a CSV file containing a list of custom PCR primer sites. This information is used to report mutations in these sites.
+  ///
+  /// Supports the following compression formats: "gz", "bz2", "xz", "zstd". Use "-" to read uncompressed data from standard input (stdin).
+  #[clap(long)]
+  #[clap(value_hint = ValueHint::FilePath)]
+  pub input_pcr_primers: Option<PathBuf>,
+
   /// Use custom dataset server
   #[clap(long)]
   #[clap(value_hint = ValueHint::Url)]
@@ -417,11 +424,6 @@ pub struct NextcladeRunInputArgs {
   #[clap(long, short = 'R')]
   #[clap(hide_long_help = true, hide_short_help = true)]
   pub input_virus_properties: Option<String>,
-
-  /// REMOVED. The pcr_primers.csv file have been merged into pathogen.json, see `--input-pathogen-json`
-  #[clap(long)]
-  #[clap(hide_long_help = true, hide_short_help = true)]
-  pub input_pcr_primers: Option<String>,
 
   /// RENAMED to `--input-annotation`
   #[clap(long)]
@@ -959,10 +961,6 @@ const ERROR_MSG_INPUT_QC_CONFIG_REMOVED: &str = r#"The argument `--input-qc-conf
 
 Since version 3 Nextclade uses single file `pathogen.json` rather than a set of files `qc.json`, `primers.csv`, `virus_properties.json` and `tag.json` used in Nextclade v2."#;
 
-const ERROR_MSG_INPUT_PCR_PRIMERS_REMOVED: &str = r#"The argument `--input-pcr-primers` (alias `-p`) is removed in favor of `--input-pathogen-json`.
-
-Since version 3 Nextclade uses single file `pathogen.json` rather than a set of files `qc.json`, `primers.csv`, `virus_properties.json` and `tag.json` used in Nextclade v2."#;
-
 const ERROR_MSG_OUTPUT_INSERTIONS_REMOVED: &str = r#"The argument `--output-insertions` have been removed in favor of `--output-csv` and `--output-tsv`.
 
 In Nextclade v3 the separate arguments `--output-insertions` and `--output-errors` are removed. Please use `--output-csv` (for semicolon-separated table) and `--output-tsv` (for tab-separated table) arguments instead. These tables contain, among others, all the columns from the output insertions table (`--output-insertions`) as well as from the output errors table (`--output-errors`)."#;
@@ -1000,10 +998,6 @@ pub fn nextclade_check_removed_args(run_args: &NextcladeRunArgs) -> Result<(), R
 
   if run_args.inputs.input_qc_config.is_some() {
     return make_error!("{ERROR_MSG_INPUT_QC_CONFIG_REMOVED}{MSG_READ_RUN_DOCS}");
-  }
-
-  if run_args.inputs.input_pcr_primers.is_some() {
-    return make_error!("{ERROR_MSG_INPUT_PCR_PRIMERS_REMOVED}{MSG_READ_RUN_DOCS}");
   }
 
   if run_args.inputs.genes.is_some() {

--- a/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages_rs/nextclade-cli/src/dataset/dataset_download.rs
@@ -236,7 +236,6 @@ pub fn dataset_individual_files_load(
             default_cds: None,
             cds_order_preference: vec![],
             mut_labels: LabelledMutationsConfig::default(),
-            primers: vec![],
             qc: None,
             general_params: None,
             alignment_params: None,

--- a/packages_rs/nextclade-web/src/build.rs
+++ b/packages_rs/nextclade-web/src/build.rs
@@ -1,5 +1,5 @@
 use eyre::Report;
-use nextclade::analyze::pcr_primer_changes::PcrPrimer;
+use nextclade::analyze::pcr_primers::PcrPrimer;
 use nextclade::analyze::virus_properties::{PhenotypeAttrDesc, VirusProperties};
 use nextclade::gene::gene_map::GeneMap;
 use nextclade::io::dataset::{

--- a/packages_rs/nextclade-web/src/wasm/main.rs
+++ b/packages_rs/nextclade-web/src/wasm/main.rs
@@ -36,7 +36,7 @@ impl NextcladeWasm {
     let params = NextcladeInputParamsOptional::default();
 
     let nextclade: Nextclade =
-      jserr(Nextclade::new(inputs, &params).wrap_err_with(|| "When initializing Nextclade runner"))?;
+      jserr(Nextclade::new(inputs, vec![], &params).wrap_err_with(|| "When initializing Nextclade runner"))?;
 
     Ok(Self { nextclade })
   }

--- a/packages_rs/nextclade/src/analyze/mod.rs
+++ b/packages_rs/nextclade/src/analyze/mod.rs
@@ -15,5 +15,6 @@ pub mod nuc_changes;
 pub mod nuc_del;
 pub mod nuc_sub;
 pub mod pcr_primer_changes;
+pub mod pcr_primers;
 pub mod phenotype;
 pub mod virus_properties;

--- a/packages_rs/nextclade/src/analyze/pcr_primer_changes.rs
+++ b/packages_rs/nextclade/src/analyze/pcr_primer_changes.rs
@@ -1,28 +1,11 @@
-use crate::alphabet::nuc::{is_nuc_match, Nuc};
+use crate::alphabet::nuc::is_nuc_match;
 use crate::analyze::nuc_sub::NucSub;
-use crate::coord::range::NucRefGlobalRange;
-use crate::gene::genotype::Genotype;
+use crate::analyze::pcr_primers::PcrPrimer;
 use itertools::Itertools;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct PcrPrimer {
-  pub name: String,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub description: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub source: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub target: Option<String>,
-  pub ref_oligonuc: String,
-  pub primer_oligonuc: String,
-  pub range: NucRefGlobalRange,
-  #[serde(default, skip_serializing_if = "Vec::is_empty")]
-  pub non_acgts: Vec<Genotype<Nuc>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PcrPrimerChange {
   pub primer: PcrPrimer,

--- a/packages_rs/nextclade/src/analyze/pcr_primers.rs
+++ b/packages_rs/nextclade/src/analyze/pcr_primers.rs
@@ -1,0 +1,160 @@
+use crate::alphabet::nuc::{from_nuc_seq, to_nuc_seq, Nuc};
+use crate::coord::position::NucRefGlobalPosition;
+use crate::coord::range::NucRefGlobalRange;
+use crate::gene::genotype::Genotype;
+use crate::io::csv::parse_csv;
+use crate::io::fs::read_file_to_string;
+use crate::make_error;
+use crate::translate::complement::reverse_complement_in_place;
+use eyre::{Report, WrapErr};
+use itertools::Itertools;
+use log::warn;
+use regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PcrPrimerCsvRow {
+  #[serde(rename = "Country (Institute)")]
+  pub source: String,
+
+  #[serde(rename = "Target")]
+  pub target: String,
+
+  #[serde(rename = "Oligonucleotide")]
+  pub name: String,
+
+  #[serde(rename = "Sequence")]
+  pub primer_oligonuc: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PcrPrimer {
+  pub source: String,
+  pub target: String,
+  pub name: String,
+  pub root_oligonuc: String,
+  pub primer_oligonuc: String,
+  pub range: NucRefGlobalRange,
+  #[serde(rename = "nonACGTs")]
+  pub non_acgts: Vec<Genotype<Nuc>>,
+}
+
+impl PcrPrimer {
+  pub fn from_str(s: &str, ref_seq_str: &str) -> Result<Vec<Self>, Report> {
+    let raw: Vec<PcrPrimerCsvRow> = parse_csv(s)?;
+    raw
+      .into_iter()
+      .map(|raw_primer| convert_pcr_primer(raw_primer, ref_seq_str))
+      .collect::<Result<Vec<Self>, Report>>()
+  }
+
+  pub fn from_path(filepath: impl AsRef<Path>, ref_seq_str: &str) -> Result<Vec<Self>, Report> {
+    let filepath = filepath.as_ref();
+
+    let data =
+      read_file_to_string(filepath).wrap_err_with(|| format!("When reading PCR primers file {filepath:#?}"))?;
+
+    Self::from_str(&data, ref_seq_str).wrap_err_with(|| format!("When parsing PCR primers file {filepath:#?}"))
+  }
+}
+
+pub fn convert_pcr_primer(raw: PcrPrimerCsvRow, ref_seq_str: &str) -> Result<PcrPrimer, Report> {
+  let PcrPrimerCsvRow {
+    source,
+    target,
+    name,
+    primer_oligonuc,
+  } = raw;
+
+  let mut primer_oligonuc = to_nuc_seq(&primer_oligonuc)?;
+
+  // If this is a reverse primer, we need to reverse-complement it before attempting to match with root sequence
+  if name.ends_with("_R") {
+    reverse_complement_in_place(&mut primer_oligonuc);
+  }
+
+  let mut root_oligonuc = find_primer_in_ref_seq(&primer_oligonuc, ref_seq_str);
+  if root_oligonuc.is_none() {
+    // If nothing found, reverse-complement the primer and retry search
+    reverse_complement_in_place(&mut primer_oligonuc);
+    root_oligonuc = find_primer_in_ref_seq(&primer_oligonuc, ref_seq_str);
+  }
+
+  match root_oligonuc {
+    None => {
+      make_error!(
+        "PCR primer not found in reference sequence: name: '{}', source: '{}', oligonuc: '{}'. \
+        This might mean that the list of primers is not compatible with the root sequence used.",
+        name,
+        source,
+        from_nuc_seq(&primer_oligonuc)
+      )
+    }
+    Some((begin, root_oligonuc)) => {
+      let range = NucRefGlobalRange::from_usize(begin, begin + root_oligonuc.len());
+
+      let non_acgts = find_non_acgt(&primer_oligonuc);
+
+      Ok(PcrPrimer {
+        source,
+        target,
+        name,
+        root_oligonuc: from_nuc_seq(&root_oligonuc),
+        primer_oligonuc: from_nuc_seq(&primer_oligonuc),
+        range,
+        non_acgts,
+      })
+    }
+  }
+}
+
+/// Finds PCR primer oligonucleotide fragment in reference sequence. Returns position of the begin of the fragment
+/// in the reference sequence and the corresponding fragment of reference sequence.
+pub fn find_primer_in_ref_seq(primer_oligonuc: &[Nuc], ref_seq_str: &str) -> Option<(usize, Vec<Nuc>)> {
+  // Remove all non-ACGTN from the primer
+  let primer_oligonuc_sanitized = from_nuc_seq(primer_oligonuc)
+    .chars()
+    .map(|nuc| if is_acgt_char(nuc) { nuc } else { '.' })
+    .collect::<String>();
+
+  match Regex::new(&primer_oligonuc_sanitized) {
+    Err(report) => {
+      warn!(
+        "When compiling regular expression for PCR primer search: '{}': {}",
+        primer_oligonuc_sanitized,
+        report.to_string()
+      );
+      None
+    }
+    Ok(primer_regex) => {
+      if let Some(captures) = primer_regex.captures(ref_seq_str) {
+        captures
+          .get(0)
+          .map(|capture| (capture.start(), to_nuc_seq(capture.as_str()).unwrap()))
+      } else {
+        None
+      }
+    }
+  }
+}
+
+pub const fn is_acgt_char(c: char) -> bool {
+  matches!(c.to_ascii_uppercase(), 'A' | 'C' | 'G' | 'T')
+}
+
+pub fn find_non_acgt(seq: &[Nuc]) -> Vec<Genotype<Nuc>> {
+  seq
+    .iter()
+    .enumerate()
+    .filter_map(|(pos, nuc)| {
+      (!nuc.is_acgt()).then_some(Genotype {
+        pos: NucRefGlobalPosition::from(pos),
+        qry: *nuc,
+      })
+    })
+    .collect_vec()
+}

--- a/packages_rs/nextclade/src/analyze/virus_properties.rs
+++ b/packages_rs/nextclade/src/analyze/virus_properties.rs
@@ -1,7 +1,7 @@
 use crate::align::params::AlignPairwiseParamsOptional;
 use crate::alphabet::aa::Aa;
 use crate::alphabet::nuc::Nuc;
-use crate::analyze::pcr_primer_changes::PcrPrimer;
+use crate::analyze::pcr_primers::PcrPrimer;
 use crate::coord::position::AaRefPosition;
 use crate::coord::range::AaRefRange;
 use crate::gene::genotype::Genotype;
@@ -48,9 +48,6 @@ pub struct VirusProperties {
 
   #[serde(default)]
   pub mut_labels: LabelledMutationsConfig,
-
-  #[serde(default, skip_serializing_if = "Vec::is_empty")]
-  pub primers: Vec<PcrPrimer>,
 
   pub qc: Option<QcConfig>,
 

--- a/packages_rs/nextclade/src/run/nextclade_run_one.rs
+++ b/packages_rs/nextclade/src/run/nextclade_run_one.rs
@@ -86,6 +86,7 @@ pub fn nextclade_run_one(
     ref_translation,
     aa_motifs_ref,
     graph,
+    primers,
     ..
   } = &state;
 
@@ -122,7 +123,7 @@ pub fn nextclade_run_one(
 
   let nucleotide_composition = get_letter_composition(&stripped.qry_seq);
 
-  let pcr_primer_changes = get_pcr_primer_changes(&substitutions, &virus_properties.primers);
+  let pcr_primer_changes = get_pcr_primer_changes(&substitutions, primers);
   let total_pcr_primer_changes = pcr_primer_changes.iter().map(|pc| pc.substitutions.len()).sum();
 
   let total_aligned_nucs = alignment_range.len();

--- a/packages_rs/nextclade/src/run/nextclade_wasm.rs
+++ b/packages_rs/nextclade/src/run/nextclade_wasm.rs
@@ -4,6 +4,7 @@ use crate::alphabet::letter::{serde_deserialize_seq, serde_serialize_seq};
 use crate::alphabet::nuc::{to_nuc_seq, to_nuc_seq_replacing, Nuc};
 use crate::analyze::find_aa_motifs::find_aa_motifs;
 use crate::analyze::find_aa_motifs_changes::AaMotifsMap;
+use crate::analyze::pcr_primers::PcrPrimer;
 use crate::analyze::phenotype::get_phenotype_attr_descs;
 use crate::analyze::virus_properties::{AaMotifsDesc, PhenotypeAttrDesc, VirusProperties};
 use crate::gene::gene_map::GeneMap;
@@ -122,6 +123,7 @@ pub struct Nextclade {
   pub seed_index: CodonSpacedIndex,
   pub gap_open_close_nuc: Vec<i32>,
   pub virus_properties: VirusProperties,
+  pub primers: Vec<PcrPrimer>,
   pub params: NextcladeInputParams,
 
   // If genome annotation is provided
@@ -152,7 +154,11 @@ pub struct NextcladeStateWithGraph {
 }
 
 impl Nextclade {
-  pub fn new(inputs: NextcladeParams, params: &NextcladeInputParamsOptional) -> Result<Self, Report> {
+  pub fn new(
+    inputs: NextcladeParams,
+    primers: Vec<PcrPrimer>,
+    params: &NextcladeInputParamsOptional,
+  ) -> Result<Self, Report> {
     let NextcladeParams {
       ref_record,
       gene_map,
@@ -224,6 +230,7 @@ impl Nextclade {
       seed_index,
       gap_open_close_nuc,
       virus_properties,
+      primers,
       params,
       gene_map,
       gap_open_close_aa,


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1388

Brings back a possibility to use`primers.csv` file and calculate PCR primer mutations in Nextclade CLI v3, just like in Nextclade v2.

What's done:

- [x] add `--input-pcr-primers` CLI argument, accepting a path to input `primers.csv`file in the same format as it was in Nextclade v2 ([example](https://github.com/nextstrain/nextclade_data/blob/e9a61fa38ac956b1ea3087aede1921b7d4ecb8af/data/datasets/sars-cov-2/references/MN908947/versions/2024-01-15T12%3A00%3A00Z/files/primers.csv))
- [x] add parser for`primers.csv`file
- [x] calculate PCR primers mutations based on the `primers.csv`file
- [x] emit PCR primer mutations into output files, just like in Nextclade v2
- [x] ignore `primers` field in `pathogen.json` - the JSON format was such that it is unrealistic to produce it, and it is not used anywhere

What it does not do:
- unlike Nextclade v2, this version does not read `primers.csv` file from a dataset
- Nextclade Web does not use primers at all - an empty array of primers is always passed into the algorithm

