### PR TITLE
feat: mutations relative to arbitrary node

### DIFF
--- a/packages/nextclade-cli/src/cli/nextclade_loop.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_loop.rs
@@ -131,6 +131,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
         clade_node_attr_key_descs,
         phenotype_attr_descs,
         aa_motif_keys,
+        ref_nodes,
         ..
       } = nextclade.get_initial_data();
 
@@ -138,6 +139,7 @@ pub fn nextclade_run(run_args: NextcladeRunArgs) -> Result<(), Report> {
         &nextclade.gene_map,
         clade_node_attr_key_descs,
         phenotype_attr_descs,
+        ref_nodes,
         aa_motif_keys,
         &csv_column_config,
         &run_args.outputs,

--- a/packages/nextclade-cli/src/cli/nextclade_ordered_writer.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_ordered_writer.rs
@@ -13,7 +13,7 @@ use nextclade::io::results_json::ResultsJsonWriter;
 use nextclade::run::nextclade_wasm::AnalysisOutput;
 use nextclade::run::params::NextcladeInputParams;
 use nextclade::translate::translate_genes::Translation;
-use nextclade::tree::tree::CladeNodeAttrKeyDesc;
+use nextclade::tree::tree::{AuspiceRefNode, CladeNodeAttrKeyDesc};
 use nextclade::types::outputs::NextcladeOutputs;
 use nextclade::utils::error::report_to_string;
 use nextclade::utils::option::OptionMapRefFallible;
@@ -37,6 +37,7 @@ impl NextcladeOrderedWriter {
     gene_map: &GeneMap,
     clade_node_attr_key_descs: &[CladeNodeAttrKeyDesc],
     phenotype_attr_key_desc: &[PhenotypeAttrDesc],
+    ref_nodes: &[AuspiceRefNode],
     aa_motifs_keys: &[String],
     csv_column_config: &CsvColumnConfig,
     output_params: &NextcladeRunOutputArgs,
@@ -49,7 +50,12 @@ impl NextcladeOrderedWriter {
       .map_ref_fallible(|output_translations| FastaPeptideWriter::new(gene_map, output_translations))?;
 
     let output_json_writer = output_params.output_json.map_ref_fallible(|output_json| {
-      ResultsJsonWriter::new(output_json, clade_node_attr_key_descs, phenotype_attr_key_desc)
+      ResultsJsonWriter::new(
+        output_json,
+        clade_node_attr_key_descs,
+        phenotype_attr_key_desc,
+        ref_nodes,
+      )
     })?;
 
     let output_ndjson_writer = output_params.output_ndjson.map_ref_fallible(NdjsonFileWriter::new)?;

--- a/packages/nextclade-web/src/hooks/useExportResults.ts
+++ b/packages/nextclade-web/src/hooks/useExportResults.ts
@@ -14,6 +14,7 @@ import {
   cladeNodeAttrDescsAtom,
   csvColumnConfigAtom,
   phenotypeAttrDescsAtom,
+  refNodesAtom,
   treeAtom,
   treeNwkAtom,
 } from 'src/state/results.state'
@@ -157,7 +158,8 @@ async function prepareResultsJson(snapshot: Snapshot, worker: ExportWorker) {
   const errors = await mapErrors(snapshot, (err) => err)
   const cladeNodeAttrDescs = await snapshot.getPromise(cladeNodeAttrDescsAtom)
   const phenotypeAttrDescs = await snapshot.getPromise(phenotypeAttrDescsAtom)
-  return worker.serializeResultsJson(results, errors, cladeNodeAttrDescs, phenotypeAttrDescs, PACKAGE_VERSION)
+  const refNodes = await snapshot.getPromise(refNodesAtom)
+  return worker.serializeResultsJson(results, errors, cladeNodeAttrDescs, phenotypeAttrDescs, refNodes, PACKAGE_VERSION)
 }
 
 export function useExportJson() {

--- a/packages/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -30,6 +30,7 @@ import {
   genesAtom,
   genomeSizeAtom,
   phenotypeAttrDescsAtom,
+  refNodesAtom,
   treeAtom,
   treeNwkAtom,
 } from 'src/state/results.state'
@@ -78,6 +79,7 @@ export function useRunAnalysis() {
             cdsOrderPreference,
             cladeNodeAttrKeyDescs,
             phenotypeAttrDescs,
+            refNodes,
             aaMotifsDescs,
             csvColumnConfigDefault,
           }) {
@@ -100,6 +102,7 @@ export function useRunAnalysis() {
             //  another from JSON-schema generated types
             set(cladeNodeAttrDescsAtom, cladeNodeAttrKeyDescs as unknown as CladeNodeAttrDesc[])
             set(phenotypeAttrDescsAtom, phenotypeAttrDescs)
+            set(refNodesAtom, refNodes)
             set(aaMotifsDescsAtom, aaMotifsDescs)
             set(csvColumnConfigAtom, csvColumnConfigDefault)
           },

--- a/packages/nextclade-web/src/state/results.state.ts
+++ b/packages/nextclade-web/src/state/results.state.ts
@@ -2,7 +2,15 @@
 import type { AuspiceJsonV2, CladeNodeAttrDesc } from 'auspice'
 import { isNil } from 'lodash'
 import { atom, atomFamily, DefaultValue, selector, selectorFamily } from 'recoil'
-import type { AaMotifsDesc, Cds, CsvColumnConfig, Gene, NextcladeResult, PhenotypeAttrDesc } from 'src/types'
+import type {
+  AaMotifsDesc,
+  AuspiceRefNode,
+  Cds,
+  CsvColumnConfig,
+  Gene,
+  NextcladeResult,
+  PhenotypeAttrDesc,
+} from 'src/types'
 import { AlgorithmGlobalStatus, AlgorithmSequenceStatus, getResultStatus } from 'src/types'
 import { plausible } from 'src/components/Common/Plausible'
 import { runFilters } from 'src/filtering/runFilters'
@@ -306,6 +314,11 @@ export const phenotypeAttrDescsAtom = atom<PhenotypeAttrDesc[]>({
 export const phenotypeAttrKeysAtom = selector<string[]>({
   key: 'phenotypeAttrKeys',
   get: ({ get }) => get(phenotypeAttrDescsAtom).map((desc) => desc.name),
+})
+
+export const refNodesAtom = atom<AuspiceRefNode[]>({
+  key: 'refNodes',
+  default: [],
 })
 
 export const aaMotifsDescsAtom = atom<AaMotifsDesc[]>({

--- a/packages/nextclade-web/src/wasm/main.rs
+++ b/packages/nextclade-web/src/wasm/main.rs
@@ -8,7 +8,7 @@ use nextclade::io::nextclade_csv::{results_to_csv_string, CsvColumnConfig};
 use nextclade::io::results_json::{results_to_json_string, results_to_ndjson_string};
 use nextclade::run::nextclade_wasm::{Nextclade, NextcladeParams, NextcladeParamsRaw, NextcladeResult};
 use nextclade::run::params::NextcladeInputParamsOptional;
-use nextclade::tree::tree::CladeNodeAttrKeyDesc;
+use nextclade::tree::tree::{AuspiceRefNode, CladeNodeAttrKeyDesc};
 use nextclade::types::outputs::{NextcladeErrorOutputs, NextcladeOutputs};
 use nextclade::utils::error::report_to_string;
 use wasm_bindgen::prelude::*;
@@ -108,6 +108,7 @@ impl NextcladeWasm {
     errors_json_str: &str,
     clade_node_attrs_json_str: &str,
     phenotype_attrs_json_str: &str,
+    ref_nodes_json_str: &str,
     nextclade_web_version: Option<String>,
   ) -> Result<String, JsError> {
     let outputs: Vec<NextcladeOutputs> = jserr(
@@ -128,12 +129,17 @@ impl NextcladeWasm {
         .wrap_err("When serializing results JSON: When parsing phenotypes attr keys JSON internally"),
     )?;
 
+    let ref_nodes: Vec<AuspiceRefNode> = jserr(
+      json_parse(ref_nodes_json_str).wrap_err("When serializing results JSON: When parsing ref nodes JSON internally"),
+    )?;
+
     jserr(
       results_to_json_string(
         &outputs,
         &errors,
         &clade_node_attrs,
         &phenotype_attrs,
+        &ref_nodes,
         &nextclade_web_version,
       )
       .wrap_err("When serializing results JSON"),

--- a/packages/nextclade-web/src/workers/ExportThread.ts
+++ b/packages/nextclade-web/src/workers/ExportThread.ts
@@ -1,5 +1,5 @@
 import { CladeNodeAttrDesc } from 'auspice'
-import type { AaMotifsDesc, AnalysisError, AnalysisResult, PhenotypeAttrDesc } from 'src/types'
+import type { AaMotifsDesc, AnalysisError, AnalysisResult, AuspiceRefNode, PhenotypeAttrDesc } from 'src/types'
 import type { NextcladeWasmWorker } from 'src/workers/nextcladeWasm.worker'
 import { spawn } from 'src/workers/spawn'
 import { CsvColumnConfig } from 'src/types'
@@ -29,6 +29,7 @@ export class ExportWorker {
     errors: AnalysisError[],
     cladeNodeAttrsJson: CladeNodeAttrDesc[],
     phenotypeAttrsJson: PhenotypeAttrDesc[],
+    refNodes: AuspiceRefNode[],
     nextcladeWebVersion: string,
   ): Promise<string> {
     return this.thread.serializeResultsJson(
@@ -36,6 +37,7 @@ export class ExportWorker {
       errors,
       cladeNodeAttrsJson,
       phenotypeAttrsJson,
+      refNodes,
       nextcladeWebVersion,
     )
   }

--- a/packages/nextclade-web/src/workers/nextcladeWasm.worker.ts
+++ b/packages/nextclade-web/src/workers/nextcladeWasm.worker.ts
@@ -1,7 +1,7 @@
 import 'regenerator-runtime'
 
 import type { CladeNodeAttrDesc } from 'auspice'
-import { AnalysisInitialData, OutputTrees } from 'src/types'
+import { AnalysisInitialData, AuspiceRefNode, OutputTrees } from 'src/types'
 import type { Thread } from 'threads'
 import { expose } from 'threads/worker'
 import { Observable as ThreadsObservable, Subject } from 'threads/observable'
@@ -124,6 +124,7 @@ export async function serializeResultsJson(
   errors: AnalysisError[],
   cladeNodeAttrsJson: CladeNodeAttrDesc[],
   phenotypeAttrsJson: PhenotypeAttrDesc[],
+  refNodes: AuspiceRefNode[],
   nextcladeWebVersion: string,
 ) {
   return NextcladeWasm.serialize_results_json(
@@ -131,6 +132,7 @@ export async function serializeResultsJson(
     JSON.stringify(errors),
     JSON.stringify(cladeNodeAttrsJson),
     JSON.stringify(phenotypeAttrsJson),
+    JSON.stringify(refNodes),
     nextcladeWebVersion,
   )
 }

--- a/packages/nextclade/src/analyze/find_relative_mutations.rs
+++ b/packages/nextclade/src/analyze/find_relative_mutations.rs
@@ -1,10 +1,15 @@
 use crate::alphabet::nuc::Nuc;
+use crate::analyze::aa_del::AaDel;
+use crate::analyze::aa_sub::AaSub;
+use crate::analyze::find_private_aa_mutations::{find_private_aa_mutations, PrivateAaMutations};
 use crate::analyze::find_private_nuc_mutations::{find_private_nuc_mutations, PrivateNucMutations};
-use crate::analyze::letter_ranges::NucRange;
+use crate::analyze::letter_ranges::{CdsAaRange, NucRange};
 use crate::analyze::nuc_del::NucDelRange;
 use crate::analyze::nuc_sub::NucSub;
 use crate::analyze::virus_properties::VirusProperties;
-use crate::coord::range::NucRefGlobalRange;
+use crate::coord::range::{AaRefRange, NucRefGlobalRange};
+use crate::gene::gene_map::GeneMap;
+use crate::translate::translate_genes::Translation;
 use crate::tree::tree::{AuspiceGraph, AuspiceRefNode};
 use eyre::{eyre, Report, WrapErr};
 use itertools::Itertools;
@@ -18,7 +23,7 @@ pub struct RelativeNucMutations {
   muts: PrivateNucMutations,
 }
 
-pub fn find_relative_mutations(
+pub fn find_relative_nuc_mutations(
   graph: &AuspiceGraph,
   clade: &str,
   clade_node_attrs: &BTreeMap<String, String>,
@@ -57,7 +62,54 @@ pub fn find_relative_mutations(
       })
     })
     .collect::<Result<Vec<RelativeNucMutations>, Report>>()
-    .wrap_err("When calling mutations relative to a reference node")
+    .wrap_err("When calling nucleotide mutations relative to a reference node")
+}
+
+#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RelativeAaMutations {
+  ref_node: AuspiceRefNode,
+  muts: BTreeMap<String, PrivateAaMutations>,
+}
+
+pub fn find_relative_aa_mutations(
+  graph: &AuspiceGraph,
+  clade: &str,
+  clade_node_attrs: &BTreeMap<String, String>,
+  aa_substitutions: &[AaSub],
+  aa_deletions: &[AaDel],
+  aa_unknowns: &[CdsAaRange],
+  aa_unsequenced_ranges: &BTreeMap<String, Vec<AaRefRange>>,
+  ref_peptides: &Translation,
+  gene_map: &GeneMap,
+) -> Result<Vec<RelativeAaMutations>, Report> {
+  let ref_nodes = filter_ref_nodes(graph, clade, clade_node_attrs);
+
+  ref_nodes
+    .iter()
+    .map(|&ref_node| -> Result<_, Report> {
+      let node = graph
+        .iter_nodes()
+        .find(|node| node.payload().name == ref_node.name)
+        .ok_or_else(|| eyre!("Unable to find reference node on the tree: '{}'", &ref_node.name))?;
+
+      let muts = find_private_aa_mutations(
+        node.payload(),
+        aa_substitutions,
+        aa_deletions,
+        aa_unknowns,
+        aa_unsequenced_ranges,
+        ref_peptides,
+        gene_map,
+      );
+
+      Ok(RelativeAaMutations {
+        ref_node: ref_node.to_owned(),
+        muts,
+      })
+    })
+    .collect::<Result<Vec<RelativeAaMutations>, Report>>()
+    .wrap_err("When calling amino acid mutations relative to a reference node")
 }
 
 /// Take only ref nodes which are relevant for this sample, according to the node's include list

--- a/packages/nextclade/src/analyze/find_relative_mutations.rs
+++ b/packages/nextclade/src/analyze/find_relative_mutations.rs
@@ -1,0 +1,85 @@
+use crate::alphabet::nuc::Nuc;
+use crate::analyze::find_private_nuc_mutations::{find_private_nuc_mutations, PrivateNucMutations};
+use crate::analyze::letter_ranges::NucRange;
+use crate::analyze::nuc_del::NucDelRange;
+use crate::analyze::nuc_sub::NucSub;
+use crate::analyze::virus_properties::VirusProperties;
+use crate::coord::range::NucRefGlobalRange;
+use crate::tree::tree::{AuspiceGraph, AuspiceRefNode};
+use eyre::{eyre, Report, WrapErr};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RelativeNucMutations {
+  ref_node: AuspiceRefNode,
+  muts: PrivateNucMutations,
+}
+
+pub fn find_relative_mutations(
+  graph: &AuspiceGraph,
+  clade: &str,
+  clade_node_attrs: &BTreeMap<String, String>,
+  substitutions: &[NucSub],
+  deletions: &[NucDelRange],
+  missing: &[NucRange],
+  alignment_range: &NucRefGlobalRange,
+  ref_seq: &[Nuc],
+  non_acgtns: &[NucRange],
+  virus_properties: &VirusProperties,
+) -> Result<Vec<RelativeNucMutations>, Report> {
+  let ref_nodes = filter_ref_nodes(graph, clade, clade_node_attrs);
+
+  ref_nodes
+    .iter()
+    .map(|&ref_node| -> Result<_, Report> {
+      let node = graph
+        .iter_nodes()
+        .find(|node| node.payload().name == ref_node.name)
+        .ok_or_else(|| eyre!("Unable to find reference node on the tree: '{}'", &ref_node.name))?;
+
+      let muts = find_private_nuc_mutations(
+        node.payload(),
+        substitutions,
+        deletions,
+        missing,
+        alignment_range,
+        ref_seq,
+        non_acgtns,
+        virus_properties,
+      );
+
+      Ok(RelativeNucMutations {
+        ref_node: ref_node.to_owned(),
+        muts,
+      })
+    })
+    .collect::<Result<Vec<RelativeNucMutations>, Report>>()
+    .wrap_err("When calling mutations relative to a reference node")
+}
+
+/// Take only ref nodes which are relevant for this sample, according to the node's include list
+pub fn filter_ref_nodes<'a>(
+  graph: &'a AuspiceGraph,
+  clade: &str,
+  clade_node_attrs: &BTreeMap<String, String>,
+) -> Vec<&'a AuspiceRefNode> {
+  graph
+    .data
+    .meta
+    .extensions
+    .nextclade
+    .reference_nodes
+    .iter()
+    .filter(|node| {
+      // For each attribute key in includes, check that the attribute value of this sample match
+      // at least one item in the include list
+      node.include.iter().all(|(key, includes)| {
+        let curr_value = if key == "clade" { clade } else { &clade_node_attrs[key] };
+        includes.iter().any(|include_value| include_value == curr_value) // TODO: consider regex match rather than equality
+      })
+    })
+    .collect_vec()
+}

--- a/packages/nextclade/src/analyze/mod.rs
+++ b/packages/nextclade/src/analyze/mod.rs
@@ -8,6 +8,7 @@ pub mod find_aa_motifs;
 pub mod find_aa_motifs_changes;
 pub mod find_private_aa_mutations;
 pub mod find_private_nuc_mutations;
+pub mod find_relative_mutations;
 pub mod is_sequenced;
 pub mod letter_composition;
 pub mod letter_ranges;

--- a/packages/nextclade/src/io/results_json.rs
+++ b/packages/nextclade/src/io/results_json.rs
@@ -1,7 +1,7 @@
 use crate::analyze::virus_properties::PhenotypeAttrDesc;
 use crate::io::json::{json_stringify, json_write, JsonPretty};
 use crate::io::ndjson::NdjsonWriter;
-use crate::tree::tree::CladeNodeAttrKeyDesc;
+use crate::tree::tree::{AuspiceRefNode, CladeNodeAttrKeyDesc};
 use crate::types::outputs::{
   combine_outputs_and_errors_sorted, NextcladeErrorOutputs, NextcladeOutputOrError, NextcladeOutputs,
 };
@@ -27,13 +27,19 @@ pub struct ResultsJson {
 
   pub phenotype_attr_keys: Vec<PhenotypeAttrDesc>,
 
+  pub ref_nodes: Vec<AuspiceRefNode>,
+
   pub results: Vec<NextcladeOutputs>,
 
   pub errors: Vec<NextcladeErrorOutputs>,
 }
 
 impl ResultsJson {
-  pub fn new(clade_node_attrs: &[CladeNodeAttrKeyDesc], phenotype_attr_keys: &[PhenotypeAttrDesc]) -> Self {
+  pub fn new(
+    clade_node_attrs: &[CladeNodeAttrKeyDesc],
+    phenotype_attr_keys: &[PhenotypeAttrDesc],
+    ref_nodes: &[AuspiceRefNode],
+  ) -> Self {
     Self {
       schema_version: "3.0.0".to_owned(),
       nextclade_algo_version: this_package_version_str().to_owned(),
@@ -41,6 +47,7 @@ impl ResultsJson {
       created_at: date_iso_now(),
       clade_node_attr_keys: clade_node_attrs.to_vec(),
       phenotype_attr_keys: phenotype_attr_keys.to_vec(),
+      ref_nodes: ref_nodes.to_vec(),
       results: vec![],
       errors: vec![],
     }
@@ -51,9 +58,10 @@ impl ResultsJson {
     errors: &[NextcladeErrorOutputs],
     clade_node_attrs: &[CladeNodeAttrKeyDesc],
     phenotype_attr_keys: &[PhenotypeAttrDesc],
+    ref_nodes: &[AuspiceRefNode],
     nextclade_web_version: &Option<String>,
   ) -> Self {
-    let mut this = Self::new(clade_node_attrs, phenotype_attr_keys);
+    let mut this = Self::new(clade_node_attrs, phenotype_attr_keys, ref_nodes);
     this.results = outputs.to_vec();
     this.errors = errors.to_vec();
     this.nextclade_web_version = nextclade_web_version.clone();
@@ -71,10 +79,11 @@ impl ResultsJsonWriter {
     filepath: impl AsRef<Path>,
     clade_node_attrs: &[CladeNodeAttrKeyDesc],
     phenotype_attr_keys: &[PhenotypeAttrDesc],
+    ref_nodes: &[AuspiceRefNode],
   ) -> Result<Self, Report> {
     Ok(Self {
       filepath: filepath.as_ref().to_owned(),
-      result: ResultsJson::new(clade_node_attrs, phenotype_attr_keys),
+      result: ResultsJson::new(clade_node_attrs, phenotype_attr_keys, ref_nodes),
     })
   }
 
@@ -107,6 +116,7 @@ pub fn results_to_json_string(
   errors: &[NextcladeErrorOutputs],
   clade_node_attrs: &[CladeNodeAttrKeyDesc],
   phenotype_attr_keys: &[PhenotypeAttrDesc],
+  ref_nodes: &[AuspiceRefNode],
   nextclade_web_version: &Option<String>,
 ) -> Result<String, Report> {
   let results_json = ResultsJson::from_outputs(
@@ -114,6 +124,7 @@ pub fn results_to_json_string(
     errors,
     clade_node_attrs,
     phenotype_attr_keys,
+    ref_nodes,
     nextclade_web_version,
   );
   json_stringify(&results_json, JsonPretty(false))

--- a/packages/nextclade/src/run/nextclade_run_one.rs
+++ b/packages/nextclade/src/run/nextclade_run_one.rs
@@ -11,7 +11,9 @@ use crate::analyze::find_aa_motifs::find_aa_motifs;
 use crate::analyze::find_aa_motifs_changes::find_aa_motifs_changes;
 use crate::analyze::find_private_aa_mutations::{find_private_aa_mutations, PrivateAaMutations};
 use crate::analyze::find_private_nuc_mutations::{find_private_nuc_mutations, PrivateNucMutations};
-use crate::analyze::find_relative_mutations::{find_relative_mutations, RelativeNucMutations};
+use crate::analyze::find_relative_mutations::{
+  find_relative_aa_mutations, find_relative_nuc_mutations, RelativeAaMutations, RelativeNucMutations,
+};
 use crate::analyze::letter_composition::get_letter_composition;
 use crate::analyze::letter_ranges::{
   find_aa_letter_ranges, find_letter_ranges, find_letter_ranges_by, CdsAaRange, NucRange,
@@ -68,6 +70,7 @@ struct NextcladeResultWithGraph {
   nearest_node_id: GraphNodeKey,
   nearest_nodes: Option<Vec<String>>,
   relative_nuc_mutations: Vec<RelativeNucMutations>,
+  relative_aa_mutations: Vec<RelativeAaMutations>,
 }
 
 pub fn nextclade_run_one(
@@ -250,6 +253,7 @@ pub fn nextclade_run_one(
     private_nuc_mutations,
     private_aa_mutations,
     relative_nuc_mutations,
+    relative_aa_mutations,
     phenotype_values,
     divergence,
     custom_node_attributes,
@@ -304,7 +308,7 @@ pub fn nextclade_run_one(
         ref_seq.len(),
       );
 
-    let relative_nuc_mutations = find_relative_mutations(
+    let relative_nuc_mutations = find_relative_nuc_mutations(
       graph,
       &clade,
       &clade_node_attrs,
@@ -315,6 +319,18 @@ pub fn nextclade_run_one(
       ref_seq,
       &non_acgtns,
       virus_properties,
+    )?;
+
+    let relative_aa_mutations = find_relative_aa_mutations(
+      graph,
+      &clade,
+      &clade_node_attrs,
+      &aa_substitutions,
+      &aa_deletions,
+      &unknown_aa_ranges,
+      &aa_unsequenced_ranges,
+      ref_translation,
+      gene_map,
     )?;
 
     let phenotype_values = virus_properties.phenotype_data.as_ref().map(|phenotype_data| {
@@ -340,6 +356,7 @@ pub fn nextclade_run_one(
       private_nuc_mutations,
       private_aa_mutations,
       relative_nuc_mutations,
+      relative_aa_mutations,
       phenotype_values,
       divergence,
       custom_node_attributes: clade_node_attrs,
@@ -415,6 +432,7 @@ pub fn nextclade_run_one(
       private_nuc_mutations,
       private_aa_mutations,
       relative_nuc_mutations,
+      relative_aa_mutations,
       phenotype_values,
       divergence,
       custom_node_attributes,

--- a/packages/nextclade/src/run/nextclade_wasm.rs
+++ b/packages/nextclade/src/run/nextclade_wasm.rs
@@ -16,7 +16,7 @@ use crate::run::nextclade_run_one::nextclade_run_one;
 use crate::run::params::{NextcladeInputParams, NextcladeInputParamsOptional};
 use crate::translate::translate_genes::Translation;
 use crate::translate::translate_genes_ref::translate_genes_ref;
-use crate::tree::tree::{AuspiceGraph, AuspiceTree, CladeNodeAttrKeyDesc};
+use crate::tree::tree::{AuspiceGraph, AuspiceRefNode, AuspiceTree, CladeNodeAttrKeyDesc};
 use crate::tree::tree_builder::graph_attach_new_nodes_in_place;
 use crate::tree::tree_preprocess::graph_preprocess_in_place;
 use crate::types::outputs::NextcladeOutputs;
@@ -90,6 +90,7 @@ pub struct AnalysisInitialData<'a> {
   pub cds_order_preference: Vec<String>,
   pub clade_node_attr_key_descs: &'a [CladeNodeAttrKeyDesc],
   pub phenotype_attr_descs: &'a [PhenotypeAttrDesc],
+  pub ref_nodes: &'a [AuspiceRefNode],
   pub aa_motifs_descs: &'a [AaMotifsDesc],
   pub aa_motif_keys: &'a [String],
   pub csv_column_config_default: CsvColumnConfig,
@@ -137,6 +138,7 @@ pub struct Nextclade {
   pub graph: Option<AuspiceGraph>,
   pub clade_attr_descs: Vec<CladeNodeAttrKeyDesc>,
   pub phenotype_attr_descs: Vec<PhenotypeAttrDesc>,
+  pub ref_nodes: Vec<AuspiceRefNode>,
 }
 
 pub struct InitialStateWithAa {
@@ -223,6 +225,11 @@ impl Nextclade {
     let aa_motifs_descs = virus_properties.aa_motifs.clone();
     let aa_motifs_keys = aa_motifs_descs.iter().map(|desc| desc.name.clone()).collect_vec();
 
+    let ref_nodes = graph
+      .as_ref()
+      .map(|graph| graph.data.meta.extensions.nextclade.reference_nodes.clone())
+      .unwrap_or_default();
+
     Ok(Self {
       ref_record,
       ref_seq,
@@ -240,6 +247,7 @@ impl Nextclade {
       graph,
       clade_attr_descs,
       phenotype_attr_descs,
+      ref_nodes,
     })
   }
 
@@ -251,6 +259,7 @@ impl Nextclade {
       cds_order_preference: self.virus_properties.cds_order_preference.clone(),
       clade_node_attr_key_descs: &self.clade_attr_descs,
       phenotype_attr_descs: &self.phenotype_attr_descs,
+      ref_nodes: &self.ref_nodes,
       aa_motifs_descs: &self.aa_motifs_descs,
       aa_motif_keys: &self.aa_motifs_keys,
       csv_column_config_default: CsvColumnConfig::default(),

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -319,6 +319,24 @@ pub struct CladeNodeAttrKeyDesc {
   pub other: serde_json::Value,
 }
 
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, schemars::JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AuspiceRefNode {
+  pub name: String,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub display_name: Option<String>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub description: Option<String>,
+
+  #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+  pub include: BTreeMap<String, Vec<String>>,
+
+  #[serde(flatten)]
+  pub other: serde_json::Value,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, Eq, PartialEq, schemars::JsonSchema, Validate, Debug)]
 pub struct AuspiceMetaExtensionsNextclade {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -326,6 +344,9 @@ pub struct AuspiceMetaExtensionsNextclade {
 
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub placement_mask_ranges: Vec<NucRefGlobalRange>,
+
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub reference_nodes: Vec<AuspiceRefNode>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,

--- a/packages/nextclade/src/types/outputs.rs
+++ b/packages/nextclade/src/types/outputs.rs
@@ -6,7 +6,7 @@ use crate::analyze::aa_sub::AaSub;
 use crate::analyze::find_aa_motifs_changes::{AaMotifsChangesMap, AaMotifsMap};
 use crate::analyze::find_private_aa_mutations::PrivateAaMutations;
 use crate::analyze::find_private_nuc_mutations::PrivateNucMutations;
-use crate::analyze::find_relative_mutations::RelativeNucMutations;
+use crate::analyze::find_relative_mutations::{RelativeAaMutations, RelativeNucMutations};
 use crate::analyze::letter_ranges::{CdsAaRange, NucRange};
 use crate::analyze::nuc_del::NucDelRange;
 use crate::analyze::nuc_sub::NucSub;
@@ -75,6 +75,7 @@ pub struct NextcladeOutputs {
   pub private_nuc_mutations: PrivateNucMutations,
   pub private_aa_mutations: BTreeMap<String, PrivateAaMutations>,
   pub relative_nuc_mutations: Vec<RelativeNucMutations>,
+  pub relative_aa_mutations: Vec<RelativeAaMutations>,
   pub warnings: Vec<PeptideWarning>,
   pub missing_cdses: Vec<String>,
   pub divergence: f64,

--- a/packages/nextclade/src/types/outputs.rs
+++ b/packages/nextclade/src/types/outputs.rs
@@ -6,6 +6,7 @@ use crate::analyze::aa_sub::AaSub;
 use crate::analyze::find_aa_motifs_changes::{AaMotifsChangesMap, AaMotifsMap};
 use crate::analyze::find_private_aa_mutations::PrivateAaMutations;
 use crate::analyze::find_private_nuc_mutations::PrivateNucMutations;
+use crate::analyze::find_relative_mutations::RelativeNucMutations;
 use crate::analyze::letter_ranges::{CdsAaRange, NucRange};
 use crate::analyze::nuc_del::NucDelRange;
 use crate::analyze::nuc_sub::NucSub;
@@ -73,6 +74,7 @@ pub struct NextcladeOutputs {
   pub clade: String,
   pub private_nuc_mutations: PrivateNucMutations,
   pub private_aa_mutations: BTreeMap<String, PrivateAaMutations>,
+  pub relative_nuc_mutations: Vec<RelativeNucMutations>,
   pub warnings: Vec<PeptideWarning>,
   pub missing_cdses: Vec<String>,
   pub divergence: f64,


### PR DESCRIPTION
This extends concept of private mutations (relative to the parent node on the ref tree) to mutations relative to an arbitrary node of interest.

The ref nodes of interest are described by the user in the `.meta .extensions .nextclade .reference_nodes` of the input Auspice JSON. The description can also contain constrains: we can match node to only query samples belonging to a certain clade or lineage.

Private mutations functionality is unchanged. New functionality, inputs and outputs are added. Though the implementation algo is largely reused.

### Work items

 - [x] read input config from Auspice JSON
 - [x] calculate relative nuc mutations
 - [x] calculate relative aa mutations
 - [x] filter by clade and clade-like attributes
 - [ ] filter by gene?
 - [x] output to Nextclade JSON
 - [x] output to Nextclade NDJSON
 - [ ] output to TSV and CSV
 - [ ] display in web app 


### Inputs

Example configuration object. Put it into `.meta.extensions.nextclade.reference_nodes`

<details>
  <summary>Click to expand</summary>

```json
{
  "extensions": {
    "nextclade": {
      "reference_nodes": [
        {
          "name": "NODE_0000659",
          "displayName": "BA.2.86 (23I)",
          "description": "Ancestral BA.2.86 sequence"
        },
        {
          "name": "XBB.1.5",
          "displayName": "XBB.1.5 (23A)",
          "description": "Ancestral XBB.1.5 sequence. Vaccine strain 2023/2024",
          "include": {
            "clade": ["23A"]
          }
        },
        {
          "name": "NODE_0000862",
          "displayName": "BA.5 (22B)",
          "description": "Ancestral BA.5 sequence. Vaccine strain 2022/2023",
          "include": {
            "clade": ["22B"]
          }
        }
      ]
    }
  }
}
```
</details>

The `name` field should match the `name` field of one of the nodes on the tree. The `displayName` and `description` are optional arbitrary strings used for display purposes.

The `include` field should be an object, which contains:
 - keys: `name`s from the `.meta.extensions.nextclade.clade_node_attrs` (for clade-line attributes) or string `"clade"` (for the built-in clades).
 - values: a list of values of the clade-like attribute or a list of built-in clades. Only query sequences which match these attributes are considered for calculation of mutations relative to that node.

If the `include` field is not present, then no constraints applied (all query sequences are considered).


### Outputs

#### Output JSON and NDJSON

Example fragment of output json entry (entry in the `.results[]` array) (mutation lists are truncated for demonstration purposes)

<details>
  <summary>Click to expand</summary>


```json
{
  "relativeNucMutations": [
    {
      "refNode": {
        "name": "NODE_0000659",
        "displayName": "BA.2.86 (23I)",
        "description": "Ancestral BA.2.86 sequence"
      },
      "muts": {
        "privateSubstitutions": [
          {"pos": 404, "refNuc": "A", "qryNuc": "G"},
          {"pos": 896, "refNuc": "A", "qryNuc": "C"}
        ],
        "privateDeletions": [],
        "reversionSubstitutions": [
          {"pos": 896, "refNuc": "A", "qryNuc": "C"},
          {"pos": 3430, "refNuc": "T", "qryNuc": "G"}
        ],
        "labeledSubstitutions": [
          {
            "substitution": {"pos": 404, "refNuc": "A", "qryNuc": "G"},
            "labels": ["23A", "23D", "23F", "23B", "22F", "23E", "23H", "23G"]
          },
          {
            "substitution": {"pos": 2333, "refNuc": "C", "qryNuc": "T"},
            "labels": ["23F", "23H"]
          }
        ],
        "unlabeledSubstitutions": [
          {"pos": 4089, "refNuc": "C", "qryNuc": "T"},
          {"pos": 11344, "refNuc": "C", "qryNuc": "T"}
        ],
        "totalPrivateSubstitutions": 75,
        "totalPrivateDeletions": 0,
        "totalReversionSubstitutions": 37,
        "totalLabeledSubstitutions": 34,
        "totalUnlabeledSubstitutions": 4
      }
    }
  ],
  "relativeAaMutations": [
    {
      "refNode": {
        "name": "NODE_0000659",
        "displayName": "BA.2.86 (23I)",
        "description": "Ancestral BA.2.86 sequence"
      },
      "muts": {
        "E": {
          "privateSubstitutions": [
            {"cdsName": "E", "pos": 10, "refAa": "T", "qryAa": "A"}
          ],
          "privateDeletions": [],
          "reversionSubstitutions": [],
          "totalPrivateSubstitutions": 1,
          "totalPrivateDeletions": 0,
          "totalReversionSubstitutions": 0
        },
        "S": {
          "privateSubstitutions": [
            {"cdsName": "S", "pos": 20, "refAa": "T", "qryAa": "R"},
            {"cdsName": "S", "pos": 26, "refAa": "-", "qryAa": "S"}
          ],
          "privateDeletions": [
            {"cdsName": "S", "pos": 23, "refAa": "S"},
            {"cdsName": "S", "pos": 143, "refAa": "Y"}
          ],
          "reversionSubstitutions": [
            {"cdsName": "S", "pos": 20, "refAa": "T", "qryAa": "R"},
            {"cdsName": "S", "pos": 49, "refAa": "L", "qryAa": "S"}
          ],
          "totalPrivateSubstitutions": 39,
          "totalPrivateDeletions": 2,
          "totalReversionSubstitutions": 25
        }
      }
    }
  ]
}

```
</details>


#### Output TSV and CSV

TODO


### Visualization in Nextclade Web

TODO
