### PR TITLE
feat(web): select top dataset when suggest was triggered manually

### DIFF
--- a/packages/nextclade-web/src/components/Main/MainInputForm.tsx
+++ b/packages/nextclade-web/src/components/Main/MainInputForm.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import { SuggestionAlertMainPage } from 'src/components/Main/SuggestionAlertMainPage'
 import { datasetCurrentAtom } from 'src/state/dataset.state'
 import { useQuerySeqInputs } from 'src/state/inputs.state'
+import { autodetectShouldSetCurrentDatasetAtom } from 'src/state/autodetect.state'
 import { useDatasetSuggestionResults } from 'src/hooks/useRunSeqAutodetect'
 import { useUpdatedDatasetIndex } from 'src/io/fetchDatasets'
 import { ButtonChangeDataset, DatasetNoneSection } from 'src/components/Main/ButtonChangeDataset'
@@ -158,12 +159,13 @@ function DatasetCurrentOrSelectButton() {
   const run = useRunAnalysis()
   const [dataset, setDataset] = useRecoilState(datasetCurrentAtom)
   const { topSuggestion } = useDatasetSuggestionResults()
+  const autodetectShouldSetCurrentDataset = useRecoilValue(autodetectShouldSetCurrentDatasetAtom)
 
   useEffect(() => {
-    if (!dataset) {
+    if (!dataset || autodetectShouldSetCurrentDataset) {
       setDataset(topSuggestion)
     }
-  }, [dataset, setDataset, topSuggestion])
+  }, [autodetectShouldSetCurrentDataset, dataset, setDataset, topSuggestion])
 
   const { push } = useRouter()
   const toDatasetSelection = useCallback(() => {

--- a/packages/nextclade-web/src/components/Main/SuggestionPanel.tsx
+++ b/packages/nextclade-web/src/components/Main/SuggestionPanel.tsx
@@ -38,7 +38,7 @@ export function SuggestionPanel() {
 export function ButtonSuggest() {
   const { t } = useTranslationSafe()
   const hasRequiredInputs = useRecoilValue(hasRequiredInputsAtom)
-  const runSuggest = useRunSeqAutodetect()
+  const runSuggest = useRunSeqAutodetect({ shouldSetCurrentDataset: true })
   const hasAutodetectResults = useRecoilValue(hasAutodetectResultsAtom)
   const autodetectRunState = useRecoilValue(autodetectRunStateAtom)
 

--- a/packages/nextclade-web/src/hooks/useRunSeqAutodetect.ts
+++ b/packages/nextclade-web/src/hooks/useRunSeqAutodetect.ts
@@ -172,8 +172,8 @@ export function processSuggestionResults(datasets: Dataset[], autodetectResults:
 
   const datasetsActive = itemsInclude
   const datasetsInactive = itemsNotInclude
-  const topSuggestion = autodetectResults ? first(datasetsActive) : undefined
-  const numSuggestions = autodetectResults ? datasetsActive.length : 0
+  const topSuggestion = first(datasetsActive)
+  const numSuggestions = datasetsActive.length
 
   return { datasetsActive, datasetsInactive, topSuggestion, showSuggestions, numSuggestions }
 }

--- a/packages/nextclade-web/src/state/autodetect.state.ts
+++ b/packages/nextclade-web/src/state/autodetect.state.ts
@@ -126,3 +126,8 @@ export const isAutodetectRunningAtom = selector({
   key: 'isAutodetectRunningAtom',
   get: ({ get }) => get(autodetectRunStateAtom) === AutodetectRunState.Started,
 })
+
+export const autodetectShouldSetCurrentDatasetAtom = atom<boolean>({
+  key: 'autodetectShouldSetCurrentDatasetAtom',
+  default: false,
+})


### PR DESCRIPTION
This changes behavior of dataset suggestions: now when use clicks "Suggest" button on main page, if suggestion run completes successfully, then top matching dataset is selected as current dataset automatically. This does not happen after automatic suggestion runs.

