### PR TITLE
fix(web): ensure table stripes are always alternating

### DIFF
--- a/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
+++ b/packages_rs/nextclade-web/src/components/Results/ResultsTableRowResult.tsx
@@ -110,7 +110,7 @@ export function ResultsTableRowResult({
   const { analysisResult, qc, warnings } = data
 
   return (
-    <TableRowColored {...restProps} index={seqIndex} overallStatus={qc.overallStatus}>
+    <TableRowColored {...restProps} index={rowIndex} overallStatus={qc.overallStatus}>
       <TableCellRowIndex basis={columnWidthsPx.rowIndex} grow={0} shrink={0}>
         <TableCellText>{rowIndex}</TableCellText>
       </TableCellRowIndex>


### PR DESCRIPTION
Ensure results table row colors always alternating and look like zebra stripes, regardless of sorting or filtering applied to the rows.

