### PR TITLE
feat(cli): display dataset capabilities in `dataset list` command

### DIFF
--- a/packages/nextclade-cli/src/dataset/dataset_table.rs
+++ b/packages/nextclade-cli/src/dataset/dataset_table.rs
@@ -15,13 +15,14 @@ pub fn format_dataset_table(filtered: &[Dataset]) -> String {
     .apply_modifier(UTF8_SOLID_INNER_BORDERS)
     .set_content_arrangement(ContentArrangement::Dynamic);
 
-  table.set_header([o!("name"), o!("attributes"), o!("versions")]);
+  table.set_header([o!("name"), o!("attributes"), o!("versions"), o!("capabilities")]);
 
   for dataset in filtered {
     let Dataset {
       path,
       shortcuts,
       attributes,
+      capabilities,
       ..
     } = dataset;
 
@@ -45,7 +46,26 @@ pub fn format_dataset_table(filtered: &[Dataset]) -> String {
 
     let versions = dataset.versions.iter().map(|ver| &ver.tag).join("\n");
 
-    table.add_row([&name, &attrs, &versions]);
+    let capabilities = {
+      let mut caps = vec![];
+      if let Some(n_clades) = capabilities.clades {
+        caps.push(format!("clade ({n_clades})"));
+      }
+
+      capabilities.custom_clades.iter().for_each(|(attr, n_attrs)| {
+        caps.push(format!("{attr} ({n_attrs})"));
+      });
+
+      capabilities.qc.iter().for_each(|rule| {
+        caps.push(format!("qc.{rule}"));
+      });
+
+      caps.extend_from_slice(&capabilities.other);
+
+      caps.join("\n")
+    };
+
+    table.add_row([&name, &attrs, &versions, &capabilities]);
   }
 
   table.to_string()

--- a/packages/nextclade/src/io/dataset.rs
+++ b/packages/nextclade/src/io/dataset.rs
@@ -292,14 +292,23 @@ pub struct DatasetCollectionMeta {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatasetCapabilities {
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub clades: Option<usize>,
+
+  #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+  pub custom_clades: BTreeMap<String, usize>,
+
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub qc: Vec<String>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub primers: Option<bool>,
 
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub other: Vec<String>,
+
   #[serde(flatten)]
-  pub other: serde_json::Value,
+  pub rest: serde_json::Value,
 }
 
 impl DatasetCapabilities {


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1458

Sibling in data: https://github.com/nextstrain/nextclade/pull/1473

This adds "capabilities" column to the console output of the `nextclade dataset list` command.  

![001](https://github.com/nextstrain/nextclade/assets/9403403/7bcda7fb-f39d-4ba6-8dd2-f18768ceeb63)
