### PR TITLE
feat: use Auspice JSON as a dataset

### DIFF
--- a/packages/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages/nextclade-cli/src/dataset/dataset_download.rs
@@ -297,41 +297,7 @@ pub fn dataset_individual_files_load(
         .and_then(|input_pathogen_json| read_file_to_string(input_pathogen_json).ok())
         .map_ref_fallible(VirusProperties::from_str)
         .wrap_err("When reading pathogen JSON")?
-        .unwrap_or_else(|| {
-          // The only case where we allow pathogen.json to be missing is when there's no dataset and files are provided
-          // explicitly through args. Let's create a dummy value to avoid making the field optional,
-          // and avoid adding `Default` trait.
-          VirusProperties {
-            schema_version: "".to_owned(),
-            attributes: BTreeMap::default(),
-            shortcuts: vec![],
-            meta: DatasetMeta::default(),
-            files: DatasetFiles {
-              reference: "".to_owned(),
-              pathogen_json: "".to_owned(),
-              genome_annotation: None,
-              tree_json: None,
-              examples: None,
-              readme: None,
-              changelog: None,
-              rest_files: BTreeMap::default(),
-              other: serde_json::Value::default(),
-            },
-            default_cds: None,
-            cds_order_preference: vec![],
-            mut_labels: LabelledMutationsConfig::default(),
-            qc: None,
-            general_params: None,
-            alignment_params: None,
-            tree_builder_params: None,
-            phenotype_data: None,
-            aa_motifs: vec![],
-            versions: vec![],
-            version: None,
-            compatibility: None,
-            other: serde_json::Value::default(),
-          }
-        });
+        .unwrap_or_default();
 
       let ref_record = read_one_fasta(input_ref).wrap_err("When reading reference sequence")?;
 

--- a/packages/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages/nextclade-cli/src/dataset/dataset_download.rs
@@ -303,48 +303,7 @@ pub fn dataset_json_load(
   // } = &run_args.inputs;
 
   let auspice_json = AuspiceTree::from_path(dataset_json).wrap_err("When reading Auspice JSON v2")?;
-
-  let virus_properties = auspice_json
-    .meta
-    .extensions
-    .nextclade
-    .pathogen
-    .as_ref()
-    .cloned()
-    .unwrap_or_default();
-
-  let ref_record = {
-    let ref_name = virus_properties
-      .attributes
-      .get("reference name")
-      .cloned()
-      .unwrap_or_else(|| AnyType::String("reference".to_owned()))
-      .as_str()
-      .wrap_err("When reading Auspice JSON v2 `.meta.extensions.nextclade.pathogen.attributes[\"reference name\"]`")?
-      .to_owned();
-
-    let ref_seq = auspice_json.root_sequence.get("nuc")
-    .ok_or_else(|| eyre!("Auspice JSON v2 is used as input dataset, but does not contain required reference sequence field (.root_sequence.nuc)"))?.to_owned();
-
-    FastaRecord {
-      index: 0,
-      seq_name: ref_name,
-      seq: ref_seq,
-    }
-  };
-
-  let gene_map = auspice_json
-    .meta
-    .genome_annotations
-    .map_ref_fallible(GeneMap::from_auspice_annotations)?
-    .unwrap_or_default();
-
-  Ok(NextcladeParams {
-    ref_record,
-    gene_map,
-    tree: Some(auspice_json),
-    virus_properties,
-  })
+  NextcladeParams::from_auspice(&auspice_json)
 }
 
 pub fn dataset_individual_files_load(

--- a/packages/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages/nextclade-cli/src/dataset/dataset_download.rs
@@ -8,12 +8,11 @@ use log::{warn, LevelFilter};
 use nextclade::analyze::virus_properties::VirusProperties;
 use nextclade::gene::gene_map::{filter_gene_map, GeneMap};
 use nextclade::io::dataset::{Dataset, DatasetsIndexJson};
-use nextclade::io::fasta::{read_one_fasta, read_one_fasta_str, FastaRecord};
+use nextclade::io::fasta::{read_one_fasta, read_one_fasta_str};
 use nextclade::io::file::create_file_or_stdout;
 use nextclade::io::fs::{ensure_dir, has_extension, read_file_to_string};
 use nextclade::run::nextclade_wasm::NextcladeParams;
 use nextclade::tree::tree::AuspiceTree;
-use nextclade::utils::any::AnyType;
 use nextclade::utils::fs::list_files_recursive;
 use nextclade::utils::option::OptionMapRefFallible;
 use nextclade::utils::string::{format_list, surround_with_quotes, Indent};
@@ -288,9 +287,9 @@ pub fn dataset_dir_load(
 }
 
 pub fn dataset_json_load(
-  run_args: &NextcladeRunArgs,
+  _run_args: &NextcladeRunArgs,
   dataset_json: impl AsRef<Path>,
-  cdses: &Option<Vec<String>>,
+  _cdses: &Option<Vec<String>>,
 ) -> Result<NextcladeParams, Report> {
   let dataset_json = dataset_json.as_ref();
 

--- a/packages/nextclade-web/src/components/Error/ErrorContent.tsx
+++ b/packages/nextclade-web/src/components/Error/ErrorContent.tsx
@@ -1,17 +1,16 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { Button, Col, Row } from 'reactstrap'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { NextcladeV2Error } from 'src/io/fetchSingleDatasetFromUrl'
 import styled from 'styled-components'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { FaClipboardCheck, FaClipboardList } from 'react-icons/fa'
-
 import { ErrorGeneric } from 'src/components/Error/error-types/ErrorGeneric'
 import { ErrorNetworkConnectionFailure } from 'src/components/Error/error-types/ErrorNetworkConnectionFailure'
 import { ErrorNetworkRequestFailure } from 'src/components/Error/error-types/ErrorNetworkRequestFailure'
 import { NextcladeV2ErrorContent } from 'src/components/Error/error-types/NextcladeV2ErrorContent'
 import { ErrorContentExplanation, getErrorReportText } from 'src/components/Error/ErrorContentExplanation'
 import { sanitizeError } from 'src/helpers/sanitizeError'
+import { NextcladeV2Error } from 'src/io/fetchSingleDatasetDirectory'
 import { HttpRequestError } from 'src/io/axiosFetch'
 import { ErrorMessageMonospace } from './ErrorStyles'
 

--- a/packages/nextclade-web/src/components/Error/error-types/NextcladeV2ErrorContent.tsx
+++ b/packages/nextclade-web/src/components/Error/error-types/NextcladeV2ErrorContent.tsx
@@ -3,8 +3,8 @@ import React, { useMemo } from 'react'
 import { ErrorContainer, ErrorMessage } from 'src/components/Error/ErrorStyles'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { PROJECT_NAME, RELEASE_OLD_URL } from 'src/constants'
+import { NextcladeV2Error } from 'src/io/fetchSingleDatasetDirectory'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { NextcladeV2Error } from 'src/io/fetchSingleDatasetFromUrl'
 import urljoin from 'url-join'
 
 export interface Props {

--- a/packages/nextclade-web/src/components/Main/ButtonLoadExample.tsx
+++ b/packages/nextclade-web/src/components/Main/ButtonLoadExample.tsx
@@ -1,4 +1,5 @@
 import { Dataset } from '_SchemaRoot'
+import { isEmpty } from 'lodash'
 import React, { useCallback } from 'react'
 import { Button } from 'reactstrap'
 import { useRecoilValue } from 'recoil'
@@ -43,6 +44,10 @@ export function ButtonLoadExample({ ...rest }) {
   const onClick = useCallback(() => {
     setExampleSequences(datasetCurrent)
   }, [datasetCurrent, setExampleSequences])
+
+  if (isEmpty(datasetCurrent?.files.examples)) {
+    return null
+  }
 
   return (
     <Button {...rest} color="link" onClick={onClick} disabled={hasInputErrors || !datasetCurrent}>

--- a/packages/nextclade-web/src/components/Main/ButtonLoadExample.tsx
+++ b/packages/nextclade-web/src/components/Main/ButtonLoadExample.tsx
@@ -45,7 +45,7 @@ export function ButtonLoadExample({ ...rest }) {
     setExampleSequences(datasetCurrent)
   }, [datasetCurrent, setExampleSequences])
 
-  if (isEmpty(datasetCurrent?.files.examples)) {
+  if (isEmpty(datasetCurrent?.files?.examples)) {
     return null
   }
 

--- a/packages/nextclade-web/src/components/Main/DatasetContentSection.tsx
+++ b/packages/nextclade-web/src/components/Main/DatasetContentSection.tsx
@@ -21,12 +21,12 @@ export function DatasetContentSection() {
   return (
     <ContentSection>
       <Nav tabs>
-        {currentDataset?.files.readme && (
+        {currentDataset?.files?.readme && (
           <TabLabel tabId={0} activeTabId={activeTabId} setActiveTabId={setActiveTabId}>
             {'Summary'}
           </TabLabel>
         )}
-        {currentDataset?.files.changelog && (
+        {currentDataset?.files?.changelog && (
           <TabLabel tabId={1} activeTabId={activeTabId} setActiveTabId={setActiveTabId}>
             {'History'}
           </TabLabel>
@@ -40,10 +40,10 @@ export function DatasetContentSection() {
       </Nav>
       <TabContent activeTab={activeTabId}>
         <TabPane tabId={0}>
-          {currentDataset?.files.readme && <MarkdownRemote url={currentDataset?.files.readme} />}
+          {currentDataset?.files?.readme && <MarkdownRemote url={currentDataset?.files.readme} />}
         </TabPane>
         <TabPane tabId={1}>
-          {currentDataset?.files.changelog && <MarkdownRemote url={currentDataset?.files.changelog} />}
+          {currentDataset?.files?.changelog && <MarkdownRemote url={currentDataset?.files.changelog} />}
         </TabPane>
         <TabPane tabId={2}>{currentDataset && <DatasetContentTabAdvanced />}</TabPane>
       </TabContent>

--- a/packages/nextclade-web/src/components/Main/DatasetInfo.tsx
+++ b/packages/nextclade-web/src/components/Main/DatasetInfo.tsx
@@ -79,7 +79,7 @@ export function DatasetInfo({ dataset, showSuggestions, ...restProps }: DatasetI
     if (version?.tag === 'unreleased') {
       updatedAt = `${updatedAt} (${t('unreleased')})`
     }
-    return updatedAt
+    return updatedAt ?? t('unknown')
   }, [t, version?.tag, version?.updatedAt])
 
   const datasetName = attrStrMaybe(attributes, 'name') ?? path

--- a/packages/nextclade-web/src/components/Main/ExampleSequencePicker.tsx
+++ b/packages/nextclade-web/src/components/Main/ExampleSequencePicker.tsx
@@ -29,7 +29,7 @@ export function ExampleSequencePicker({ ...restProps }: LanguageSwitcherProps) {
   const { datasets: allDatasets } = useRecoilValue(datasetsAtom)
 
   const filtered = useMemo(() => {
-    const datasets = allDatasets.filter((dataset) => !isNil(dataset.files.examples))
+    const datasets = allDatasets.filter((dataset) => !isNil(dataset?.files?.examples))
     if (searchTerm.trim().length === 0) {
       return datasets
     }

--- a/packages/nextclade-web/src/helpers/formatDate.ts
+++ b/packages/nextclade-web/src/helpers/formatDate.ts
@@ -1,9 +1,15 @@
+import { isEmpty } from 'lodash'
 import { DateTime } from 'luxon'
+import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 
 export function formatDateIsoUtcSimple(dateTimeStr: string) {
   const utc = DateTime.fromISO(dateTimeStr, { zone: 'UTC' })
 
   const date = utc.toISODate()
+
+  if (isEmpty(date)) {
+    return undefined
+  }
 
   const time = utc.toISOTime({
     suppressMilliseconds: true,
@@ -11,5 +17,5 @@ export function formatDateIsoUtcSimple(dateTimeStr: string) {
     includeOffset: false,
   })
 
-  return [date, time, `(${utc.zoneName})`].join(' ')
+  return [date, time, `(${utc.zoneName})`].filter(notUndefinedOrNull).filter(isEmpty).join(' ')
 }

--- a/packages/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -164,10 +164,10 @@ export function useRunAnalysis() {
 /** Resolves all param inputs into strings */
 async function getParams(paramInputs: LaunchAnalysisInputs, dataset: Dataset): Promise<NextcladeParamsRawDir> {
   const entries = [
-    { key: 'geneMap', input: paramInputs.geneMap, datasetFileUrl: dataset.files.genomeAnnotation },
-    { key: 'refSeq', input: paramInputs.refSeq, datasetFileUrl: dataset.files.reference },
-    { key: 'tree', input: paramInputs.tree, datasetFileUrl: dataset.files.treeJson },
-    { key: 'virusProperties', input: paramInputs.virusProperties, datasetFileUrl: dataset.files.pathogenJson },
+    { key: 'geneMap', input: paramInputs.geneMap, datasetFileUrl: dataset?.files?.genomeAnnotation },
+    { key: 'refSeq', input: paramInputs.refSeq, datasetFileUrl: dataset?.files?.reference },
+    { key: 'tree', input: paramInputs.tree, datasetFileUrl: dataset?.files?.treeJson },
+    { key: 'virusProperties', input: paramInputs.virusProperties, datasetFileUrl: dataset?.files?.pathogenJson },
   ]
 
   return Object.fromEntries(

--- a/packages/nextclade-web/src/hooks/useRunAnalysis.ts
+++ b/packages/nextclade-web/src/hooks/useRunAnalysis.ts
@@ -1,18 +1,20 @@
 import type { AuspiceJsonV2, CladeNodeAttrDesc } from 'auspice'
-
 import { changeColorBy } from 'auspice/src/actions/colors'
+import { concurrent } from 'fasy'
 import { useRouter } from 'next/router'
 import { useDispatch } from 'react-redux'
 import { useRecoilCallback } from 'recoil'
+import { ErrorInternal } from 'src/helpers/ErrorInternal'
 import { clearAllFiltersAtom } from 'src/state/resultFilters.state'
 import { viewedCdsAtom } from 'src/state/seqViewSettings.state'
-import { AlgorithmGlobalStatus } from 'src/types'
+import { AlgorithmGlobalStatus, AlgorithmInput, Dataset, NextcladeParamsRaw, NextcladeParamsRawDir } from 'src/types'
 import { sanitizeError } from 'src/helpers/sanitizeError'
 import { auspiceStartClean, treeFilterByNodeType } from 'src/state/auspice/auspice.actions'
 import { createAuspiceState } from 'src/state/auspice/createAuspiceState'
 import { datasetCurrentAtom, cdsOrderPreferenceAtom } from 'src/state/dataset.state'
 import { globalErrorAtom } from 'src/state/error.state'
 import {
+  datasetJsonAtom,
   geneMapInputAtom,
   qrySeqInputsStorageAtom,
   refSeqInputAtom,
@@ -35,6 +37,7 @@ import {
 } from 'src/state/results.state'
 import { numThreadsAtom, showNewRunPopupAtom } from 'src/state/settings.state'
 import { launchAnalysis, LaunchAnalysisCallbacks, LaunchAnalysisInputs } from 'src/workers/launchAnalysis'
+import { axiosFetchRaw } from 'src/io/axiosFetch'
 
 export function useRunAnalysis() {
   const router = useRouter()
@@ -59,6 +62,8 @@ export function useRunAnalysis() {
 
         const qryInputs = getPromise(qrySeqInputsStorageAtom)
         const csvColumnConfig = getPromise(csvColumnConfigAtom)
+
+        const datasetJsonPromise = getPromise(datasetJsonAtom)
 
         const inputs: LaunchAnalysisInputs = {
           refSeq: getPromise(refSeqInputAtom),
@@ -130,7 +135,22 @@ export function useRunAnalysis() {
           .push('/results', '/results')
           .then(async () => {
             set(analysisStatusGlobalAtom, AlgorithmGlobalStatus.initWorkers)
-            return launchAnalysis(qryInputs, inputs, callbacks, datasetCurrent, numThreads, csvColumnConfig)
+
+            const tree = await datasetJsonPromise
+
+            let params: NextcladeParamsRaw
+            if (tree) {
+              params = { Auspice: { tree: JSON.stringify(tree) } }
+            } else {
+              const dataset = await datasetCurrent
+              if (!dataset) {
+                throw new ErrorInternal('Dataset is required but not found')
+              }
+              const data = await getParams(inputs, dataset)
+              params = { Dir: data }
+            }
+
+            return launchAnalysis(qryInputs, params, callbacks, numThreads, csvColumnConfig)
           })
           .catch((error) => {
             set(analysisStatusGlobalAtom, AlgorithmGlobalStatus.failed)
@@ -139,4 +159,34 @@ export function useRunAnalysis() {
       },
     [router, dispatch],
   )
+}
+
+/** Resolves all param inputs into strings */
+async function getParams(paramInputs: LaunchAnalysisInputs, dataset: Dataset): Promise<NextcladeParamsRawDir> {
+  const entries = [
+    { key: 'geneMap', input: paramInputs.geneMap, datasetFileUrl: dataset.files.genomeAnnotation },
+    { key: 'refSeq', input: paramInputs.refSeq, datasetFileUrl: dataset.files.reference },
+    { key: 'tree', input: paramInputs.tree, datasetFileUrl: dataset.files.treeJson },
+    { key: 'virusProperties', input: paramInputs.virusProperties, datasetFileUrl: dataset.files.pathogenJson },
+  ]
+
+  return Object.fromEntries(
+    await concurrent.map(async ({ key, input, datasetFileUrl }) => {
+      return [key, await resolveInput(await input, datasetFileUrl)]
+    }, entries),
+  ) as unknown as NextcladeParamsRawDir
+}
+
+async function resolveInput(input: AlgorithmInput | undefined, datasetFileUrl: string | undefined) {
+  // If data is provided explicitly, load it
+  if (input) {
+    return input.getContent()
+  }
+
+  // Otherwise fetch corresponding file from the dataset
+  if (datasetFileUrl) {
+    return axiosFetchRaw(datasetFileUrl)
+  }
+
+  return undefined
 }

--- a/packages/nextclade-web/src/io/AlgorithmInput.ts
+++ b/packages/nextclade-web/src/io/AlgorithmInput.ts
@@ -1,3 +1,6 @@
+import { isEmpty } from 'lodash'
+import { FatalError } from 'next/dist/lib/fatal-error'
+import serializeJavascript from 'serialize-javascript'
 import { uniqueId } from 'src/helpers/uniqueId'
 import { AlgorithmInput, AlgorithmInputType, Dataset } from 'src/types'
 import { axiosFetchRaw } from 'src/io/axiosFetch'
@@ -115,6 +118,10 @@ export class AlgorithmInputDefault implements AlgorithmInput {
   }
 
   public async getContent(): Promise<string> {
-    return axiosFetchRaw(this.dataset.files.examples)
+    if (isEmpty(this.dataset.files?.examples)) {
+      const url = serializeJavascript(this.dataset.files?.examples)
+      throw new FatalError(`Attempting to fetch dataset example sequences from an invalid URL: '${url}'`)
+    }
+    return axiosFetchRaw(this.dataset.files?.examples)
   }
 }

--- a/packages/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages/nextclade-web/src/io/fetchDatasets.ts
@@ -9,7 +9,7 @@ import {
   parseGithubRepoUrl,
 } from 'src/io/fetchSingleDatasetFromGithub'
 
-import { Dataset } from 'src/types'
+import { type AuspiceTree, Dataset } from 'src/types'
 import {
   fetchDatasetsIndex,
   filterDatasets,
@@ -128,7 +128,11 @@ export async function initializeDatasets(datasetServerUrl: string, urlQuery: Par
   const minimizerIndexVersion = await getCompatibleMinimizerIndexVersion(datasetServerUrl, datasetsIndexJson)
 
   // Check if URL params specify dataset params and try to find the corresponding dataset
-  const currentDataset = await getDatasetFromUrlParams(urlQuery, datasets)
+  const currentDataset:
+    | (Dataset & {
+        auspiceJson?: AuspiceTree
+      })
+    | undefined = await getDatasetFromUrlParams(urlQuery, datasets)
 
   return { datasets, currentDataset, minimizerIndexVersion }
 }

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -7,7 +7,9 @@ import { axiosFetch } from 'src/io/axiosFetch'
 export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
   const datasetJsonUrl = removeTrailingSlash(datasetJsonUrl_)
 
-  const auspiceJson = await axiosFetch<AuspiceTree>(datasetJsonUrl)
+  const auspiceJson = await axiosFetch<AuspiceTree>(datasetJsonUrl, {
+    headers: { Accept: 'application/json, text/plain, */*' },
+  })
   const pathogen = auspiceJson.meta?.extensions?.nextclade?.pathogen
 
   if (isEmpty(auspiceJson.root_sequence?.nuc)) {

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -10,7 +10,7 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
   const auspiceJson = await axiosFetch<AuspiceTree>(datasetJsonUrl)
   const pathogen = auspiceJson.meta?.extensions?.nextclade?.pathogen
 
-  if (isEmpty(auspiceJson.root_sequence.nuc)) {
+  if (isEmpty(auspiceJson.root_sequence?.nuc)) {
     throw new FatalError(`Auspice JSON does not contain required field '.root_sequence.nuc': ${datasetJsonUrl_}`)
   }
 

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -1,5 +1,3 @@
-import { isEmpty } from 'lodash'
-import { FatalError } from 'next/dist/lib/fatal-error'
 import { attrStrMaybe, AuspiceTree, Dataset } from 'src/types'
 import { removeTrailingSlash } from 'src/io/url'
 import { axiosFetch } from 'src/io/axiosFetch'
@@ -11,10 +9,6 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
     headers: { Accept: 'application/json, text/plain, */*' },
   })
   const pathogen = auspiceJson.meta?.extensions?.nextclade?.pathogen
-
-  if (isEmpty(auspiceJson.root_sequence?.nuc)) {
-    throw new FatalError(`Auspice JSON does not contain required field '.root_sequence.nuc': ${datasetJsonUrl_}`)
-  }
 
   const currentDataset: Dataset & { auspiceJson?: AuspiceTree } = {
     path: datasetJsonUrl,

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -8,7 +8,22 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
   const auspiceJson = await axiosFetch<AuspiceTree>(datasetJsonUrl, {
     headers: { Accept: 'application/json, text/plain, */*' },
   })
-  const pathogen = auspiceJson.meta?.extensions?.nextclade?.pathogen
+  const pathogen = auspiceJson.meta.extensions?.nextclade?.pathogen
+
+  const name =
+    auspiceJson.meta.title ??
+    auspiceJson.meta.description ??
+    attrStrMaybe(pathogen?.attributes, 'name') ??
+    datasetJsonUrl
+
+  let version = pathogen?.version
+  if (!version) {
+    const updatedAt = pathogen?.version?.updatedAt ?? auspiceJson.meta.updated
+    version = {
+      tag: updatedAt ?? '',
+      updatedAt,
+    }
+  }
 
   const currentDataset: Dataset & { auspiceJson?: AuspiceTree } = {
     path: datasetJsonUrl,
@@ -17,6 +32,11 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
       qc: [],
     },
     ...pathogen,
+    attributes: {
+      name,
+      ...pathogen?.attributes,
+    },
+    version,
     auspiceJson,
   }
 

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash'
 import { FatalError } from 'next/dist/lib/fatal-error'
-import { attrStrMaybe, AuspiceTree, Dataset, DatasetFiles } from 'src/types'
+import { attrStrMaybe, AuspiceTree, Dataset } from 'src/types'
 import { removeTrailingSlash } from 'src/io/url'
 import { axiosFetch } from 'src/io/axiosFetch'
 
@@ -23,10 +23,6 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
       qc: [],
     },
     ...pathogen,
-
-    // HACK: there is no files if dataset comes from Auspice JSON, neither they are needed. What to do?
-    files: {} as unknown as DatasetFiles,
-
     auspiceJson,
   }
 

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -14,7 +14,7 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
     throw new FatalError(`Auspice JSON does not contain required field '.root_sequence.nuc': ${datasetJsonUrl_}`)
   }
 
-  const currentDataset: Dataset = {
+  const currentDataset: Dataset & { auspiceJson?: AuspiceTree } = {
     path: datasetJsonUrl,
     capabilities: {
       primers: false,
@@ -24,6 +24,8 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
 
     // HACK: there is no files if dataset comes from Auspice JSON, neither they are needed. What to do?
     files: {} as unknown as DatasetFiles,
+
+    auspiceJson,
   }
 
   const datasets = [currentDataset]
@@ -32,5 +34,5 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
   const defaultDatasetName = currentDatasetName
   const defaultDatasetNameFriendly = attrStrMaybe(currentDataset.attributes, 'name') ?? currentDatasetName
 
-  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset, auspiceJson }
+  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
 }

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -1,0 +1,36 @@
+import { isEmpty } from 'lodash'
+import { FatalError } from 'next/dist/lib/fatal-error'
+import { attrStrMaybe, AuspiceTree, Dataset, DatasetFiles } from 'src/types'
+import { removeTrailingSlash } from 'src/io/url'
+import { axiosFetch } from 'src/io/axiosFetch'
+
+export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
+  const datasetJsonUrl = removeTrailingSlash(datasetJsonUrl_)
+
+  const auspiceJson = await axiosFetch<AuspiceTree>(datasetJsonUrl)
+  const pathogen = auspiceJson.meta?.extensions?.nextclade?.pathogen
+
+  if (isEmpty(auspiceJson.root_sequence.nuc)) {
+    throw new FatalError(`Auspice JSON does not contain required field '.root_sequence.nuc': ${datasetJsonUrl_}`)
+  }
+
+  const currentDataset: Dataset = {
+    path: datasetJsonUrl,
+    capabilities: {
+      primers: false,
+      qc: [],
+    },
+    ...pathogen,
+
+    // HACK: there is no files if dataset comes from Auspice JSON, neither they are needed. What to do?
+    files: {} as unknown as DatasetFiles,
+  }
+
+  const datasets = [currentDataset]
+  const defaultDataset = currentDataset
+  const currentDatasetName = currentDataset.path
+  const defaultDatasetName = currentDatasetName
+  const defaultDatasetNameFriendly = attrStrMaybe(currentDataset.attributes, 'name') ?? currentDatasetName
+
+  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset, auspiceJson }
+}

--- a/packages/nextclade-web/src/io/fetchSingleDatasetDirectory.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetDirectory.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import urljoin from 'url-join'
 import { mapValues } from 'lodash'
 import { concurrent } from 'fasy'
-import { attrStrMaybe, Dataset, DatasetFiles, VirusProperties } from 'src/types'
+import { attrStrMaybe, AuspiceTree, Dataset, DatasetFiles, VirusProperties } from 'src/types'
 import { removeTrailingSlash } from 'src/io/url'
 import { axiosFetch, axiosHead, axiosHeadOrUndefined } from 'src/io/axiosFetch'
 import { sanitizeError } from 'src/helpers/sanitizeError'
@@ -15,7 +15,7 @@ export async function fetchSingleDatasetDirectory(
 
   const pathogen = await fetchPathogenJson(datasetRootUrl)
 
-  const currentDataset: Dataset = {
+  const currentDataset: Dataset & { auspiceJson?: AuspiceTree } = {
     path: datasetRootUrl,
     capabilities: {
       primers: false,
@@ -49,14 +49,7 @@ export async function fetchSingleDatasetDirectory(
     Object.entries(currentDataset.files).filter(([filename, _]) => !['sequences.fasta'].includes(filename)),
   )
 
-  return {
-    datasets,
-    defaultDataset,
-    defaultDatasetName,
-    defaultDatasetNameFriendly,
-    currentDataset,
-    auspiceJson: undefined,
-  }
+  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
 }
 
 async function fetchPathogenJson(datasetRootUrl: string) {

--- a/packages/nextclade-web/src/io/loadInputs.ts
+++ b/packages/nextclade-web/src/io/loadInputs.ts
@@ -1,0 +1,18 @@
+import type { ParsedUrlQuery } from 'querystring'
+import type { Dataset } from 'src/types'
+import { createInputFastasFromUrlParam, createInputFromUrlParamMaybe } from 'src/io/createInputFromUrlParamMaybe'
+
+export async function loadInputs(urlQuery: ParsedUrlQuery, dataset?: Dataset) {
+  const inputFastas = await createInputFastasFromUrlParam(urlQuery, dataset)
+  const refSeq = await createInputFromUrlParamMaybe(urlQuery, 'input-ref')
+  const geneMap = await createInputFromUrlParamMaybe(urlQuery, 'input-annotation')
+  const refTree = await createInputFromUrlParamMaybe(urlQuery, 'input-tree')
+  const virusProperties = await createInputFromUrlParamMaybe(urlQuery, 'input-pathogen-json')
+  return {
+    inputFastas,
+    refSeq,
+    geneMap,
+    refTree,
+    virusProperties,
+  }
+}

--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -16,6 +16,7 @@ import { mdxComponents } from 'src/mdx-components'
 import LoadingPage from 'src/pages/loading'
 import { globalErrorAtom } from 'src/state/error.state'
 import {
+  datasetJsonAtom,
   geneMapInputAtom,
   qrySeqInputsStorageAtom,
   refSeqInputAtom,
@@ -101,8 +102,8 @@ export function RecoilStateInitializer() {
 
         const datasetInfo = await fetchSingleDataset(urlQuery)
         if (!isNil(datasetInfo)) {
-          const { datasets, currentDataset } = datasetInfo
-          return { datasets, currentDataset, minimizerIndexVersion: undefined }
+          const { datasets, currentDataset, auspiceJson } = datasetInfo
+          return { datasets, currentDataset, minimizerIndexVersion: undefined, auspiceJson }
         }
         return { datasets, currentDataset, minimizerIndexVersion }
       })
@@ -112,12 +113,13 @@ export function RecoilStateInitializer() {
         set(globalErrorAtom, sanitizeError(error))
         throw error
       })
-      .then(async ({ datasets, currentDataset, minimizerIndexVersion }) => {
+      .then(async ({ datasets, currentDataset, minimizerIndexVersion, auspiceJson }) => {
         set(datasetsAtom, { datasets })
         const previousDataset = await getPromise(datasetCurrentAtom)
         const dataset = currentDataset ?? previousDataset
         set(datasetCurrentAtom, dataset)
         set(minimizerIndexVersionAtom, minimizerIndexVersion)
+        set(datasetJsonAtom, auspiceJson)
         return dataset
       })
       .then(async (dataset) => {

--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -56,6 +56,8 @@ import {
 import { ErrorBoundary } from 'src/components/Error/ErrorBoundary'
 
 import 'src/styles/global.scss'
+import { Dataset } from '../types'
+import { AuspiceTree } from '../types'
 
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false
 
@@ -102,8 +104,8 @@ export function RecoilStateInitializer() {
 
         const datasetInfo = await fetchSingleDataset(urlQuery)
         if (!isNil(datasetInfo)) {
-          const { datasets, currentDataset, auspiceJson } = datasetInfo
-          return { datasets, currentDataset, minimizerIndexVersion: undefined, auspiceJson }
+          const { datasets, currentDataset } = datasetInfo
+          return { datasets, currentDataset, minimizerIndexVersion: undefined }
         }
         return { datasets, currentDataset, minimizerIndexVersion }
       })
@@ -113,13 +115,13 @@ export function RecoilStateInitializer() {
         set(globalErrorAtom, sanitizeError(error))
         throw error
       })
-      .then(async ({ datasets, currentDataset, minimizerIndexVersion, auspiceJson }) => {
+      .then(async ({ datasets, currentDataset, minimizerIndexVersion }) => {
         set(datasetsAtom, { datasets })
         const previousDataset = await getPromise(datasetCurrentAtom)
-        const dataset = currentDataset ?? previousDataset
+        const dataset: (Dataset & { auspiceJson?: AuspiceTree }) | undefined = currentDataset ?? previousDataset
         set(datasetCurrentAtom, dataset)
         set(minimizerIndexVersionAtom, minimizerIndexVersion)
-        set(datasetJsonAtom, auspiceJson)
+        set(datasetJsonAtom, dataset?.auspiceJson)
         return dataset
       })
       .then(async (dataset) => {

--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import dynamic from 'next/dynamic'
 import { sanitizeError } from 'src/helpers/sanitizeError'
 import { useRunAnalysis } from 'src/hooks/useRunAnalysis'
 import i18nAuspice, { changeAuspiceLocale } from 'src/i18n/i18n.auspice'
-import { createInputFastasFromUrlParam, createInputFromUrlParamMaybe } from 'src/io/createInputFromUrlParamMaybe'
+import { loadInputs } from 'src/io/loadInputs'
 import { mdxComponents } from 'src/mdx-components'
 import LoadingPage from 'src/pages/loading'
 import { globalErrorAtom } from 'src/state/error.state'
@@ -37,7 +37,6 @@ import { I18nextProvider } from 'react-i18next'
 import { MDXProvider } from '@mdx-js/react'
 import { QueryClient, QueryClientConfig, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
-
 import { DOMAIN_STRIPPED } from 'src/constants'
 import { parseUrl } from 'src/helpers/parseUrl'
 import { getDatasetServerUrl, initializeDatasets } from 'src/io/fetchDatasets'
@@ -122,19 +121,18 @@ export function RecoilStateInitializer() {
         return dataset
       })
       .then(async (dataset) => {
-        const inputFastas = await createInputFastasFromUrlParam(urlQuery, dataset)
+        const { inputFastas, refSeq, geneMap, refTree, virusProperties } = await loadInputs(urlQuery, dataset)
+
+        set(refSeqInputAtom, refSeq)
+        set(geneMapInputAtom, geneMap)
+        set(refTreeInputAtom, refTree)
+        set(virusPropertiesInputAtom, virusProperties)
 
         if (!isEmpty(inputFastas)) {
           set(qrySeqInputsStorageAtom, inputFastas)
-        }
-
-        set(refSeqInputAtom, await createInputFromUrlParamMaybe(urlQuery, 'input-ref'))
-        set(geneMapInputAtom, await createInputFromUrlParamMaybe(urlQuery, 'input-annotation'))
-        set(refTreeInputAtom, await createInputFromUrlParamMaybe(urlQuery, 'input-tree'))
-        set(virusPropertiesInputAtom, await createInputFromUrlParamMaybe(urlQuery, 'input-pathogen-json'))
-
-        if (!isEmpty(inputFastas) && !isEmpty(dataset)) {
-          run()
+          if (!isEmpty(dataset)) {
+            run()
+          }
         }
 
         return undefined

--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { RecoilEnv, RecoilRoot, useRecoilCallback, useRecoilState, useRecoilValu
 import { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
 import dynamic from 'next/dynamic'
+import type { Dataset, AuspiceTree } from 'src/types'
 import { sanitizeError } from 'src/helpers/sanitizeError'
 import { useRunAnalysis } from 'src/hooks/useRunAnalysis'
 import i18nAuspice, { changeAuspiceLocale } from 'src/i18n/i18n.auspice'
@@ -56,8 +57,6 @@ import {
 import { ErrorBoundary } from 'src/components/Error/ErrorBoundary'
 
 import 'src/styles/global.scss'
-import { Dataset } from '../types'
-import { AuspiceTree } from '../types'
 
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false
 

--- a/packages/nextclade-web/src/state/inputs.state.ts
+++ b/packages/nextclade-web/src/state/inputs.state.ts
@@ -1,11 +1,11 @@
 import { isEmpty } from 'lodash'
 import { useCallback, useEffect } from 'react'
 import { atom, selector, useRecoilState, useResetRecoilState } from 'recoil'
+import type { AlgorithmInput, AuspiceTree } from 'src/types'
 import { cdsOrderPreferenceAtom } from 'src/state/dataset.state'
 import { clearAllFiltersAtom } from 'src/state/resultFilters.state'
 import { analysisResultsAtom, analysisStatusGlobalAtom, treeAtom } from 'src/state/results.state'
 import { viewedCdsAtom } from 'src/state/seqViewSettings.state'
-import { AlgorithmInput } from 'src/types'
 import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 import { useResetSuggestions } from 'src/hooks/useResetSuggestions'
 
@@ -101,6 +101,11 @@ export const hasRequiredInputsAtom = selector({
   },
 })
 
+export const datasetJsonAtom = atom<AuspiceTree | undefined>({
+  key: 'datasetJson',
+  default: undefined,
+})
+
 /** Counts how many custom inputs are set */
 export const inputCustomizationCounterAtom = selector<number>({
   key: 'inputCustomizationCounterAtom',
@@ -130,5 +135,6 @@ export const datasetFilesResetAtom = selector<undefined>({
     reset(geneMapInputAtom)
     reset(refTreeInputAtom)
     reset(virusPropertiesInputAtom)
+    reset(datasetJsonAtom)
   },
 })

--- a/packages/nextclade/src/align/params.rs
+++ b/packages/nextclade/src/align/params.rs
@@ -1,12 +1,14 @@
+use crate::utils::any::AnyType;
 use crate::{make_error, o};
 use clap::{Parser, ValueEnum};
 use eyre::Report;
 use itertools::Itertools;
 use optfield::optfield;
+use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(ValueEnum, Copy, Clone, Debug, Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(ValueEnum, Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum GapAlignmentSide {
   Left,
@@ -25,7 +27,7 @@ impl Default for GapAlignmentSide {
 
 #[allow(clippy::struct_excessive_bools)]
 #[optfield(pub AlignPairwiseParamsOptional, attrs, doc, field_attrs, field_doc, merge_fn = pub)]
-#[derive(Parser, Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Parser, Debug, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AlignPairwiseParams {
   /// Minimum length of nucleotide sequence to consider for alignment.
@@ -116,7 +118,7 @@ pub struct AlignPairwiseParams {
   /// Fraction of the query sequence that has to be covered by extended seeds
   /// to proceed with the banded alignment.
   #[clap(long)]
-  pub min_seed_cover: f64,
+  pub min_seed_cover: OrderedFloat<f64>,
 
   /// Number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
   #[clap(long)]
@@ -125,27 +127,27 @@ pub struct AlignPairwiseParams {
   // The following args are deprecated and are kept for backwards compatibility (to emit errors if they are set)
   /// REMOVED
   #[clap(long, hide_long_help = true, hide_short_help = true)]
-  pub max_indel: Option<f64>,
+  pub max_indel: Option<AnyType>,
 
   /// REMOVED
   #[clap(long, hide_long_help = true, hide_short_help = true)]
-  pub seed_length: Option<f64>,
+  pub seed_length: Option<AnyType>,
 
   /// REMOVED
   #[clap(long, hide_long_help = true, hide_short_help = true)]
-  pub mismatches_allowed: Option<f64>,
+  pub mismatches_allowed: Option<AnyType>,
 
   /// REMOVED
   #[clap(long, hide_long_help = true, hide_short_help = true)]
-  pub min_seeds: Option<f64>,
+  pub min_seeds: Option<AnyType>,
 
   /// REMOVED
   #[clap(long, hide_long_help = true, hide_short_help = true)]
-  pub min_match_rate: Option<f64>,
+  pub min_match_rate: Option<AnyType>,
 
   /// REMOVED
   #[clap(long, hide_long_help = true, hide_short_help = true)]
-  pub seed_spacing: Option<f64>,
+  pub seed_spacing: Option<AnyType>,
 }
 
 impl Default for AlignPairwiseParams {
@@ -166,7 +168,7 @@ impl Default for AlignPairwiseParams {
       gap_alignment_side: GapAlignmentSide::default(),
       excess_bandwidth: 9,
       terminal_bandwidth: 50,
-      min_seed_cover: 0.33,
+      min_seed_cover: OrderedFloat(0.33),
       kmer_length: 10,       // Should not be much larger than 1/divergence of amino acids
       kmer_distance: 50,     // Distance between successive k-mers
       min_match_length: 40,  // Experimentally determined, to keep off-target matches reasonably low

--- a/packages/nextclade/src/align/seed_match.rs
+++ b/packages/nextclade/src/align/seed_match.rs
@@ -481,15 +481,15 @@ pub fn get_seed_matches2(
   // write_matches_to_file(&seed_matches, "chained_matches.csv");
 
   let sum_of_seed_length: usize = seed_matches.iter().map(|sm| sm.length).sum();
-  if (sum_of_seed_length as f64 / qry_seq.len() as f64) < params.min_seed_cover {
+  if (sum_of_seed_length as f64 / qry_seq.len() as f64) < *params.min_seed_cover {
     let query_knowns = qry_seq.iter().filter(|n| n.is_acgt()).count();
-    if (sum_of_seed_length as f64 / query_knowns as f64) < params.min_seed_cover {
+    if (sum_of_seed_length as f64 / query_knowns as f64) < *params.min_seed_cover {
       return make_error!(
         "Unable to align: seed alignment covers {:.2}% of the query sequence, which is less than expected {:.2}% \
         (configurable using 'min seed cover' CLI flag or dataset property). This is likely due to low quality of the \
         provided sequence, or due to using incorrect reference sequence.",
         100.0 * (sum_of_seed_length as f64) / (query_knowns as f64),
-        100.0 * params.min_seed_cover
+        100.0 * *params.min_seed_cover
       );
     }
   }

--- a/packages/nextclade/src/analyze/phenotype.rs
+++ b/packages/nextclade/src/analyze/phenotype.rs
@@ -16,7 +16,7 @@ pub fn calculate_phenotype(phenotype_data: &PhenotypeData, aa_substitutions: &[A
         .iter()
         .map(|AaSub { pos, qry_aa: qry, .. }| phenotype_data.get_coeff(*pos, *qry))
         .sum();
-      phenotype_data.weight * (-phenotype_for_antibody).exp()
+      *phenotype_data.weight * (-phenotype_for_antibody).exp()
     })
     .sum();
 

--- a/packages/nextclade/src/analyze/virus_properties.rs
+++ b/packages/nextclade/src/analyze/virus_properties.rs
@@ -39,6 +39,7 @@ pub struct VirusProperties {
   #[serde(default, skip_serializing_if = "DatasetMeta::is_default")]
   pub meta: DatasetMeta,
 
+  #[serde(default, skip_serializing_if = "DatasetFiles::is_default")]
   pub files: DatasetFiles,
 
   pub default_cds: Option<String>,

--- a/packages/nextclade/src/gene/auspice_annotations.rs
+++ b/packages/nextclade/src/gene/auspice_annotations.rs
@@ -16,7 +16,7 @@ pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> 
     index: 0,
     id: "landmark".to_owned(),
     name: "landmark".to_owned(),
-    range: NucRefGlobalRange::from_isize(anns.nuc.start, anns.nuc.end),
+    range: NucRefGlobalRange::from_isize(anns.nuc.start.saturating_sub(1), anns.nuc.end),
     strand: anns.nuc.strand,
     is_circular: true,
   };
@@ -72,8 +72,7 @@ fn convert_cds_segments(
   for (index, &StartEnd { start, end }) in ann_segments.iter().enumerate() {
     let name = format!("{cds_name}_fragment_{index}");
 
-    let start = start.saturating_sub(1);
-    let range = NucRefGlobalRange::from_isize(start, end);
+    let range = NucRefGlobalRange::from_isize(start.saturating_sub(1), end);
     let range_local = Range::from_usize(begin, begin + range.len());
     let phase = Phase::from_begin(range_local.begin)?;
     let frame = Frame::from_begin(range.begin)?;

--- a/packages/nextclade/src/gene/auspice_annotations.rs
+++ b/packages/nextclade/src/gene/auspice_annotations.rs
@@ -1,0 +1,84 @@
+use crate::coord::range::{NucRefGlobalRange, NucRefLocalRange};
+use crate::gene::cds::Cds;
+use crate::gene::cds_segment::{CdsSegment, WrappingPart};
+use crate::gene::frame::Frame;
+use crate::gene::gene::Gene;
+use crate::gene::phase::Phase;
+use crate::tree::tree::{AuspiceGenomeAnnotations, Segments, StartEnd};
+use eyre::Report;
+use std::collections::HashMap;
+
+pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> Result<Vec<Gene>, Report> {
+  anns
+    .cdses
+    .iter()
+    .enumerate()
+    .map(|(index, (cds_name, ann))| {
+      let gene_name = ann.gene.as_ref().cloned().unwrap_or_else(|| format!("gene_{index}"));
+
+      let segments = match &ann.segments {
+        Segments::OneSegment(StartEnd { start, end }) => vec![CdsSegment {
+          index,
+          id: cds_name.to_owned(),
+          name: cds_name.to_owned(),
+          range: NucRefGlobalRange::from_isize(*start, *end),
+          range_local: NucRefLocalRange::from_isize(0, *end - *start),
+          landmark: None,
+          wrapping_part: WrappingPart::NonWrapping,
+          strand: ann.strand,
+          frame: Frame::_0,
+          phase: Phase::_0,
+          exceptions: vec![],
+          attributes: HashMap::default(),
+          source_record: None,
+          compat_is_gene: false,
+          color: None,
+        }],
+        Segments::MultipleSegments { segments } => segments
+          .iter()
+          .map(|StartEnd { start, end }| CdsSegment {
+            index,
+            id: cds_name.to_owned(),
+            name: cds_name.to_owned(),
+            range: NucRefGlobalRange::from_isize(*start, *end),
+            range_local: NucRefLocalRange::from_isize(0, *end - *start),
+            landmark: None,
+            wrapping_part: WrappingPart::NonWrapping,
+            strand: ann.strand,
+            frame: Frame::_0,
+            phase: Phase::_0,
+            exceptions: vec![],
+            attributes: HashMap::default(),
+            source_record: None,
+            compat_is_gene: false,
+            color: None,
+          })
+          .collect(),
+      };
+
+      let cds = Cds {
+        id: cds_name.to_owned(),
+        name: cds_name.to_owned(),
+        product: cds_name.to_owned(),
+        segments,
+        proteins: vec![],
+        exceptions: vec![],
+        attributes: HashMap::default(),
+        compat_is_gene: true,
+        color: ann.color.clone(),
+      };
+
+      Ok(Gene {
+        index,
+        id: gene_name.clone(),
+        name: gene_name,
+        cdses: vec![cds],
+        exceptions: vec![],
+        attributes: HashMap::default(),
+        source_record: None,
+        compat_is_cds: true,
+        color: ann.color.clone(),
+      })
+    })
+    .collect()
+}

--- a/packages/nextclade/src/gene/auspice_annotations.rs
+++ b/packages/nextclade/src/gene/auspice_annotations.rs
@@ -1,60 +1,37 @@
-use crate::coord::range::{NucRefGlobalRange, NucRefLocalRange};
-use crate::gene::cds::Cds;
+use crate::coord::range::{NucRefGlobalRange, Range};
+use crate::features::feature::Landmark;
+use crate::gene::cds::{split_circular_cds_segments, Cds};
 use crate::gene::cds_segment::{CdsSegment, WrappingPart};
 use crate::gene::frame::Frame;
 use crate::gene::gene::Gene;
 use crate::gene::phase::Phase;
-use crate::tree::tree::{AuspiceGenomeAnnotations, Segments, StartEnd};
+use crate::io::json::{json_stringify, JsonPretty};
+use crate::tree::tree::{AuspiceGenomeAnnotationCds, AuspiceGenomeAnnotations, Segments, StartEnd};
 use eyre::Report;
+use maplit::hashmap;
 use std::collections::HashMap;
 
 pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> Result<Vec<Gene>, Report> {
+  let landmark = Landmark {
+    index: 0,
+    id: "landmark".to_owned(),
+    name: "landmark".to_owned(),
+    range: NucRefGlobalRange::from_isize(anns.nuc.start, anns.nuc.end),
+    strand: anns.nuc.strand,
+    is_circular: true,
+  };
+
   anns
     .cdses
     .iter()
     .enumerate()
     .map(|(index, (cds_name, ann))| {
-      let gene_name = ann.gene.as_ref().cloned().unwrap_or_else(|| format!("gene_{index}"));
+      let gene_name = ann.gene.as_ref().unwrap_or(cds_name);
 
       let segments = match &ann.segments {
-        Segments::OneSegment(StartEnd { start, end }) => vec![CdsSegment {
-          index,
-          id: cds_name.to_owned(),
-          name: cds_name.to_owned(),
-          range: NucRefGlobalRange::from_isize(*start, *end),
-          range_local: NucRefLocalRange::from_isize(0, *end - *start),
-          landmark: None,
-          wrapping_part: WrappingPart::NonWrapping,
-          strand: ann.strand,
-          frame: Frame::_0,
-          phase: Phase::_0,
-          exceptions: vec![],
-          attributes: HashMap::default(),
-          source_record: None,
-          compat_is_gene: false,
-          color: None,
-        }],
-        Segments::MultipleSegments { segments } => segments
-          .iter()
-          .map(|StartEnd { start, end }| CdsSegment {
-            index,
-            id: cds_name.to_owned(),
-            name: cds_name.to_owned(),
-            range: NucRefGlobalRange::from_isize(*start, *end),
-            range_local: NucRefLocalRange::from_isize(0, *end - *start),
-            landmark: None,
-            wrapping_part: WrappingPart::NonWrapping,
-            strand: ann.strand,
-            frame: Frame::_0,
-            phase: Phase::_0,
-            exceptions: vec![],
-            attributes: HashMap::default(),
-            source_record: None,
-            compat_is_gene: false,
-            color: None,
-          })
-          .collect(),
-      };
+        Segments::OneSegment(segment) => convert_cds_segments(ann, &landmark, cds_name, &[segment.to_owned()]),
+        Segments::MultipleSegments { segments } => convert_cds_segments(ann, &landmark, cds_name, segments),
+      }?;
 
       let cds = Cds {
         id: cds_name.to_owned(),
@@ -70,8 +47,8 @@ pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> 
 
       Ok(Gene {
         index,
-        id: gene_name.clone(),
-        name: gene_name,
+        id: gene_name.to_owned(),
+        name: gene_name.to_owned(),
         cdses: vec![cds],
         exceptions: vec![],
         attributes: HashMap::default(),
@@ -81,4 +58,48 @@ pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> 
       })
     })
     .collect()
+}
+
+fn convert_cds_segments(
+  ann: &AuspiceGenomeAnnotationCds,
+  landmark: &Landmark,
+  cds_name: &str,
+  ann_segments: &[StartEnd],
+) -> Result<Vec<CdsSegment>, Report> {
+  let mut begin = 0;
+  let mut segments = vec![];
+
+  for (index, &StartEnd { start, end }) in ann_segments.iter().enumerate() {
+    let name = format!("{cds_name}_fragment_{index}");
+
+    let start = start.saturating_sub(1);
+    let range = NucRefGlobalRange::from_isize(start, end);
+    let range_local = Range::from_usize(begin, begin + range.len());
+    let phase = Phase::from_begin(range_local.begin)?;
+    let frame = Frame::from_begin(range.begin)?;
+
+    segments.push(CdsSegment {
+      index,
+      id: name.clone(),
+      name,
+      range: range.clone(),
+      range_local,
+      landmark: Some(landmark.to_owned()),
+      wrapping_part: WrappingPart::NonWrapping,
+      strand: ann.strand,
+      frame,
+      phase,
+      exceptions: vec![],
+      attributes: hashmap! {},
+      source_record: Some(json_stringify(ann, JsonPretty(true))?),
+      compat_is_gene: false,
+      color: ann.color.clone(),
+    });
+
+    begin += range.len();
+  }
+
+  let segments = split_circular_cds_segments(&segments)?;
+
+  Ok(segments)
 }

--- a/packages/nextclade/src/gene/auspice_annotations.rs
+++ b/packages/nextclade/src/gene/auspice_annotations.rs
@@ -30,7 +30,7 @@ pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> 
 
       let segments = match &ann.segments {
         Segments::OneSegment(segment) => convert_cds_segments(ann, &landmark, cds_name, &[segment.to_owned()]),
-        Segments::MultipleSegments { segments } => convert_cds_segments(ann, &landmark, cds_name, segments),
+        Segments::MultipleSegments { segments, .. } => convert_cds_segments(ann, &landmark, cds_name, segments),
       }?;
 
       let cds = Cds {
@@ -69,7 +69,7 @@ fn convert_cds_segments(
   let mut begin = 0;
   let mut segments = vec![];
 
-  for (index, &StartEnd { start, end }) in ann_segments.iter().enumerate() {
+  for (index, &StartEnd { start, end, .. }) in ann_segments.iter().enumerate() {
     let name = format!("{cds_name}_fragment_{index}");
 
     let range = NucRefGlobalRange::from_isize(start.saturating_sub(1), end);

--- a/packages/nextclade/src/gene/cds.rs
+++ b/packages/nextclade/src/gene/cds.rs
@@ -14,7 +14,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Cds {
@@ -199,7 +198,7 @@ impl Cds {
 ///   - the part from segment start to landmark end, before the wrap around
 ///   - (optionally) the middle parts spanning the entire sequence
 ///   - the last part from landmark start to segment end
-fn split_circular_cds_segments(segments: &[CdsSegment]) -> Result<Vec<CdsSegment>, Report> {
+pub fn split_circular_cds_segments(segments: &[CdsSegment]) -> Result<Vec<CdsSegment>, Report> {
   let mut linear_segments = vec![];
   for segment in segments {
     if let Some(landmark) = &segment.landmark {

--- a/packages/nextclade/src/gene/gene_map.rs
+++ b/packages/nextclade/src/gene/gene_map.rs
@@ -1,11 +1,13 @@
 use crate::features::feature_group::FeatureGroup;
 use crate::features::feature_tree::FeatureTree;
 use crate::features::sequence_region::SequenceRegion;
+use crate::gene::auspice_annotations::convert_auspice_annotations_to_genes;
 use crate::gene::cds::Cds;
 use crate::gene::cds_segment::CdsSegment;
 use crate::gene::gene::{find_cdses, Gene};
 use crate::io::file::open_file_or_stdin;
 use crate::io::yaml::yaml_parse;
+use crate::tree::tree::AuspiceGenomeAnnotations;
 use crate::utils::collections::take_exactly_one;
 use crate::utils::error::report_to_string;
 use crate::{make_error, make_internal_report};
@@ -15,7 +17,6 @@ use log::warn;
 use num::Integer;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
 use std::path::Path;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
@@ -35,6 +36,11 @@ impl GeneMap {
 
   pub fn from_feature_tree(feature_tree: &FeatureTree) -> Result<Self, Report> {
     convert_feature_tree_to_gene_map(feature_tree)
+  }
+
+  pub fn from_auspice_annotations(anns: &AuspiceGenomeAnnotations) -> Result<Self, Report> {
+    let genes = convert_auspice_annotations_to_genes(anns)?;
+    Ok(GeneMap::from_genes(genes))
   }
 
   pub fn from_path<P: AsRef<Path>>(filename: P) -> Result<Self, Report> {

--- a/packages/nextclade/src/gene/mod.rs
+++ b/packages/nextclade/src/gene/mod.rs
@@ -1,3 +1,4 @@
+pub mod auspice_annotations;
 pub mod cds;
 pub mod cds_segment;
 pub mod frame;

--- a/packages/nextclade/src/graph/graph.rs
+++ b/packages/nextclade/src/graph/graph.rs
@@ -13,6 +13,7 @@ use num_traits::Float;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use maplit::btreemap;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[allow(clippy::partial_pub_fields)]
@@ -556,6 +557,7 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
     version: graph.data.auspice_tree_version.clone(),
     meta: graph.data.meta.clone(),
     tree,
+    root_sequence: btreemap! {},
     other: graph.data.other.clone(),
   })
 }

--- a/packages/nextclade/src/graph/graph.rs
+++ b/packages/nextclade/src/graph/graph.rs
@@ -13,7 +13,6 @@ use num_traits::Float;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use maplit::btreemap;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[allow(clippy::partial_pub_fields)]
@@ -557,7 +556,7 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
     version: graph.data.auspice_tree_version.clone(),
     meta: graph.data.meta.clone(),
     tree,
-    root_sequence: btreemap! {},
+    root_sequence: None,
     other: graph.data.other.clone(),
   })
 }

--- a/packages/nextclade/src/io/dataset.rs
+++ b/packages/nextclade/src/io/dataset.rs
@@ -328,7 +328,7 @@ impl DatasetMeta {
   }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatasetFiles {
   pub reference: String,

--- a/packages/nextclade/src/io/dataset.rs
+++ b/packages/nextclade/src/io/dataset.rs
@@ -66,6 +66,7 @@ pub struct Dataset {
   #[serde(default, skip_serializing_if = "DatasetMeta::is_default")]
   pub meta: DatasetMeta,
 
+  #[serde(default, skip_serializing_if = "DatasetFiles::is_default")]
   pub files: DatasetFiles,
 
   #[serde(default, skip_serializing_if = "DatasetCapabilities::is_default")]
@@ -331,9 +332,11 @@ impl DatasetMeta {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatasetFiles {
-  pub reference: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub reference: Option<String>,
 
-  pub pathogen_json: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub pathogen_json: Option<String>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub genome_annotation: Option<String>,
@@ -355,6 +358,13 @@ pub struct DatasetFiles {
 
   #[serde(flatten)]
   pub other: serde_json::Value,
+}
+
+impl DatasetFiles {
+  #[inline]
+  pub fn is_default(&self) -> bool {
+    self == &Self::default()
+  }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/packages/nextclade/src/qc/qc_config.rs
+++ b/packages/nextclade/src/qc/qc_config.rs
@@ -2,21 +2,22 @@ use crate::coord::range::AaRefRange;
 use crate::io::fs::read_file_to_string;
 use crate::io::json::json_parse;
 use eyre::{Report, WrapErr};
+use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::str::FromStr;
 use validator::Validate;
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcRulesConfigMissingData {
   pub enabled: bool,
-  pub missing_data_threshold: f64,
-  pub score_bias: f64,
+  pub missing_data_threshold: OrderedFloat<f64>,
+  pub score_bias: OrderedFloat<f64>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcRulesConfigMixedSites {
@@ -24,49 +25,49 @@ pub struct QcRulesConfigMixedSites {
   pub mixed_sites_threshold: usize,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcRulesConfigPrivateMutations {
   pub enabled: bool,
 
   #[serde(default = "one")]
-  pub weight_reversion_substitutions: f64,
+  pub weight_reversion_substitutions: OrderedFloat<f64>,
 
   #[serde(default = "one")]
-  pub weight_reversion_deletions: f64,
+  pub weight_reversion_deletions: OrderedFloat<f64>,
 
   #[serde(default = "one")]
-  pub weight_labeled_substitutions: f64,
+  pub weight_labeled_substitutions: OrderedFloat<f64>,
 
   #[serde(default = "one")]
-  pub weight_labeled_deletions: f64,
+  pub weight_labeled_deletions: OrderedFloat<f64>,
 
   #[serde(default = "one")]
-  pub weight_unlabeled_substitutions: f64,
+  pub weight_unlabeled_substitutions: OrderedFloat<f64>,
 
   #[serde(default = "one")]
-  pub weight_unlabeled_deletions: f64,
+  pub weight_unlabeled_deletions: OrderedFloat<f64>,
 
-  pub typical: f64,
-  pub cutoff: f64,
+  pub typical: OrderedFloat<f64>,
+  pub cutoff: OrderedFloat<f64>,
 }
 
-const fn one() -> f64 {
-  1.0
+const fn one() -> OrderedFloat<f64> {
+  OrderedFloat(1.0)
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcRulesConfigSnpClusters {
   pub enabled: bool,
   pub window_size: usize,
   pub cluster_cut_off: usize,
-  pub score_weight: f64,
+  pub score_weight: OrderedFloat<f64>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct FrameShiftLocation {
@@ -74,14 +75,14 @@ pub struct FrameShiftLocation {
   pub codon_range: AaRefRange,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcRulesConfigFrameShifts {
   pub enabled: bool,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub ignored_frame_shifts: Vec<FrameShiftLocation>,
-  pub score_weight: f64,
+  pub score_weight: OrderedFloat<f64>,
 }
 
 impl Default for QcRulesConfigFrameShifts {
@@ -89,7 +90,7 @@ impl Default for QcRulesConfigFrameShifts {
     Self {
       enabled: false,
       ignored_frame_shifts: vec![],
-      score_weight: 75.0,
+      score_weight: OrderedFloat(75.0),
     }
   }
 }
@@ -101,14 +102,14 @@ pub struct StopCodonLocation {
   pub codon: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcRulesConfigStopCodons {
   pub enabled: bool,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub ignored_stop_codons: Vec<StopCodonLocation>,
-  pub score_weight: f64,
+  pub score_weight: OrderedFloat<f64>,
 }
 
 impl Default for QcRulesConfigStopCodons {
@@ -116,12 +117,12 @@ impl Default for QcRulesConfigStopCodons {
     Self {
       enabled: false,
       ignored_stop_codons: vec![],
-      score_weight: 75.0,
+      score_weight: OrderedFloat(75.0),
     }
   }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, schemars::JsonSchema, Validate)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct QcConfig {

--- a/packages/nextclade/src/qc/qc_rule_frame_shifts.rs
+++ b/packages/nextclade/src/qc/qc_rule_frame_shifts.rs
@@ -45,7 +45,7 @@ pub fn rule_frame_shifts(
   let total_frame_shifts = frame_shifts.len();
   let total_frame_shifts_ignored = frame_shifts_ignored.len();
 
-  let score = total_frame_shifts as f64 * config.score_weight;
+  let score = total_frame_shifts as f64 * *config.score_weight;
   let status = QcStatus::from_score(score);
 
   Some(QcResultFrameShifts {

--- a/packages/nextclade/src/qc/qc_rule_missing_data.rs
+++ b/packages/nextclade/src/qc/qc_rule_missing_data.rs
@@ -24,7 +24,7 @@ pub fn rule_missing_data(total_missing: usize, config: &QcRulesConfigMissingData
   }
 
   let score = clamp_min(
-    ((total_missing as f64 - config.score_bias) * 100.0) / config.missing_data_threshold,
+    ((total_missing as f64 - *config.score_bias) * 100.0) / *config.missing_data_threshold,
     0.0,
   );
   let status = QcStatus::from_score(score);
@@ -33,6 +33,6 @@ pub fn rule_missing_data(total_missing: usize, config: &QcRulesConfigMissingData
     score,
     status,
     total_missing,
-    missing_data_threshold: config.missing_data_threshold + config.score_bias,
+    missing_data_threshold: *config.missing_data_threshold + *config.score_bias,
   })
 }

--- a/packages/nextclade/src/qc/qc_rule_private_mutations.rs
+++ b/packages/nextclade/src/qc/qc_rule_private_mutations.rs
@@ -46,13 +46,13 @@ pub fn rule_private_mutations(
   let total_deletion_ranges = deletion_ranges.len();
 
   let weighted_total = 0.0
-    + config.weight_reversion_substitutions * num_reversion_substitutions as f64
-    + config.weight_labeled_substitutions * num_labeled_substitutions as f64
-    + config.weight_unlabeled_substitutions * num_unlabeled_substitutions as f64
+    + *config.weight_reversion_substitutions * num_reversion_substitutions as f64
+    + *config.weight_labeled_substitutions * num_labeled_substitutions as f64
+    + *config.weight_unlabeled_substitutions * num_unlabeled_substitutions as f64
     + total_deletion_ranges as f64;
 
   // the score hits 100 if the excess mutations equals the cutoff value
-  let score = (clamp_min(weighted_total - config.typical, 0.0) * 100.0) / config.cutoff;
+  let score = (clamp_min(weighted_total - *config.typical, 0.0) * 100.0) / *config.cutoff;
   let status = QcStatus::from_score(score);
 
   Some(QcResultPrivateMutations {
@@ -63,8 +63,8 @@ pub fn rule_private_mutations(
     num_unlabeled_substitutions,
     total_deletion_ranges,
     weighted_total,
-    excess: weighted_total - config.typical,
-    cutoff: config.cutoff,
+    excess: weighted_total - *config.typical,
+    cutoff: *config.cutoff,
   })
 }
 

--- a/packages/nextclade/src/qc/qc_rule_snp_clusters.rs
+++ b/packages/nextclade/src/qc/qc_rule_snp_clusters.rs
@@ -52,7 +52,7 @@ pub fn rule_snp_clusters(
   let clustered_snps = process_snp_clusters(snp_clusters);
   let total_snps = clustered_snps.iter().map(|cluster| cluster.number_of_snps).sum();
 
-  let score = clamp_min(total_clusters as f64 * config.score_weight, 0.0);
+  let score = clamp_min(total_clusters as f64 * *config.score_weight, 0.0);
   let status = QcStatus::from_score(score);
 
   Some(QcResultSnpClusters {

--- a/packages/nextclade/src/qc/qc_rule_stop_codons.rs
+++ b/packages/nextclade/src/qc/qc_rule_stop_codons.rs
@@ -50,7 +50,7 @@ pub fn rule_stop_codons(translation: &Translation, config: &QcRulesConfigStopCod
   let total_stop_codons = stop_codons.len();
   let total_stop_codons_ignored = stop_codons_ignored.len();
 
-  let score = total_stop_codons as f64 * config.score_weight;
+  let score = total_stop_codons as f64 * *config.score_weight;
   let status = QcStatus::from_score(score);
 
   Some(QcResultStopCodons {

--- a/packages/nextclade/src/run/nextclade_wasm.rs
+++ b/packages/nextclade/src/run/nextclade_wasm.rs
@@ -59,7 +59,7 @@ impl NextcladeParams {
         .wrap_err("When reading Auspice JSON v2 `.meta.extensions.nextclade.pathogen.attributes[\"reference name\"]`")?
         .to_owned();
 
-      let ref_seq = auspice_json.root_sequence.get("nuc")
+      let ref_seq = auspice_json.root_sequence.as_ref().and_then(|root_sequence| root_sequence.get("nuc"))
       .ok_or_else(|| eyre!("Auspice JSON v2 is used as input dataset, but does not contain required reference sequence field (.root_sequence.nuc)"))?.to_owned();
 
       FastaRecord {

--- a/packages/nextclade/src/run/nextclade_wasm.rs
+++ b/packages/nextclade/src/run/nextclade_wasm.rs
@@ -7,7 +7,7 @@ use crate::analyze::find_aa_motifs_changes::AaMotifsMap;
 use crate::analyze::pcr_primers::PcrPrimer;
 use crate::analyze::phenotype::get_phenotype_attr_descs;
 use crate::analyze::virus_properties::{AaMotifsDesc, PhenotypeAttrDesc, VirusProperties};
-use crate::gene::gene_map::GeneMap;
+use crate::gene::gene_map::{filter_gene_map, GeneMap};
 use crate::graph::graph::{convert_auspice_tree_to_graph, convert_graph_to_auspice_tree};
 use crate::io::fasta::{read_one_fasta_str, FastaRecord};
 use crate::io::nextclade_csv::CsvColumnConfig;
@@ -21,14 +21,16 @@ use crate::tree::tree_builder::graph_attach_new_nodes_in_place;
 use crate::tree::tree_preprocess::graph_preprocess_in_place;
 use crate::types::outputs::NextcladeOutputs;
 use crate::utils::any::AnyType;
-use crate::utils::option::OptionMapRefFallible;
+use crate::utils::option::{find_some, OptionMapRefFallible};
 use eyre::{eyre, Report, WrapErr};
 use itertools::Itertools;
+use optfield::optfield;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[optfield(pub NextcladeParamsOptional, attrs, doc, field_attrs, field_doc, merge_fn = pub)]
 #[serde(rename_all = "camelCase")]
 pub struct NextcladeParams {
   #[schemars(with = "String")]
@@ -39,46 +41,68 @@ pub struct NextcladeParams {
 }
 
 impl NextcladeParams {
-  pub fn from_auspice(auspice_json: &AuspiceTree) -> Result<Self, Report> {
-    let virus_properties = auspice_json
-      .meta
-      .extensions
-      .nextclade
-      .pathogen
-      .as_ref()
-      .cloned()
-      .unwrap_or_default();
+  pub fn from_auspice(
+    auspice_json: &AuspiceTree,
+    overrides: &NextcladeParamsOptional,
+    cdses: &Option<Vec<String>>,
+  ) -> Result<Self, Report> {
+    let virus_properties = find_some(&[
+      &overrides.virus_properties,
+      &auspice_json.meta.extensions.nextclade.pathogen,
+    ])
+    .cloned()
+    .unwrap_or_default();
 
     let ref_record = {
-      let ref_name = virus_properties
-        .attributes
-        .get("reference name")
-        .cloned()
-        .unwrap_or_else(|| AnyType::String("reference".to_owned()))
-        .as_str()
-        .wrap_err("When reading Auspice JSON v2 `.meta.extensions.nextclade.pathogen.attributes[\"reference name\"]`")?
-        .to_owned();
+      match &overrides.ref_record {
+        Some(ref_record) => ref_record.clone(),
+        None => {
+          let ref_name = virus_properties
+            .attributes
+            .get("reference name")
+            .cloned()
+            .unwrap_or_else(|| AnyType::String("reference".to_owned()))
+            .as_str()
+            .wrap_err(
+              "When reading Auspice JSON v2 `.meta.extensions.nextclade.pathogen.attributes[\"reference name\"]`",
+            )?
+            .to_owned();
 
-      let ref_seq = auspice_json.root_sequence.as_ref().and_then(|root_sequence| root_sequence.get("nuc"))
-      .ok_or_else(|| eyre!("Auspice JSON v2 is used as input dataset, but does not contain required reference sequence field (.root_sequence.nuc)"))?.to_owned();
+          let ref_seq = auspice_json.root_sequence.as_ref().and_then(|root_sequence| root_sequence.get("nuc"))
+          .ok_or_else(|| eyre!("Auspice JSON v2 is used as input dataset, but does not contain required reference sequence field (.root_sequence.nuc)"))?.to_owned();
 
-      FastaRecord {
-        index: 0,
-        seq_name: ref_name,
-        seq: ref_seq,
+          FastaRecord {
+            index: 0,
+            seq_name: ref_name,
+            seq: ref_seq,
+          }
+        }
       }
     };
 
-    let gene_map = auspice_json
-      .meta
-      .genome_annotations
-      .map_ref_fallible(GeneMap::from_auspice_annotations)?
-      .unwrap_or_default();
+    let gene_map = {
+      match &overrides.gene_map {
+        Some(gene_map) => gene_map.clone(),
+        None => auspice_json
+          .meta
+          .genome_annotations
+          .map_ref_fallible(GeneMap::from_auspice_annotations)?
+          .map(|gene_map| filter_gene_map(gene_map, cdses))
+          .unwrap_or_default(),
+      }
+    };
+
+    let tree = {
+      match &overrides.tree {
+        Some(tree) => Some(tree.to_owned()),
+        None => Some(auspice_json.to_owned()),
+      }
+    };
 
     Ok(Self {
       ref_record,
       gene_map,
-      tree: Some(auspice_json.to_owned()),
+      tree,
       virus_properties,
     })
   }
@@ -86,8 +110,38 @@ impl NextcladeParams {
   pub fn from_raw(raw: NextcladeParamsRaw) -> Result<Self, Report> {
     match raw {
       NextcladeParamsRaw::Auspice(raw) => {
-        let auspice_json = AuspiceTree::from_str(raw.tree)?;
-        Self::from_auspice(&auspice_json)
+        let auspice_json = AuspiceTree::from_str(raw.auspice_json)?;
+
+        let overrides = {
+          let virus_properties = raw
+            .virus_properties
+            .map_ref_fallible(VirusProperties::from_str)
+            .wrap_err("When parsing pathogen JSON")?;
+
+          let ref_record = raw
+            .ref_seq
+            .map_ref_fallible(read_one_fasta_str)
+            .wrap_err("When parsing reference sequence")?;
+
+          let tree = raw
+            .tree
+            .map_ref_fallible(AuspiceTree::from_str)
+            .wrap_err("When parsing reference tree Auspice JSON v2")?;
+
+          let gene_map = raw
+            .gene_map
+            .map_ref_fallible(GeneMap::from_str)
+            .wrap_err("When parsing genome annotation")?;
+
+          NextcladeParamsOptional {
+            ref_record,
+            gene_map,
+            tree,
+            virus_properties,
+          }
+        };
+
+        Self::from_auspice(&auspice_json, &overrides, &None)
       }
       NextcladeParamsRaw::Dir(raw) => {
         let virus_properties =
@@ -120,7 +174,11 @@ impl NextcladeParams {
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NextcladeParamsRawAuspice {
-  pub tree: String,
+  pub auspice_json: String,
+  pub ref_seq: Option<String>,
+  pub gene_map: Option<String>,
+  pub tree: Option<String>,
+  pub virus_properties: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]

--- a/packages/nextclade/src/run/nextclade_wasm.rs
+++ b/packages/nextclade/src/run/nextclade_wasm.rs
@@ -69,7 +69,7 @@ impl NextcladeParams {
             .to_owned();
 
           let ref_seq = auspice_json.root_sequence.as_ref().and_then(|root_sequence| root_sequence.get("nuc"))
-          .ok_or_else(|| eyre!("Auspice JSON v2 is used as input dataset, but does not contain required reference sequence field (.root_sequence.nuc)"))?.to_owned();
+          .ok_or_else(|| eyre!("Auspice JSON v2 is used as input dataset, but does not contain required reference sequence field (.root_sequence.nuc) and a reference sequence is not provided any other way."))?.to_owned();
 
           FastaRecord {
             index: 0,

--- a/packages/nextclade/src/run/params_general.rs
+++ b/packages/nextclade/src/run/params_general.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[allow(clippy::struct_excessive_bools)]
 #[optfield(pub NextcladeGeneralParamsOptional, attrs, doc, field_attrs, field_doc, merge_fn = pub)]
-#[derive(Parser, Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Parser, Debug, Clone, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NextcladeGeneralParams {
   /// Whether to include aligned reference nucleotide sequence into output nucleotide sequence FASTA file and reference peptides into output peptide FASTA files.

--- a/packages/nextclade/src/tree/params.rs
+++ b/packages/nextclade/src/tree/params.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use optfield::optfield;
+use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 // NOTE: The `optfield` attribute creates a struct that have the same fields, but which are wrapped into `Option`,
@@ -7,7 +8,7 @@ use serde::{Deserialize, Serialize};
 // into self (mutably).
 #[allow(clippy::struct_excessive_bools)]
 #[optfield(pub TreeBuilderParamsOptional, attrs, doc, field_attrs, field_doc, merge_fn = pub)]
-#[derive(Parser, Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Parser, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeBuilderParams {
   /// Disable greedy tree builder algorithm
@@ -16,7 +17,7 @@ pub struct TreeBuilderParams {
   pub without_greedy_tree_builder: bool,
 
   #[clap(long)]
-  pub masked_muts_weight: f64,
+  pub masked_muts_weight: OrderedFloat<f64>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -24,7 +25,7 @@ impl Default for TreeBuilderParams {
   fn default() -> Self {
     Self {
       without_greedy_tree_builder: false,
-      masked_muts_weight: 0.05,
+      masked_muts_weight: OrderedFloat(0.05),
     }
   }
 }

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -11,7 +11,7 @@ use crate::graph::node::{GraphNode, Node};
 use crate::graph::traits::{HasDivergence, HasName};
 use crate::io::fs::read_file_to_string;
 use crate::io::json::json_parse;
-use eyre::{Report, WrapErr};
+use eyre::{eyre, Report, WrapErr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -466,6 +466,17 @@ pub struct AuspiceGenomeAnnotations {
 
   #[serde(flatten)]
   pub other: serde_json::Value,
+}
+
+impl AuspiceGenomeAnnotations {
+  pub fn from_tree_json_str(content: impl AsRef<str>) -> Result<Self, Report> {
+    let content = content.as_ref();
+    let tree = AuspiceTree::from_str(content)?;
+    tree
+      .meta
+      .genome_annotations
+      .ok_or_else(|| eyre!("Auspice JSON does not contain `.genome_annotations` field, but required"))
+  }
 }
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -564,8 +564,8 @@ pub struct AuspiceTree {
 
   pub tree: AuspiceTreeNode,
 
-  #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-  pub root_sequence: BTreeMap<String, String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub root_sequence: Option<BTreeMap<String, String>>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -486,6 +486,15 @@ impl AuspiceGenomeAnnotations {
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
 pub struct AuspiceTreeMeta {
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub title: Option<String>,
+
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub description: Option<String>,
+
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub updated: Option<String>,
+
   #[serde(skip_serializing_if = "Option::is_none")]
   pub genome_annotations: Option<AuspiceGenomeAnnotations>,
 

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -404,8 +404,8 @@ pub struct AuspiceGenomeAnnotationNuc {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct StartEnd {
-  pub start: usize,
-  pub end: usize,
+  pub start: isize,
+  pub end: isize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -1,6 +1,7 @@
 use crate::alphabet::aa::Aa;
 use crate::alphabet::nuc::Nuc;
 use crate::analyze::find_private_nuc_mutations::BranchMutations;
+use crate::analyze::virus_properties::VirusProperties;
 use crate::coord::position::{AaRefPosition, NucRefGlobalPosition};
 use crate::coord::range::NucRefGlobalRange;
 use crate::gene::gene::GeneStrand;
@@ -321,13 +322,16 @@ pub struct CladeNodeAttrKeyDesc {
   pub other: serde_json::Value,
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, Eq, PartialEq, schemars::JsonSchema, Validate, Debug)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
 pub struct AuspiceMetaExtensionsNextclade {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub clade_node_attrs: Vec<CladeNodeAttrKeyDesc>,
 
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub placement_mask_ranges: Vec<NucRefGlobalRange>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub pathogen: Option<VirusProperties>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -416,13 +416,21 @@ pub struct AuspiceGenomeAnnotationNuc {
 pub struct StartEnd {
   pub start: isize,
   pub end: isize,
+
+  #[serde(flatten)]
+  pub other: serde_json::Value,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum Segments {
   OneSegment(StartEnd),
-  MultipleSegments { segments: Vec<StartEnd> },
+  MultipleSegments {
+    segments: Vec<StartEnd>,
+
+    #[serde(flatten)]
+    other: serde_json::Value,
+  },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -447,9 +455,6 @@ pub struct AuspiceGenomeAnnotationCds {
 
   #[serde(flatten)]
   pub segments: Segments,
-
-  #[serde(flatten)]
-  pub other: serde_json::Value,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -398,6 +398,16 @@ impl AuspiceDisplayDefaults {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuspiceGenomeAnnotationNuc {
+  pub start: isize,
+
+  pub end: isize,
+
+  #[serde(default)]
+  pub strand: GeneStrand,
+
+  #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+  pub r#type: Option<String>,
+
   #[serde(flatten)]
   pub other: serde_json::Value,
 }

--- a/packages/nextclade/src/utils/option.rs
+++ b/packages/nextclade/src/utils/option.rs
@@ -59,3 +59,8 @@ impl<'o, T: 'o> OptionMapMutFallible<'o, T> for Option<T> {
     (*self).as_mut().map(f).transpose()
   }
 }
+
+/// Find first Some in a list of Options
+pub fn find_some<'a, T>(options: &'a [&'a Option<T>]) -> Option<&'a T> {
+  options.iter().find_map(|&x| x.as_ref())
+}


### PR DESCRIPTION
Slack threads:
 - https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1715225548823919
 - https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1716475486151749

This allows to use Auspice JSON v2 as input dataset. In this case we attempt to read not only tree, but also ref sequence, genome annotation and pathogen properties from that file, rather than from a conventional dataset.

### Work items

 - [x] parse genome annotation, reference and pathogen info from Auspice JSON in CLI, when passing Auspice JSON filepath to `--input-dataset`
 - [x] parse genome annotation, reference and pathogen info from Auspice JSON in Web, when passing URL to Auspice JSON file into `?dataset-json-url` URL param. Note that the URL passed as an argument to the URL param might need to be [percent-encoded](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding) (urlencoded).
 - [x] accept Auspice JSON in `read-annotation` command. This allows to visualize genome annotation from Auspice JSON the way Nextclade sees it. Might be useful for debugging.


### Requirements

 - JSONs must contain ref nuc sequence `.root_sequence.nuc` field ~and `clade_membership` node attributes. The `clade_membership` requirement will be lifted in ~the near future~ [#1457](https://github.com/nextstrain/nextclade/pull/1457).~ (`clade_membership` is no longer required)
 - Scientifically, root node of the tree should either correspond to reference sequence or to contain all mutations between reference sequence and sequence corresponding to the root node. This is ensured by authors of Nextclade datasets, but this is not generally true for Auspice JSONs. Nextclade has no possibility to verify this correspondence. If this assumption is violated, it will produce incorrect results.


### Data sources within Auspice JSON

| required? | what               | path in Auspice JSON                  | Notes |
|-----------|--------------------|---------------------------------------|-------|
| yes       | reference sequence | `.root_sequence.nuc`                  | 1, 2  |
| no        | genome annotation  | `.meta.genome_annotations`            | 3, 4  |
| no        | pathogen info      | `.meta.extensions.nextclade.pathogen` | 5     |
| no        | examples           | ???                                   |       |
| no        | readme             | ???                                   |       |
| no        | changelog          | ???                                   |       |

Notes:

1. If `.root_sequence.nuc` is missing and reference sequence is not provided otherwise (e.g. using individual args/params), then an error is thrown.

2. Auspice JSON does not contain name of the reference in `.root_sequence.nuc`. When writing reference sequence to outputs (with `--include-reference` in CLI and always in Web), the name is taken from pathogen info at `.meta.extensions.nextclade.pathogen.attributes["reference name"]` if present. Otherwise a hardcoded value "reference" is used.

3. Genome annotation in the Auspice format (https://github.com/nextstrain/augur/pull/354, https://github.com/nextstrain/auspice/pull/1684)

4. If `.meta.genome_annotations` is missing, similarly to when `genome_annotation.gff3` is missing, an empty annotation will be used, meaning translation, aa mutation calling and anything else related to amino acids will not run.

5. Object of the same format as `pathogen.json`. Just paste contents of `pathogen.json` into a new field: `.meta.extensions.nextclade.pathogen`. If pathogen info is missing, then QC and other features configurable in `pathogen.json` will be disabled. There will be no pretty dataset name and ref sequence name.

### Examples

 - ~From nextstrain.org: https://nextclade-git-feat-ref-and-ann-from-tree-json-nextstrain.vercel.app?dataset-json-url=https://nextstrain.org/charon/getDataset?prefix=ncov/gisaid/global/all-time~ (does not contain required `.root_sequence.nuc`. Please suggest a json that has it)

 - :heavy_check_mark:  SC2 from GitHub (the tree originally contains `.root_sequence.nuc`, as well as `.meta.genome_annotations` and I added `.meta.extensions.nextclade.pathogen` for pretty dataset name display): https://nextclade-git-feat-ref-and-ann-from-tree-json-nextstrain.vercel.app?dataset-json-url=https://github.com/nextstrain/nextclade_data/blob/feat/ref-and-ann-from-tree-json/data/nextstrain/sars-cov-2/wuhan-hu-1/orfs/tree.json

 - :boom: **crashing** H5 from GitHub: https://nextclade-git-feat-ref-and-ann-from-tree-json-nextstrain.vercel.app/?dataset-json-url=https://github.com/rneher/h5_cattle_genome/blob/master/tree.json


### Future work

 - `.meta.extensions.nextclade.pathogen.files` or another similar field could contain URLs to the (1) data which cannot be in JSON (e.g. example sequences, readme, changelog) or (2) you could have a separate ref sequence, annotation and pathogen.json files if for some reason you decide that Auspice fields do not suite you.
