### PR TITLE
fix(cli): don't use hardcoded filenames when reading dataset zip

### DIFF
--- a/packages/nextclade/src/utils/string.rs
+++ b/packages/nextclade/src/utils/string.rs
@@ -1,11 +1,31 @@
 use itertools::Itertools;
+use std::fmt::Display;
 use strsim::sorensen_dice;
 
 /// Return copy of a string surrounded with quotation marks
 #[must_use]
-pub fn surround_with_quotes(s: impl AsRef<str>) -> String {
-  let s = s.as_ref();
-  format!(r#""{s}""#)
+pub fn surround_with_quotes(item: impl Display) -> String {
+  format!(r#""{item}""#)
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Indent(pub usize);
+
+impl Default for Indent {
+  fn default() -> Self {
+    Self(2)
+  }
+}
+
+/// Display elements as a bullet list
+#[must_use]
+pub fn format_list(n: Indent, items: impl Iterator<Item = impl Display>) -> String {
+  items.map(|s| format!("- {s}")).map(indent(n)).join("\n")
+}
+
+/// Indent by given number of spaces
+pub fn indent<U: Display>(n: Indent) -> impl FnMut(U) -> String {
+  move |s: U| format!("{:indent$}{s}", "", indent = n.0)
 }
 
 /// Return copy of a string truncated up to a given length


### PR DESCRIPTION
We want to only read dataset files which are declared in the `pathogen.json`.Most of these files are optional and can be missing, so we should never rely on their presence or their particular names, without checking with what's declared in `pathogen.json`

However, in Nextclade CLI we've been reading hardcoded `tree.json` and `genome_annotation.gff3` whenever `--input-dataset` was given a dataset zip archive (as opposed to a dataset directory).

Let's made it to use `pathogen.json:files.treeJson` and `pathogen.json:files.genomeAnnotation`, just like it happens when using dataset in the form of directory, or like it happens in Nextclade Web.

While we are here, let's also improve error messages when reading zip archives.
