### PR TITLE
chore(ci): fix error in `actions/upload-artifact@v4`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -138,7 +138,7 @@ jobs:
       - name: "Upload build artifacts (${{ matrix.arch }})"
         uses: actions/upload-artifact@v4
         with:
-          name: out
+          name: out-${{ matrix.arch }}
           path: ./.out/*
 
 
@@ -255,7 +255,8 @@ jobs:
       - name: "Download build artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: "out"
+          pattern: out-*
+          merge-multiple: true
           path: ".out"
 
       - name: "Run smoke tests (linux)"
@@ -302,7 +303,8 @@ jobs:
       - name: "Download build artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: "out"
+          pattern: out-*
+          merge-multiple: true
           path: ".out"
 
       - name: "Test Linux distros compatibility"
@@ -326,7 +328,8 @@ jobs:
       - name: "Download build artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: "out"
+          pattern: out-*
+          merge-multiple: true
           path: ".out"
 
       - name: "Re-generate CLI docs"
@@ -354,7 +357,8 @@ jobs:
       - name: "Download build artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: "out"
+          pattern: out-*
+          merge-multiple: true
           path: ".out"
 
       - name: "Install deploy dependencies"
@@ -390,7 +394,8 @@ jobs:
       - name: "Download build artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: "out"
+          pattern: out-*
+          merge-multiple: true
           path: ".out"
 
       - name: "Install deploy dependencies"


### PR DESCRIPTION
Fix CI error
```
Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

Example: https://github.com/nextstrain/nextclade/actions/runs/7742331041/job/21111396773?pr=1398#step:14:16

This is due to changes in `actions/upload-artifact@v4`. We recently upgraded it from `v3`  (see commit 24b4ea8a091718c40fab79ee0aee738d4b834e79). Now once an artifact is uploaded in one matrix job, the subsequent uploads with the same name from other jobs fail.

To resolve this, I add matrix value to the artifact name and when downloading these artifacts later, I download them by wildcard pattern and merge them.

The solution is from here: https://github.com/actions/upload-artifact/issues/478#issuecomment-1918746908

