### PR TITLE
feat(cli): warn on extra or undeclared dataset files

### DIFF
--- a/packages/nextclade/src/utils/fs.rs
+++ b/packages/nextclade/src/utils/fs.rs
@@ -1,0 +1,20 @@
+use eyre::Report;
+use std::fs::read_dir;
+use std::path::{Path, PathBuf};
+
+pub fn list_files_recursive(dir: impl AsRef<Path>) -> Result<Vec<PathBuf>, Report> {
+  let mut files = Vec::new();
+  let mut stack = vec![dir.as_ref().to_path_buf()];
+  while let Some(current) = stack.pop() {
+    let entries = read_dir(&current)?;
+    for entry in entries.flatten() {
+      let path = entry.path();
+      if path.is_dir() {
+        stack.push(path);
+      } else {
+        files.push(path);
+      }
+    }
+  }
+  Ok(files)
+}

--- a/packages/nextclade/src/utils/mod.rs
+++ b/packages/nextclade/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod boolean;
 pub mod collections;
 pub mod datetime;
 pub mod error;
+pub mod fs;
 pub mod getenv;
 pub mod global_init;
 pub mod info;


### PR DESCRIPTION
For dataset authors It is hard to debug problems when:
 -  a file is present in the dataset, but author forgot to declare it in pathogen.json
 -  there is a typo in the file declaration in pathogen.json, so it is ignored by Nextclade

In both cases, Nextclade will ignore unknown entries and potentially miss a tree.json or a genome_annotation.gff3, which leads to missing the parts of the analysis - either clades and tree or translation and aminoacid mutations.

Let's add a check which warns Nextclade CLI users when they run with a dataset with either extra undeclared files or, conversely, when there's extra unknown files declared. This way authors can catch the mistakes early.

Example warning message:

```
When reading dataset from "dataset.zip": The following files are present in the dataset archive, but are not declared in its pathogen.json:
  - present-but-not-declared.txt
The following files are not present in the dataset archive, but are declared in its pathogen.json:
  - declared-but-not-present.txt

Context:
Files declared in pathogen.json:
  - CHANGELOG.md
  - README.md
  - declared-but-not-present.txt
  - genome_annotation.gff3
  - pathogen.json
  - reference.fasta
  - sequences.fasta
  - tree.json
Files present in the archive:
  - CHANGELOG.md
  - README.md
  - genome_annotation.gff3
  - pathogen.json
  - present-but-not-declared.txt
  - reference.fasta
  - sequences.fasta
  - tree.json

This is not an error. Nextclade ignores unknown file declarations and undeclared files. But this could be a mistake by the dataset author. For example, there could be a typo in pathogen.json file declaration, or a file could have been added to the dataset, but not declared in the pathogen.json. In this case, Nextclade analysis could be missing some of the features intended by the author. Contact the author to resolve this. It could also be that the dataset contains files for a newer version of Nextclade, and that the currently used version does not recognize these files. In which case try to upgrade Nextclade.
```

