### PR TITLE
fix(cli): crash when using `--verbosity` option

### DIFF
--- a/packages/nextclade-cli/src/cli/nextclade_cli.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_cli.rs
@@ -4,7 +4,7 @@ use crate::cli::nextclade_loop::nextclade_run;
 use crate::cli::nextclade_read_annotation::nextclade_read_annotation;
 use crate::cli::nextclade_seq_sort::nextclade_seq_sort;
 use crate::cli::print_help_markdown::print_help_markdown;
-use crate::cli::verbosity::{Verbosity, WarnLevel};
+use crate::cli::verbosity::Verbosity;
 use crate::io::http_client::ProxyConfig;
 use clap::builder::styling;
 use clap::{ArgGroup, CommandFactory, Parser, Subcommand, ValueEnum, ValueHint};
@@ -60,7 +60,7 @@ pub struct NextcladeArgs {
 
   /// Make output more quiet or more verbose
   #[clap(flatten, next_help_heading = "Verbosity")]
-  pub verbosity: Verbosity<WarnLevel>,
+  pub verbosity: Verbosity,
 }
 
 #[derive(Subcommand, Debug)]

--- a/packages/nextclade-cli/src/cli/verbosity.rs
+++ b/packages/nextclade-cli/src/cli/verbosity.rs
@@ -1,17 +1,18 @@
 //! Inspired by clap-verbosity-flag:
 //! https://github.com/rust-cli/clap-verbosity-flag
+use clap::builder::{PossibleValuesParser, TypedValueParser};
 use clap::{ArgAction, Args};
-use log::{Level, LevelFilter};
-use std::fmt::{Display, Formatter, Result};
-use std::marker::PhantomData;
+use log::LevelFilter;
 
 #[derive(Args, Debug, Clone)]
-pub struct Verbosity<L: LogLevel = ErrorLevel> {
-  /// Set verbosity level of console output [default: warn]
-  #[clap(long, global = true, value_parser = ["off", "error", "warn", "info", "debug", "trace"])]
+pub struct Verbosity {
+  /// Set verbosity level of console output
+  #[clap(long, global = true, value_parser = PossibleValuesParser::new(["off", "error", "warn", "info", "debug", "trace"])
+      .map(|s| s.parse::<LevelFilter>().unwrap()))]
   #[clap(conflicts_with = "quiet", conflicts_with = "verbose", conflicts_with = "silent")]
+  #[clap(default_value = "warn")]
   #[clap(display_order = 900)]
-  pub verbosity: Option<LevelFilter>,
+  pub verbosity: LevelFilter,
 
   /// Disable all console output. Same as `--verbosity=off`
   #[clap(long, global = true)]
@@ -30,101 +31,15 @@ pub struct Verbosity<L: LogLevel = ErrorLevel> {
   #[clap(conflicts_with = "verbose", conflicts_with = "verbosity")]
   #[clap(display_order = 903)]
   pub quiet: u8,
-
-  #[clap(skip)]
-  pub phantom: PhantomData<L>,
 }
 
-impl<L: LogLevel> Verbosity<L> {
-  pub fn get_filter_level(&self) -> LevelFilter {
+impl Verbosity {
+  pub const fn get_filter_level(&self) -> LevelFilter {
     // --verbosity=<level> and --silent take priority over -v and -q
     if self.silent {
       LevelFilter::Off
     } else {
-      match self.verbosity {
-        Some(verbosity) => verbosity,
-        None => self.log_level_filter(),
-      }
+      self.verbosity
     }
-  }
-
-  /// Get the log level.
-  ///
-  /// `None` means all output is disabled.
-  pub fn log_level(&self) -> Option<Level> {
-    level_enum(self.verbosity())
-  }
-
-  /// Get the log level filter.
-  pub fn log_level_filter(&self) -> LevelFilter {
-    level_enum(self.verbosity()).map_or(LevelFilter::Off, |l| l.to_level_filter())
-  }
-
-  /// If the user requested complete silence (i.e. not just no-logging).
-  pub fn is_silent(&self) -> bool {
-    self.log_level().is_none()
-  }
-
-  fn verbosity(&self) -> i8 {
-    level_value(L::default()) - self.quiet as i8 + self.verbose as i8
-  }
-}
-
-const fn level_value(level: Option<Level>) -> i8 {
-  match level {
-    None => -1,
-    Some(Level::Error) => 0,
-    Some(Level::Warn) => 1,
-    Some(Level::Info) => 2,
-    Some(Level::Debug) => 3,
-    Some(Level::Trace) => 4,
-  }
-}
-
-const fn level_enum(verbosity: i8) -> Option<Level> {
-  match verbosity {
-    i8::MIN..=-1 => None,
-    0 => Some(Level::Error),
-    1 => Some(Level::Warn),
-    2 => Some(Level::Info),
-    3 => Some(Level::Debug),
-    4..=i8::MAX => Some(Level::Trace),
-  }
-}
-
-impl<L: LogLevel> Display for Verbosity<L> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-    write!(f, "{}", self.verbosity())
-  }
-}
-
-pub trait LogLevel {
-  fn default() -> Option<Level>;
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub struct ErrorLevel;
-
-impl LogLevel for ErrorLevel {
-  fn default() -> Option<Level> {
-    Some(Level::Error)
-  }
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub struct WarnLevel;
-
-impl LogLevel for WarnLevel {
-  fn default() -> Option<Level> {
-    Some(Level::Warn)
-  }
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub struct InfoLevel;
-
-impl LogLevel for InfoLevel {
-  fn default() -> Option<Level> {
-    Some(Level::Info)
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1428

When using `--verbosity` option, Nextclade panicked with error:
```
The application panicked (crashed).
Message:  Mismatch between definition and access of `verbosity`. Could not downcast to log::LevelFilter, need to downcast to alloc::string::String
```
(in release builds the message can be different due to type mangling)

This is due to particularities of how `value_parser` works in `clap` v4, which is a replacement for `possible_values` functionality we used in `clap` v3, but which was removed in v4.

In Nextclade the `verbosity` filed is of type `log::LevelFilter`. It seems `clap` v4 can read a list of string values passed to `value_parser` and displays them correctly in the `--help` text, but when trying to actually pass one of these values to the `--verbosity` arg, `clap` would panic with a downcast error somewhere deep inside the library.

It's unclear to me why this is now suddenly needed, because `possible_values` worked just fine, but it seems that using an an iterator to the `clap`'s `PossibleValue`s constructed out of `LevelFilter` instead of strings work. I found this solution here: https://github.com/clap-rs/clap/discussions/4264. There are many more issues and discussions in clap repo about that. Maybe there's a better solution.

At the same time, I could not resist to clean up our `verbosity.rs` file, because most of the stuff we copied from `clap-verbosity-flag` crate and never actually use. I also use clap's `default_value` parameter to set a default value for the `verbosity` now, rather than setting a default manually on runtime.

