### PR TITLE
refactor: remove unused code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,7 @@ trivial_numeric_casts = "warn"
 
 # Disable some of the lints enabled by default
 # https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html
-dead_code = "allow"
 elided_lifetimes_in_paths = "allow"
-unused_variables = "allow"
 
 # Enable lints not enabled by default
 # https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
@@ -210,6 +208,7 @@ pattern_type_mismatch = "allow"
 print_stderr = "allow"
 print_stdout = "allow"
 pub_use = "allow"
+pub_with_shorthand = "allow"
 question_mark_used = "allow"
 self_named_module_files = "allow"
 semicolon_inside_block = "allow"

--- a/packages/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_loop.rs
@@ -124,12 +124,10 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
       });
     }
 
-    let writer = s.spawn(move || {
+    s.spawn(move || {
       let nextclade = &nextclade;
 
       let AnalysisInitialData {
-        genome_size,
-        gene_map,
         clade_node_attr_key_descs,
         phenotype_attr_descs,
         aa_motif_keys,

--- a/packages/nextclade-cli/src/cli/nextclade_seq_sort.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_seq_sort.rs
@@ -127,7 +127,7 @@ pub fn run(args: &NextcladeSortArgs, minimizer_index: &MinimizerIndexJson, verbo
       });
     }
 
-    let writer = s.spawn(move || {
+    s.spawn(move || {
       writer_thread(args, result_receiver, verbose).unwrap();
     });
   });

--- a/packages/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages/nextclade-cli/src/dataset/dataset_download.rs
@@ -16,10 +16,8 @@ use nextclade::{make_error, make_internal_error, o};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Seek, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::ZipArchive;
-
-const PATHOGEN_JSON: &str = "pathogen.json";
 
 pub fn nextclade_get_inputs(
   run_args: &NextcladeRunArgs,
@@ -273,14 +271,6 @@ pub fn dataset_individual_files_load(
     }
     _ => make_internal_error!("Reached unknown match arm"),
   }
-}
-
-#[allow(clippy::struct_field_names)]
-pub struct DatasetFilePaths<'a> {
-  input_ref: &'a Path,
-  input_tree: &'a Option<PathBuf>,
-  input_pathogen_json: &'a Option<PathBuf>,
-  input_annotation: &'a Option<PathBuf>,
 }
 
 pub fn read_from_path_or_url(

--- a/packages/nextclade/src/align/backtrace.rs
+++ b/packages/nextclade/src/align/backtrace.rs
@@ -1,14 +1,7 @@
-use crate::align::band_2d::{Band2d};
+use crate::align::band_2d::Band2d;
 use crate::align::score_matrix::{BOUNDARY, MATCH, QRY_GAP_EXTEND, QRY_GAP_MATRIX, REF_GAP_EXTEND, REF_GAP_MATRIX};
 use crate::alphabet::letter::Letter;
-
-
 use serde::{Deserialize, Serialize};
-
-
-const fn index_to_shift(si: i32, band_width: i32, mean_shift: i32) -> i32 {
-  si - band_width + mean_shift
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct AlignmentOutput<T> {
@@ -27,8 +20,6 @@ pub fn backtrace<T: Letter<T>>(
 ) -> AlignmentOutput<T> {
   let num_cols = scores.num_cols();
   let num_rows = scores.num_rows();
-  let qry_len = qry_seq.len() as i32;
-  let ref_len = ref_seq.len() as i32;
 
   // max length of the alignment is the sum of query and reference length
   let aln_capacity = scores.num_cols() + scores.num_rows();
@@ -108,7 +99,7 @@ mod tests {
   use crate::align::band_2d::simple_stripes;
   use crate::align::gap_open::{get_gap_open_close_scores_codon_aware, GapScoreMap};
   use crate::align::params::AlignPairwiseParams;
-  
+
   use crate::alphabet::nuc::{to_nuc_seq, Nuc};
   use crate::gene::gene_map::GeneMap;
   use eyre::Report;

--- a/packages/nextclade/src/align/band_2d.rs
+++ b/packages/nextclade/src/align/band_2d.rs
@@ -55,9 +55,7 @@ pub fn simple_stripes(mean_shift: i32, band_width: usize, ref_len: usize, qry_le
 
 pub fn full_matrix(ref_len: usize, qry_len: usize) -> Vec<Stripe> {
   let mut stripes = Vec::<Stripe>::with_capacity(ref_len + 1);
-  let ref_len_i32 = ref_len.to_i32().unwrap();
-  let qry_len_i32 = qry_len.to_i32().unwrap();
-  for i in 0..=ref_len_i32 {
+  for _ in 0..=ref_len {
     stripes.push(Stripe::new(0, qry_len + 1));
   }
   stripes
@@ -67,7 +65,7 @@ pub fn full_matrix(ref_len: usize, qry_len: usize) -> Vec<Stripe> {
 ///
 /// The underlying storage is sparse - the row storage consists of `Stripe`s, each of a given size (`stripe.length`)
 /// and shifted by a given amount (`stripe.begin`) relative to the left boundary of the matrix. In each row, the cells
-/// which are outside of the corresponding stripe are not allocated and accessing them is illegal.
+/// which are outside the corresponding stripe are not allocated and accessing them is illegal.
 ///
 /// Stripe begins must increase monotonically
 #[derive(Clone, PartialEq, Eq)]

--- a/packages/nextclade/src/align/score_matrix.rs
+++ b/packages/nextclade/src/align/score_matrix.rs
@@ -94,7 +94,6 @@ pub fn score_matrix<T: Letter<T>>(
       let r_gap_extend: i32;
       let r_gap_open: i32;
       let q_gap_open: i32;
-      let tmp_match: i32;
       let mut tmp_score: i32;
 
       if qpos == 0 {
@@ -209,7 +208,7 @@ mod tests {
   use super::*;
   use crate::align::band_2d::simple_stripes;
   use crate::align::gap_open::{get_gap_open_close_scores_codon_aware, GapScoreMap};
-  
+
   use crate::alphabet::nuc::{to_nuc_seq, Nuc};
   use crate::gene::gene_map::GeneMap;
   use eyre::Report;

--- a/packages/nextclade/src/analyze/divergence.rs
+++ b/packages/nextclade/src/analyze/divergence.rs
@@ -1,36 +1,29 @@
 use crate::analyze::nuc_sub::NucSub;
 use crate::coord::range::NucRefGlobalRange;
-use crate::tree::params::TreeBuilderParams;
 use crate::tree::tree::DivergenceUnits;
 
-pub struct NucMutsCounted<'a> {
-  muts: Vec<&'a NucSub>,
-  masked_muts: Vec<&'a NucSub>,
-  other_muts: Vec<&'a NucSub>,
+pub struct NucMutsCounted {
   n_muts: usize,
   n_masked_muts: usize,
   n_other_muts: usize,
 }
 
-pub fn count_nuc_muts<'a>(nuc_muts: &'a [NucSub], masked_ranges: &[NucRefGlobalRange]) -> NucMutsCounted<'a> {
+pub fn count_nuc_muts<'a>(nuc_muts: &'a [NucSub], masked_ranges: &[NucRefGlobalRange]) -> NucMutsCounted {
   // Split away non_acgt mutations
-  let (nuc_muts, other_muts): (Vec<_>, Vec<_>) = nuc_muts
+  let (nuc_muts, other_muts) = nuc_muts
     .iter()
-    .partition(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt());
+    .partition::<Vec<&'a NucSub>, _>(|m| m.ref_nuc.is_acgt() && m.qry_nuc.is_acgt());
 
   // Split away masked mutations
-  let (masked_muts, muts): (Vec<_>, Vec<_>) = nuc_muts
+  let (masked_muts, muts) = nuc_muts
     .iter()
-    .partition(|m| masked_ranges.iter().any(|range| range.contains(m.pos)));
+    .partition::<Vec<&'a NucSub>, _>(|m| masked_ranges.iter().any(|range| range.contains(m.pos)));
 
   let n_muts = muts.len();
   let n_masked_muts = masked_muts.len();
   let n_other_muts = other_muts.len();
 
   NucMutsCounted {
-    muts,
-    masked_muts,
-    other_muts,
     n_muts,
     n_masked_muts,
     n_other_muts,
@@ -47,7 +40,6 @@ pub fn calculate_branch_length(
     n_muts,
     n_masked_muts,
     n_other_muts,
-    ..
   } = count_nuc_muts(nuc_muts, masked_ranges);
 
   let mut this_div = n_muts as f64;
@@ -65,12 +57,11 @@ pub fn calculate_branch_length(
 }
 
 /// Calculate nuc mut score
-pub fn score_nuc_muts(nuc_muts: &[NucSub], masked_ranges: &[NucRefGlobalRange], params: &TreeBuilderParams) -> f64 {
+pub fn score_nuc_muts(nuc_muts: &[NucSub], masked_ranges: &[NucRefGlobalRange]) -> f64 {
   let NucMutsCounted {
     n_muts,
     n_masked_muts,
     n_other_muts,
-    ..
   } = count_nuc_muts(nuc_muts, masked_ranges);
   let mut score = n_muts as f64;
   // modify the score by sub-integer amounts for masked and other mutations. this effectively means

--- a/packages/nextclade/src/features/feature_group.rs
+++ b/packages/nextclade/src/features/feature_group.rs
@@ -37,7 +37,7 @@ impl PartialOrd for FeatureGroup {
 }
 
 impl FeatureGroup {
-  pub fn new(id: &str, features: &[Feature]) -> Self {
+  pub fn new(features: &[Feature]) -> Self {
     let index = features
       .iter()
       .map(|feature| feature.index)

--- a/packages/nextclade/src/features/feature_tree.rs
+++ b/packages/nextclade/src/features/feature_tree.rs
@@ -87,7 +87,7 @@ fn read_gff3_feature_tree_str(content: impl AsRef<str>) -> Result<Vec<SequenceRe
     ranges
     .into_iter()
     .enumerate()
-    .map(|(index,(content, content_begin, content_end))| {
+    .map(|(index,(content, content_begin, _))| {
       let content = content.trim();
 
       // Extract '##sequence-region' header line
@@ -228,7 +228,7 @@ fn build_hierarchy_of_features(features: &[Feature]) -> Result<Vec<FeatureGroup>
     .iter()
     .group_by(|feature| feature.id.clone())
     .into_iter()
-    .map(|(id, features)| FeatureGroup::new(&id, &features.cloned().collect_vec()))
+    .map(|(_, features)| FeatureGroup::new(&features.cloned().collect_vec()))
     .collect_vec();
 
   // Find top-level features (having no parents)

--- a/packages/nextclade/src/features/feature_tree_format.rs
+++ b/packages/nextclade/src/features/feature_tree_format.rs
@@ -85,9 +85,6 @@ fn format_sequence_region_feature<W: Write>(
   Ok(())
 }
 
-const PASS_ICON: &str = "│  ";
-const FORK_ICON: &str = "├──";
-const IMPASSE_ICON: &str = "└──";
 const INDENT: usize = 2;
 
 fn format_feature_groups<W: Write>(w: &mut W, feature_map: &[FeatureGroup], max_name_len: usize) -> Result<(), Report> {
@@ -103,7 +100,7 @@ fn format_feature_groups_recursive<W: Write>(
   feature_groups
     .iter()
     .enumerate()
-    .try_for_each(|(height, feature_group)| -> Result<(), Report> {
+    .try_for_each(|(_, feature_group)| -> Result<(), Report> {
       format_feature_group(w, feature_group, max_name_len, depth)?;
       format_feature_groups_recursive(w, &feature_group.children, max_name_len, depth + 1)?;
       Ok(())

--- a/packages/nextclade/src/io/gff3.rs
+++ b/packages/nextclade/src/io/gff3.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-
-
 /// Possible keys for name attribute (in order of preference!)
 pub const NAME_ATTRS_GENE: &[&str] = &[
   "Gene",
@@ -162,24 +160,9 @@ impl GffCommonInfo {
   }
 }
 
-/// Retrieve GFF records of a certain "feature_type"
-fn get_records_by_feature_type<'r>(
-  records: &'r [(usize, GffRecord)],
-  record_type: &str,
-) -> Vec<&'r (usize, GffRecord)> {
-  records
-    .iter()
-    .filter(|(i, record)| {
-      let searched = record_type.to_lowercase();
-      let candidate = record.feature_type().to_lowercase();
-      (candidate == searched) || (candidate == get_sequence_onthology_code(&searched).unwrap_or_default())
-    })
-    .collect_vec()
-}
-
 #[inline]
 #[must_use]
-pub fn get_sequence_onthology_code(feature_name: &str) -> Option<&str> {
+pub fn get_sequence_ontology_code(feature_name: &str) -> Option<&str> {
   match feature_name {
     "cds" => Some("SO:0000316"),
     "gene" => Some("SO:0000704"),

--- a/packages/nextclade/src/io/nextclade_csv.rs
+++ b/packages/nextclade/src/io/nextclade_csv.rs
@@ -234,7 +234,7 @@ fn prepare_headers(
       .categories
       .iter()
       .flat_map(|(_, columns)| columns.iter())
-      .filter(|(column, enabled)| **enabled)
+      .filter(|(_, enabled)| **enabled)
       .map(|(column, _)| column.as_str());
 
     let individual_headers = column_config.individual.iter().map(String::as_str);
@@ -799,14 +799,7 @@ pub fn format_escape(escape: &[PhenotypeValue]) -> String {
 fn format_aa_motifs(motifs: &[AaMotif]) -> String {
   motifs
     .iter()
-    .map(
-      |AaMotif {
-         name,
-         cds,
-         position,
-         seq,
-       }| format!("{}:{}:{seq}", cds, position + 1),
-    )
+    .map(|AaMotif { cds, position, seq, .. }| format!("{}:{}:{seq}", cds, position + 1))
     .join(";")
 }
 

--- a/packages/nextclade/src/io/results_json.rs
+++ b/packages/nextclade/src/io/results_json.rs
@@ -6,10 +6,10 @@ use crate::types::outputs::{
   combine_outputs_and_errors_sorted, NextcladeErrorOutputs, NextcladeOutputOrError, NextcladeOutputs,
 };
 use crate::utils::datetime::date_iso_now;
+use crate::utils::info::this_package_version_str;
 use eyre::Report;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use crate::utils::info::this_package_version_str;
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -129,7 +129,7 @@ pub fn results_to_ndjson_string(
 
     let output_or_errors = combine_outputs_and_errors_sorted(outputs, errors);
 
-    for (i, output_or_error) in output_or_errors {
+    for (_, output_or_error) in output_or_errors {
       match output_or_error {
         NextcladeOutputOrError::Outputs(output) => writer.write(&output),
         NextcladeOutputOrError::Error(error) => writer.write_nuc_error(error.index, &error.seq_name, &error.errors),

--- a/packages/nextclade/src/qc/qc_rule_mixed_sites.rs
+++ b/packages/nextclade/src/qc/qc_rule_mixed_sites.rs
@@ -32,7 +32,7 @@ pub fn rule_mixed_sites(
   // Calculate total of mixed (ambiguous) nucleotides: non-ACGT, non-N, non-Gap
   let total_mixed_sites = nucleotide_composition
     .iter()
-    .filter(|(nuc, total)| !(nuc.is_acgtn() || nuc.is_gap()))
+    .filter(|(nuc, _)| !(nuc.is_acgtn() || nuc.is_gap()))
     .map(|(_, total)| total)
     .sum();
 

--- a/packages/nextclade/src/run/nextclade_run_one.rs
+++ b/packages/nextclade/src/run/nextclade_run_one.rs
@@ -46,7 +46,6 @@ struct NextcladeResultWithAa {
   total_aminoacid_insertions: usize,
   nuc_to_aa_muts: BTreeMap<String, Vec<AaSub>>,
   missing_genes: Vec<String>,
-  present_genes: HashSet<String>,
   warnings: Vec<PeptideWarning>,
   aa_insertions: Vec<AaIns>,
   frame_shifts: Vec<FrameShift>,
@@ -148,7 +147,6 @@ pub fn nextclade_run_one(
     total_unknown_aa,
     aa_alignment_ranges,
     aa_unsequenced_ranges,
-    ..
   } = if !gene_map.is_empty() {
     let coord_map_global = CoordMapGlobal::new(&alignment.ref_seq);
 
@@ -232,7 +230,6 @@ pub fn nextclade_run_one(
       total_aminoacid_insertions,
       nuc_to_aa_muts,
       missing_genes,
-      present_genes,
       warnings,
       aa_insertions,
       frame_shifts,

--- a/packages/nextclade/src/utils/error.rs
+++ b/packages/nextclade/src/utils/error.rs
@@ -15,14 +15,6 @@ pub fn from_eyre_error<T, E: FromStr>(val_or_err: Result<T, Report>) -> Result<T
   val_or_err.map_err(|report| E::from_str(&report_to_string(&report)).ok().unwrap())
 }
 
-pub fn report_to_string_debug_only(report: &Report) -> String {
-  #[cfg(not(debug_assertions))]
-  return "An unexpected error occurred. Please try again later.".to_owned();
-
-  #[cfg(debug_assertions)]
-  report_to_string(report)
-}
-
 /// Preserves only the Result::Ok values in a given collection
 pub fn keep_ok<T, E>(results: &[Result<T, E>]) -> impl Iterator<Item = &T> {
   results.iter().filter_map(|res| match res {

--- a/packages/nextclade/src/utils/global_init.rs
+++ b/packages/nextclade/src/utils/global_init.rs
@@ -3,12 +3,7 @@ use crate::utils::datetime::{date_format_precise, date_now};
 use env_logger::Env;
 use log::{Level, LevelFilter, Record};
 use owo_colors::OwoColorize;
-use std::env;
 use std::io::Write;
-
-fn get_current_exe_filename() -> Option<String> {
-  env::current_exe().ok().and_then(filename_maybe)
-}
 
 fn get_file_line(record: &Record) -> String {
   let file = record.file().and_then(filename_maybe);
@@ -42,7 +37,6 @@ pub fn setup_logger(filter_level: LevelFilter) {
   env_logger::Builder::from_env(Env::default().default_filter_or("warn"))
     .filter_level(filter_level)
     .format(|buf, record| {
-      let current_exe = get_current_exe_filename().unwrap_or_default().dimmed().to_string();
       let file_line = get_file_line(record);
       let level = color_log_level(record);
       let date = date_format_precise(&date_now()).dimmed().to_string();


### PR DESCRIPTION
This re-enables lints `dead_code` and `unused_variables` and fixes the resulting warnings

