### PR TITLE
refactor: remove recursion when writing out Auspice JSON

### DIFF
--- a/packages/nextclade/src/graph/graph.rs
+++ b/packages/nextclade/src/graph/graph.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use num_traits::Float;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[allow(clippy::partial_pub_fields)]
@@ -550,8 +550,52 @@ impl Graph<AuspiceGraphNodePayload, AuspiceGraphEdgePayload, AuspiceGraphMeta> {
 }
 
 pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree, Report> {
+  // Convert all graph nodes to Auspice format in advance, and map graph keys to corresponding Auspice nodes.
+  // At this point we leave `children` arrays empty and we will fill them during traversal.
+  let mut new_nodes: BTreeMap<GraphNodeKey, AuspiceTreeNode> = graph
+    .nodes
+    .iter()
+    .map(|node| {
+      (
+        node.key(),
+        AuspiceTreeNode::from_graph_node_payload(node.payload(), vec![]),
+      )
+    })
+    .collect();
+
+  // Traverse post-order
   let root = graph.get_exactly_one_root()?;
-  let tree = convert_graph_to_auspice_tree_recursive(graph, root)?;
+  let mut stack = vec![(root.key(), false)];
+  while let Some((node_key, visited)) = stack.pop() {
+    if visited {
+      // We are done with child nodes and are going backwards.
+      // Finalize this node: move child nodes from the map into new node's `children` array.
+      let child_keys = graph.iter_child_keys_of_by_key(node_key).collect_vec();
+      for child_key in child_keys {
+        let new_child = new_nodes
+          .remove(&child_key)
+          .ok_or_else(|| make_internal_report!("Node '{child_key}' is expected, but not found"))?;
+
+        let new_node = new_nodes
+          .get_mut(&node_key)
+          .ok_or_else(|| make_internal_report!("Node '{child_key}' is expected, but not found"))?;
+
+        new_node.children.push(new_child);
+      }
+    } else {
+      // We are going forward, exploring child nodes
+      stack.push((node_key, true));
+      let child_keys = graph.iter_child_keys_of_by_key(node_key).collect_vec();
+      for child_key in child_keys {
+        stack.push((child_key, false));
+      }
+    }
+  }
+
+  let tree = new_nodes
+    .remove(&root.key())
+    .ok_or_else(|| make_internal_report!("Root node not found"))?;
+
   Ok(AuspiceTree {
     version: graph.data.auspice_tree_version.clone(),
     meta: graph.data.meta.clone(),
@@ -559,17 +603,6 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
     root_sequence: None,
     other: graph.data.other.clone(),
   })
-}
-
-fn convert_graph_to_auspice_tree_recursive(
-  graph: &AuspiceGraph,
-  node: &Node<AuspiceGraphNodePayload>,
-) -> Result<AuspiceTreeNode, Report> {
-  let children = graph
-    .iter_children_of(node)
-    .map(|child| convert_graph_to_auspice_tree_recursive(graph, child))
-    .collect::<Result<Vec<_>, Report>>()?;
-  Ok(AuspiceTreeNode::from_graph_node_payload(node.payload(), children))
 }
 
 pub fn convert_auspice_tree_to_graph(tree: AuspiceTree) -> Result<AuspiceGraph, Report> {
@@ -612,4 +645,188 @@ fn get_max_divergence<N: GraphNode + HasDivergence, E: GraphEdge, D>(graph: &Gra
     .map(|node| node.payload().divergence())
     .max_by(f64::total_cmp)
     .unwrap_or_else(f64::infinity)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::io::json::{json_stringify, JsonPretty};
+  use crate::o;
+  use crate::tree::tree::{AuspiceTreeMeta, TreeBranchAttrs, TreeNodeAttrs};
+  use eyre::Report;
+  use pretty_assertions::assert_eq;
+  use serde_json::Value::Null;
+
+  #[test]
+  #[allow(clippy::many_single_char_names)]
+  fn test_convert_graph_to_auspice_tree() -> Result<(), Report> {
+    let graph = {
+      let mut graph = AuspiceGraph::new(AuspiceGraphMeta::default());
+
+      //          root
+      //           |
+      //     a-----+----- b
+      //    / \           |
+      //   c   d    +-----+-----+
+      //   |        |     |     |
+      //   h        e     f     g
+      //            |     |     |
+      //            i     j     k
+      //           / \    |
+      //          l   m   n
+
+      let root = graph.add_node(AuspiceGraphNodePayload::new("root"));
+      let a = graph.add_node(AuspiceGraphNodePayload::new("a"));
+      let b = graph.add_node(AuspiceGraphNodePayload::new("b"));
+      let c = graph.add_node(AuspiceGraphNodePayload::new("c"));
+      let d = graph.add_node(AuspiceGraphNodePayload::new("d"));
+      let e = graph.add_node(AuspiceGraphNodePayload::new("e"));
+      let f = graph.add_node(AuspiceGraphNodePayload::new("f"));
+      let g = graph.add_node(AuspiceGraphNodePayload::new("g"));
+      let h = graph.add_node(AuspiceGraphNodePayload::new("h"));
+      let i = graph.add_node(AuspiceGraphNodePayload::new("i"));
+      let j = graph.add_node(AuspiceGraphNodePayload::new("j"));
+      let k = graph.add_node(AuspiceGraphNodePayload::new("k"));
+      let l = graph.add_node(AuspiceGraphNodePayload::new("l"));
+      let m = graph.add_node(AuspiceGraphNodePayload::new("m"));
+      let n = graph.add_node(AuspiceGraphNodePayload::new("n"));
+
+      graph.add_edge(root, a, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(root, b, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(a, c, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(a, d, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(c, h, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(b, e, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(b, f, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(b, g, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(e, i, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(f, j, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(g, k, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(i, l, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(i, m, AuspiceGraphEdgePayload::new())?;
+      graph.add_edge(j, n, AuspiceGraphEdgePayload::new())?;
+
+      graph.build()
+    }?;
+
+    let tree = convert_graph_to_auspice_tree(&graph)?;
+
+    let expected = AuspiceTree {
+      version: None,
+      meta: AuspiceTreeMeta::default(),
+      tree: AuspiceTreeNode {
+        name: o!("root"),
+        branch_attrs: TreeBranchAttrs::default(),
+        node_attrs: TreeNodeAttrs::default(),
+        children: vec![
+          AuspiceTreeNode {
+            name: o!("a"),
+            branch_attrs: TreeBranchAttrs::default(),
+            node_attrs: TreeNodeAttrs::default(),
+            children: vec![
+              AuspiceTreeNode {
+                name: o!("c"),
+                branch_attrs: TreeBranchAttrs::default(),
+                node_attrs: TreeNodeAttrs::default(),
+                children: vec![AuspiceTreeNode {
+                  name: o!("h"),
+                  branch_attrs: TreeBranchAttrs::default(),
+                  node_attrs: TreeNodeAttrs::default(),
+                  children: vec![],
+                  other: Null,
+                }],
+                other: Null,
+              },
+              AuspiceTreeNode {
+                name: o!("d"),
+                branch_attrs: TreeBranchAttrs::default(),
+                node_attrs: TreeNodeAttrs::default(),
+                children: vec![],
+                other: Null,
+              },
+            ],
+            other: Null,
+          },
+          AuspiceTreeNode {
+            name: o!("b"),
+            branch_attrs: TreeBranchAttrs::default(),
+            node_attrs: TreeNodeAttrs::default(),
+            children: vec![
+              AuspiceTreeNode {
+                name: o!("e"),
+                branch_attrs: TreeBranchAttrs::default(),
+                node_attrs: TreeNodeAttrs::default(),
+                children: vec![AuspiceTreeNode {
+                  name: o!("i"),
+                  branch_attrs: TreeBranchAttrs::default(),
+                  node_attrs: TreeNodeAttrs::default(),
+                  children: vec![
+                    AuspiceTreeNode {
+                      name: o!("l"),
+                      branch_attrs: TreeBranchAttrs::default(),
+                      node_attrs: TreeNodeAttrs::default(),
+                      children: vec![],
+                      other: Null,
+                    },
+                    AuspiceTreeNode {
+                      name: o!("m"),
+                      branch_attrs: TreeBranchAttrs::default(),
+                      node_attrs: TreeNodeAttrs::default(),
+                      children: vec![],
+                      other: Null,
+                    },
+                  ],
+                  other: Null,
+                }],
+                other: Null,
+              },
+              AuspiceTreeNode {
+                name: o!("f"),
+                branch_attrs: TreeBranchAttrs::default(),
+                node_attrs: TreeNodeAttrs::default(),
+                children: vec![AuspiceTreeNode {
+                  name: o!("j"),
+                  branch_attrs: TreeBranchAttrs::default(),
+                  node_attrs: TreeNodeAttrs::default(),
+                  children: vec![AuspiceTreeNode {
+                    name: o!("n"),
+                    branch_attrs: TreeBranchAttrs::default(),
+                    node_attrs: TreeNodeAttrs::default(),
+                    children: vec![],
+                    other: Null,
+                  }],
+                  other: Null,
+                }],
+                other: Null,
+              },
+              AuspiceTreeNode {
+                name: o!("g"),
+                branch_attrs: TreeBranchAttrs::default(),
+                node_attrs: TreeNodeAttrs::default(),
+                children: vec![AuspiceTreeNode {
+                  name: o!("k"),
+                  branch_attrs: TreeBranchAttrs::default(),
+                  node_attrs: TreeNodeAttrs::default(),
+                  children: vec![],
+                  other: Null,
+                }],
+                other: Null,
+              },
+            ],
+            other: Null,
+          },
+        ],
+        other: Null,
+      },
+      root_sequence: None,
+      other: Null,
+    };
+
+    assert_eq!(
+      json_stringify(&tree, JsonPretty(true))?,
+      json_stringify(&expected, JsonPretty(true))?
+    );
+
+    Ok(())
+  }
 }

--- a/packages/nextclade/src/graph/graph.rs
+++ b/packages/nextclade/src/graph/graph.rs
@@ -578,14 +578,16 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
 
         let new_node = new_nodes
           .get_mut(&node_key)
-          .ok_or_else(|| make_internal_report!("Node '{child_key}' is expected, but not found"))?;
+          .ok_or_else(|| make_internal_report!("Node '{node_key}' is expected, but not found"))?;
 
         new_node.children.push(new_child);
       }
     } else {
       // We are going forward, exploring child nodes
       stack.push((node_key, true));
-      let child_keys = graph.iter_child_keys_of_by_key(node_key).collect_vec();
+      let child_keys = graph.iter_child_keys_of_by_key(node_key).map(||).collect_vec();
+      stack.extend()
+
       for child_key in child_keys {
         stack.push((child_key, false));
       }

--- a/packages/nextclade/src/graph/graph.rs
+++ b/packages/nextclade/src/graph/graph.rs
@@ -585,12 +585,10 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
     } else {
       // We are going forward, exploring child nodes
       stack.push((node_key, true));
-      let child_keys = graph.iter_child_keys_of_by_key(node_key).map(||).collect_vec();
-      stack.extend()
-
-      for child_key in child_keys {
-        stack.push((child_key, false));
-      }
+      let children = graph
+        .iter_child_keys_of_by_key(node_key)
+        .map(|child_key| (child_key, false));
+      stack.extend(children);
     }
   }
 

--- a/packages/nextclade/src/graph/graph.rs
+++ b/packages/nextclade/src/graph/graph.rs
@@ -567,10 +567,20 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
   let root = graph.get_exactly_one_root()?;
   let mut stack = vec![(root.key(), false)];
   while let Some((node_key, visited)) = stack.pop() {
-    if visited {
-      // We are done with child nodes and are going backwards.
-      // Finalize this node: move child nodes from the map into new node's `children` array.
+    if !visited {
+      // Not visited yet: we are going forward. Explore child nodes.
+
+      stack.push((node_key, true));
+
       let children = graph
+        .iter_child_keys_of_by_key(node_key)
+        .map(|child_key| (child_key, false));
+
+      stack.extend(children);
+    } else {
+      // Already visited before: we are done with child nodes and are returning back.
+      // Finalize this node: move child nodes from the map into new node's `children` array.
+      let new_children = graph
         .iter_child_keys_of_by_key(node_key)
         .map(|child_key| {
           new_nodes
@@ -583,14 +593,7 @@ pub fn convert_graph_to_auspice_tree(graph: &AuspiceGraph) -> Result<AuspiceTree
         .get_mut(&node_key)
         .ok_or_else(|| make_internal_report!("Node '{node_key}' is expected, but not found"))?;
 
-      new_node.children = children;
-    } else {
-      // We are going forward, exploring child nodes
-      stack.push((node_key, true));
-      let children = graph
-        .iter_child_keys_of_by_key(node_key)
-        .map(|child_key| (child_key, false));
-      stack.extend(children);
+      new_node.children = new_children;
     }
   }
 

--- a/packages/nextclade/src/graph/node.rs
+++ b/packages/nextclade/src/graph/node.rs
@@ -1,15 +1,15 @@
 use crate::graph::edge::GraphEdgeKey;
 use crate::io::json::is_json_value_null;
-use core::fmt::{Debug};
-use derive_more::Display;
+use core::fmt::Debug;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Display, Formatter};
 
 pub trait GraphNode: Clone + Debug {}
 
-#[derive(Copy, Clone, Debug, Default, Display, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct GraphNodeKey(usize);
 
 impl GraphNodeKey {
@@ -23,6 +23,18 @@ impl GraphNodeKey {
   #[must_use]
   pub const fn as_usize(self) -> usize {
     self.0
+  }
+}
+
+impl Display for GraphNodeKey {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.as_usize())
+  }
+}
+
+impl Debug for GraphNodeKey {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    Display::fmt(self, f)
   }
 }
 

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -60,7 +60,7 @@ pub struct GraphTempData {
   pub other: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AuspiceGraphMeta {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub auspice_tree_version: Option<String>,
@@ -123,7 +123,7 @@ pub struct TreeBranchAttrsLabels {
   pub other: serde_json::Value,
 }
 
-#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
+#[derive(Clone, Default, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
 pub struct TreeBranchAttrs {
   pub mutations: BTreeMap<String, Vec<String>>,
 
@@ -134,7 +134,7 @@ pub struct TreeBranchAttrs {
   pub other: serde_json::Value,
 }
 
-#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
+#[derive(Clone, Default, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
 pub struct TreeNodeAttrs {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub div: Option<f64>,
@@ -198,6 +198,7 @@ pub struct TreeNodeAttrs {
 /// It is not serialized or deserialized, but is added during preprocessing step and then used for internal calculations
 #[derive(Clone, Debug, Default)]
 pub struct TreeNodeTempData {
+  pub child_visit: usize,
   pub substitutions: BTreeMap<NucRefGlobalPosition, Nuc>,
   pub mutations: BTreeMap<NucRefGlobalPosition, Nuc>,
   pub private_mutations: BranchMutations,
@@ -205,7 +206,7 @@ pub struct TreeNodeTempData {
   pub aa_mutations: BTreeMap<String, BTreeMap<AaRefPosition, Aa>>,
 }
 
-#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
+#[derive(Clone, Default, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
 pub struct AuspiceGraphNodePayload {
   pub name: String,
 
@@ -246,6 +247,13 @@ impl From<&AuspiceTreeNode> for AuspiceGraphNodePayload {
 }
 
 impl AuspiceGraphNodePayload {
+  pub fn new(name: impl AsRef<str>) -> Self {
+    Self {
+      name: name.as_ref().to_owned(),
+      ..Self::default()
+    }
+  }
+
   /// Extracts clade of the node
   pub fn clade(&self) -> Option<String> {
     self
@@ -484,7 +492,7 @@ impl AuspiceGenomeAnnotations {
   }
 }
 
-#[derive(Clone, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
+#[derive(Clone, Default, Serialize, Deserialize, schemars::JsonSchema, Validate, Debug)]
 pub struct AuspiceTreeMeta {
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub title: Option<String>,


### PR DESCRIPTION
Recursion has been overflowing call stack in the web app when very large trees are used.

Let's remove recursion when converting internal graph into Auspice JSON when writing out Auspice JSON tree. 

In this version I convert all nodes in advance, and store them in a map (which may or may not be needed) and then explore the tree using stack-based post-order traversal.

This should provide byte-equal JSONs when compared to the previous, recursive implementation. 
