### PR TITLE
fix(cli): dataset tag not applied correctly in dataset cli commands

### DIFF
--- a/packages/nextclade-cli/src/cli/nextclade_dataset_get.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_dataset_get.rs
@@ -56,7 +56,7 @@ pub fn dataset_http_get(http: &HttpClient, name: impl AsRef<str>, tag: &Option<S
     .filter(|dataset| -> bool  {
       // If a concrete version `tag` is specified, we skip 'enabled', 'compatibility' and 'latest' checks
       if let Some(tag) = tag.as_ref() {
-        dataset.is_tag(tag)
+        dataset.has_tag(tag)
       } else {
         true
       }

--- a/packages/nextclade-cli/src/cli/nextclade_dataset_list.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_dataset_list.rs
@@ -35,7 +35,7 @@ pub fn nextclade_dataset_list(
     .flat_map(|collection| collection.datasets)
     .filter(|dataset| -> bool {
       if let Some(tag) = tag.as_ref() {
-        dataset.is_tag(tag)
+        dataset.has_tag(tag)
       } else {
         let is_compatible = include_incompatible || dataset.is_cli_compatible(this_package_version());
         let is_not_deprecated = include_deprecated || !dataset.deprecated();

--- a/packages/nextclade/src/io/dataset.rs
+++ b/packages/nextclade/src/io/dataset.rs
@@ -151,11 +151,13 @@ impl Dataset {
       .map_or(true, |compat| compat.is_cli_compatible(cli_version))
   }
 
-  pub fn is_tag(&self, tag: impl AsRef<str>) -> bool {
+  pub fn has_tag(&self, tag: impl AsRef<str>) -> bool {
     let tag = tag.as_ref();
-    self.version.tag == tag
-      || (self.version.tag == "unreleased" && tag == "latest")
-      || (self.version.tag == "latest" && tag == "unreleased")
+    self.versions.iter().any(|version| {
+      version.tag == tag
+        || (version.tag == "unreleased" && tag == "latest")
+        || (version.tag == "latest" && tag == "unreleased")
+    })
   }
 }
 


### PR DESCRIPTION
Partially addresses #175

The `--tag` argument have been filtering only by the latest tag. This correct the filtering logic, so that all version tags are considered when filtering.

