### PR TITLE
fix(web): update current dataset when remote pathogen.json changes

### DIFF
--- a/packages/nextclade-web/src/state/dataset.state.ts
+++ b/packages/nextclade-web/src/state/dataset.state.ts
@@ -4,7 +4,6 @@ import { autodetectResultsAtom } from 'src/state/autodetect.state'
 import type { Dataset, MinimizerIndexVersion } from 'src/types'
 import { persistAtom } from 'src/state/persist/localStorage'
 import { isDefaultValue } from 'src/state/utils/isDefaultValue'
-import { areDatasetsEqual } from 'src/types'
 
 export interface Datasets {
   datasets: Dataset[]
@@ -29,11 +28,11 @@ export const datasetCurrentAtom = selector<Dataset | undefined>({
   get({ get }) {
     return get(datasetCurrentStorageAtom)
   },
-  set({ get, set, reset }, dataset: Dataset | undefined | DefaultValue) {
+  set({ set, reset }, dataset: Dataset | undefined | DefaultValue) {
     if (isDefaultValue(dataset) || isNil(dataset)) {
       reset(autodetectResultsAtom)
       reset(datasetCurrentStorageAtom)
-    } else if (!areDatasetsEqual(get(datasetCurrentStorageAtom), dataset)) {
+    } else {
       set(datasetCurrentStorageAtom, dataset)
     }
   },


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1450

This removes dataset path equality check preventing dataset object from being updated. The older dataset object version from local storage will then be used.

I don't remember why this check was needed. It seems overwriting current dataset is fine whether it's equal (by path or before paths were a thing using name/ref/tag). Hopefully this does not bring any undesired effects.

I consider this a short-term fix. A proper solution should probably remove storing dataset object in the local storage, but only storing a dataset identifier there. But ti's more involved and we need to figure out what generally identifies a dataset (dataset path, alright, but we can also have the same path on different dataset servers as well as single datasets not belonging to any server).

