### PR TITLE
chore(ci): update linux-aarch64 sha in bioconda publish script

### DIFF
--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -29,6 +29,7 @@ export artifacts_dir="${THIS_DIR}/../artifacts"
 
 artifacts=(
   'nextclade-aarch64-apple-darwin'
+  'nextclade-aarch64-unknown-linux-gnu'
   'nextclade-x86_64-apple-darwin'
   'nextclade-x86_64-unknown-linux-gnu'
 )


### PR DESCRIPTION
Bioconda now publishes linux-aarch64 packages for nextclade as well, so those shas also should be updated.

https://github.com/bioconda/bioconda-recipes/pull/46185/

