### PR TITLE
fix(web): prevent writing large auspice json to local storage

### DIFF
--- a/packages/nextclade-web/.eslintrc.js
+++ b/packages/nextclade-web/.eslintrc.js
@@ -130,6 +130,7 @@ module.exports = {
     'no-shadow': 'off',
     'no-unused-vars': 'off',
     'only-ascii/only-ascii': 'warn',
+    'prefer-const': ['warn', { destructuring: 'all' }],
     'prefer-for-of': 'off',
     'prettier/prettier': 'warn',
     'react-hooks/exhaustive-deps': [
@@ -148,7 +149,7 @@ module.exports = {
     'react/state-in-constructor': 'off',
     'security/detect-non-literal-fs-filename': 'off',
     'security/detect-object-injection': 'off',
-    'sonarjs/cognitive-complexity': ['warn', 20],
+    'sonarjs/cognitive-complexity': 'off',
     'unicorn/consistent-function-scoping': 'off',
     'unicorn/escape-case': 'off',
     'unicorn/filename-case': 'off',

--- a/packages/nextclade-web/src/components/Main/SuggestionAlertMainPage.tsx
+++ b/packages/nextclade-web/src/components/Main/SuggestionAlertMainPage.tsx
@@ -13,7 +13,6 @@ export function SuggestionAlertMainPage({ ...restProps }) {
   const { numSuggestions, datasetsActive: datasetSuggestions } = useDatasetSuggestionResults()
   const autodetectRunState = useRecoilValue(autodetectRunStateAtom)
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
   const alert = useMemo(() => {
     const hasMatch = datasetCurrent && datasetSuggestions.some((suggestion) => suggestion.path === datasetCurrent.path)
 

--- a/packages/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages/nextclade-web/src/io/fetchDatasets.ts
@@ -9,7 +9,7 @@ import {
   parseGithubRepoUrl,
 } from 'src/io/fetchSingleDatasetFromGithub'
 
-import { type AuspiceTree, Dataset } from 'src/types'
+import { Dataset } from 'src/types'
 import {
   fetchDatasetsIndex,
   filterDatasets,

--- a/packages/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages/nextclade-web/src/io/fetchDatasets.ts
@@ -128,11 +128,7 @@ export async function initializeDatasets(datasetServerUrl: string, urlQuery: Par
   const minimizerIndexVersion = await getCompatibleMinimizerIndexVersion(datasetServerUrl, datasetsIndexJson)
 
   // Check if URL params specify dataset params and try to find the corresponding dataset
-  const currentDataset:
-    | (Dataset & {
-        auspiceJson?: AuspiceTree
-      })
-    | undefined = await getDatasetFromUrlParams(urlQuery, datasets)
+  const currentDataset = await getDatasetFromUrlParams(urlQuery, datasets)
 
   return { datasets, currentDataset, minimizerIndexVersion }
 }

--- a/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetAuspice.ts
@@ -39,7 +39,7 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
     }
   }
 
-  const currentDataset: Dataset & { auspiceJson?: AuspiceTree } = {
+  const currentDataset: Dataset = {
     path: datasetJsonUrl,
     capabilities: {
       primers: false,
@@ -50,8 +50,8 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
       name,
       ...pathogen?.attributes,
     },
+    type: 'auspiceJson',
     version,
-    auspiceJson,
   }
 
   const datasets = [currentDataset]
@@ -60,5 +60,5 @@ export async function fetchSingleDatasetAuspice(datasetJsonUrl_: string) {
   const defaultDatasetName = currentDatasetName
   const defaultDatasetNameFriendly = attrStrMaybe(currentDataset.attributes, 'name') ?? currentDatasetName
 
-  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
+  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset, auspiceJson }
 }

--- a/packages/nextclade-web/src/io/fetchSingleDatasetDirectory.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetDirectory.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import urljoin from 'url-join'
 import { mapValues } from 'lodash'
 import { concurrent } from 'fasy'
-import { attrStrMaybe, AuspiceTree, Dataset, VirusProperties } from 'src/types'
+import { attrStrMaybe, Dataset, VirusProperties } from 'src/types'
 import { removeTrailingSlash } from 'src/io/url'
 import { axiosFetch, axiosHead, axiosHeadOrUndefined } from 'src/io/axiosFetch'
 import { sanitizeError } from 'src/helpers/sanitizeError'
@@ -17,7 +17,7 @@ export async function fetchSingleDatasetDirectory(
 
   const files = mapValues(pathogen.files, (file) => (file ? urljoin(datasetRootUrl, file) : file))
 
-  const currentDataset: Dataset & { auspiceJson?: AuspiceTree } = {
+  const currentDataset: Dataset = {
     path: datasetRootUrl,
     capabilities: {
       primers: false,
@@ -25,6 +25,7 @@ export async function fetchSingleDatasetDirectory(
     },
     ...pathogen,
     files,
+    type: 'directory',
   }
 
   const datasets = [currentDataset]
@@ -51,7 +52,14 @@ export async function fetchSingleDatasetDirectory(
     Object.entries(files).filter(([_, key]) => !['examples', 'readme'].includes(key)),
   )
 
-  return { datasets, defaultDataset, defaultDatasetName, defaultDatasetNameFriendly, currentDataset }
+  return {
+    datasets,
+    defaultDataset,
+    defaultDatasetName,
+    defaultDatasetNameFriendly,
+    currentDataset,
+    auspiceJson: undefined,
+  }
 }
 
 async function fetchPathogenJson(datasetRootUrl: string) {

--- a/packages/nextclade-web/src/io/fetchSingleDatasetFromGithub.ts
+++ b/packages/nextclade-web/src/io/fetchSingleDatasetFromGithub.ts
@@ -1,4 +1,4 @@
-/* eslint-disable security/detect-unsafe-regex,prefer-const */
+/* eslint-disable security/detect-unsafe-regex */
 import type { Optional } from 'utility-types'
 import { isEmpty, isNil, trim } from 'lodash'
 import pMemoize from 'p-memoize'

--- a/packages/nextclade/src/io/dataset.rs
+++ b/packages/nextclade/src/io/dataset.rs
@@ -78,6 +78,9 @@ pub struct Dataset {
   #[serde(default, skip_serializing_if = "DatasetVersion::is_empty")]
   pub version: DatasetVersion,
 
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub r#type: Option<DatasetType>,
+
   #[serde(flatten)]
   pub other: serde_json::Value,
 }
@@ -385,4 +388,12 @@ pub struct MinimizerIndexVersion {
   pub path: String,
   #[serde(flatten)]
   pub other: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum DatasetType {
+  Directory,
+  AuspiceJson,
+  Other,
 }


### PR DESCRIPTION
When `dataset-json-url` param is used, the entire auspice json was stored in local storage. For large files this might be bigger than what browsers allow and the store operation would fail. Subsequent reads would retrieve either nothing or some fragment of data.

Here I add some logic to make sure we store auspice json in memory only. Sadly, this means that page reload wipes all the data and we currently don't have a good mechanism to store the previous dataset URL in order to re-fetch it. This will need to be implemented. Currently I opted for discarding the stored dataset if it was auspice dataset. This should be alright, as the feature was primarily designed to be used when navigating to Nextclade with url params set.

This PR only implements a workaround for something that's fundamentally poorly designed and broken. The full dataset description object is still saved to local storage (just not the full auspice json anymore). The definitive fix requires serious restructuring and altering many components. It will be implemented later (https://github.com/nextstrain/nextclade/issues/1464)

But this workaround should allow most use-cases of `dataset-json-url` to work and makes [the auspice dataset feature](https://github.com/nextstrain/nextclade/pull/1455) releasable.

Can be tested with a large tree like this:

```
?dataset-json-url=https://nextstrain.org/ncov/gisaid/global/all-time
```


