### PR TITLE
feat(web): restrict Safari browser support to >= 16.5

### DIFF
--- a/packages/nextclade-web/src/components/Common/BrowserWarning.tsx
+++ b/packages/nextclade-web/src/components/Common/BrowserWarning.tsx
@@ -25,7 +25,7 @@ export function BrowserWarning() {
       chrome: '>60',
       edge: '>79',
       firefox: '>52',
-      safari: '>=16',
+      safari: '>=16.5',
     })
 
     if (isSupportedBrowser || dismissed) {


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade/pull/1348

There are reports that WebWorkers don't work in Nextclade on Safari 16.3.

I was able to confirm that they do work on 16.5, so I am setting this version as the lowest supported. I don't have access to versions lower than that.

