### PR TITLE
Update aarch64 sha256sum in bioconda recipe as well

### DIFF
--- a/scripts/publish_bioconda
+++ b/scripts/publish_bioconda
@@ -28,9 +28,10 @@ THIS_DIR="$(
 export artifacts_dir="${THIS_DIR}/../artifacts"
 
 artifacts=(
-  'nextclade-aarch64-apple-darwin'
-  'nextclade-x86_64-apple-darwin'
   'nextclade-x86_64-unknown-linux-gnu'
+  'nextclade-aarch64-unknown-linux-gnu'
+  'nextclade-x86_64-apple-darwin'
+  'nextclade-aarch64-apple-darwin'
 )
 
 mkdir -p "${artifacts_dir}"

--- a/scripts/update-bioconda.py
+++ b/scripts/update-bioconda.py
@@ -11,8 +11,9 @@ import sys
 
 archs = {
   "linux64": "x86_64-unknown-linux-gnu",
+  "aarch64": "aarch64-unknown-linux-gnu",
   "osx and x86_64": "x86_64-apple-darwin",
-  "arm64": "aarch64-apple-darwin"
+  "osx and arm64": "aarch64-apple-darwin",
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
Doing #1430 but now properly

It's a 2 line fix, just adding aarch64 to a list and a dict. I've tested it works and discovered a bug in our previous sha

This is the PR test: https://github.com/bioconda/bioconda-recipes/pull/47271