### PR TITLE
feat: allow `index` and `seqName` in column selection

### DIFF
--- a/packages/nextclade/src/io/nextclade_csv.rs
+++ b/packages/nextclade/src/io/nextclade_csv.rs
@@ -126,6 +126,8 @@ lazy_static! {
   // Default configuration and layout of CSV column categories
   pub static ref CSV_COLUMN_CONFIG_MAP_DEFAULT: CsvColumnConfigMap = indexmap! {
     CsvColumnCategory::General => indexmap! {
+      o!("index") => true,
+      o!("seqName") => true,
       o!("clade") => true,
       o!("qc.overallScore") => true,
       o!("qc.overallStatus") => true,
@@ -228,8 +230,6 @@ fn prepare_headers(
 ) -> Vec<String> {
   // Get names of enabled columns
   let mut headers = {
-    let mandatory_headers = vec!["index", "seqName"].into_iter();
-
     let category_headers = column_config
       .categories
       .iter()
@@ -239,7 +239,7 @@ fn prepare_headers(
 
     let individual_headers = column_config.individual.iter().map(String::as_str);
 
-    chain![mandatory_headers, category_headers, individual_headers]
+    chain![category_headers, individual_headers]
       .unique()
       .map(String::from)
       .collect_vec()


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1459

Previously, Nextclade treated output CSV/TSV columns `index` and `seqName` as mandatory.

Here I make them optional. Users now can:

 - in CLI: use `index` and `seqName` values in  `--output-columns-selection`
- in Web: tick checkboxes for `index` and `seqName` in "Column config" on export page

