### PR TITLE
fix(web): exclude selected GitHub URLs when checking for repo URL

### DIFF
--- a/packages/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages/nextclade-web/src/io/fetchDatasets.ts
@@ -4,7 +4,7 @@ import { findSimilarStrings } from 'src/helpers/string'
 import { axiosHeadOrUndefined } from 'src/io/axiosFetch'
 import {
   isGithubShortcut,
-  isGithubUrl,
+  isGithubRepoUrl,
   parseGitHubRepoShortcut,
   parseGithubRepoUrl,
 } from 'src/io/fetchSingleDatasetFromGithub'
@@ -94,7 +94,7 @@ export async function getDatasetServerUrl(urlQuery: ParsedUrlQuery) {
       return urljoin('https://raw.githubusercontent.com', owner, repo, branch, path)
     }
 
-    if (isGithubUrl(datasetServerUrl)) {
+    if (isGithubRepoUrl(datasetServerUrl)) {
       const { owner, repo, branch, path } = await parseGithubRepoUrl(datasetServerUrl)
       return urljoin('https://raw.githubusercontent.com', owner, repo, branch, path)
     }

--- a/packages/nextclade-web/src/io/fetchSingleDatasetFromGithub.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetFromGithub.ts
@@ -125,14 +125,17 @@ export async function parseGitHubRepoUrlOrShortcut(url_: string): Promise<GitHub
   if (isGithubShortcut(url)) {
     return parseGitHubRepoShortcut(url)
   }
-  if (isGithubUrl(url)) {
+  if (isGithubRepoUrl(url)) {
     return parseGithubRepoUrl(url)
   }
   throw new ErrorDatasetGithubUrlPatternInvalid(url)
 }
 
-export function isGithubUrl(url: string): boolean {
-  return !isNil(/^https?:\/\/github.com\/.*/.exec(url))
+export function isGithubRepoUrl(url: string): boolean {
+  const excludedPaths = ['assets', 'gist', 'gists', 'releases', 'settings', 'user-attachments']
+  const excludedPathsPattern = excludedPaths.join('|')
+  const githubUrlPattern = new RegExp(`^https?:\\/\\/github\\.com\\/(?!${excludedPathsPattern}\\/).*`) // eslint-disable-line security/detect-non-literal-regexp
+  return githubUrlPattern.test(url)
 }
 
 export function isGithubShortcut(url: string): boolean {
@@ -140,7 +143,7 @@ export function isGithubShortcut(url: string): boolean {
 }
 
 export function isGithubUrlOrShortcut(url: string): boolean {
-  return isGithubUrl(url) || isGithubShortcut(url)
+  return isGithubRepoUrl(url) || isGithubShortcut(url)
 }
 
 const GITHUB_URL_ERROR_HINTS = ` Check the correctness of the URL. If it's a full GitHub URL, please try to navigate to it - you should see a GitHub repo branch with your files listed. If it's a GitHub URL shortcut, please double-check the syntax. See documentation for the correct syntax and examples. If you don't intend to use custom datasets, remove the parameter from the address or restart the application.`


### PR DESCRIPTION
When deciding whether a URL is a GitHub repo url, currently certain URLs trigger false positives.

For example, user attachments (`https://github.com/user-attachments/files/12345678/example.txt`), assets, gists, releases etc.

Let's exclude certain paths in regex from consideration.

Some of these paths don't respond with CORS headers, so they cannot be used in Nextclade anyways, but at least users will see a correct error message, rather than GitHub repo URL parsing error, which does not make sense for the URL types listed above.


P.S. I wish there would be a library for that, so that I don't need to write and maintain this... All we need is to download single files and directories from GitHub repos.
