### PR TITLE
feat: warn when standalone ref and tree ref don't match exactly

### DIFF
--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -674,7 +674,7 @@ impl AuspiceTree {
     self
       .root_sequence
       .as_ref()
-      .and_then(|map| map.get("nuc"))
+      .and_then(|root_sequence| root_sequence.get("nuc"))
       .map(String::as_str)
   }
 }

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -12,6 +12,7 @@ use crate::graph::traits::{HasDivergence, HasName};
 use crate::io::fs::read_file_to_string;
 use crate::io::json::json_parse;
 use eyre::{eyre, Report, WrapErr};
+use log::warn;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -668,4 +669,37 @@ impl AuspiceTree {
   pub fn map_nodes_mut(&mut self, action: fn((usize, &mut AuspiceTreeNode))) {
     Self::map_nodes_mut_rec(0, &mut self.tree, action);
   }
+
+  pub fn root_sequence(&self) -> Option<&str> {
+    self
+      .root_sequence
+      .as_ref()
+      .and_then(|map| map.get("nuc"))
+      .map(String::as_str)
+  }
+}
+
+pub fn check_ref_seq_mismatch(
+  standalone_ref_seq: impl AsRef<str>,
+  tree_ref_seq: impl AsRef<str>,
+) -> Result<(), Report> {
+  if standalone_ref_seq.as_ref() != tree_ref_seq.as_ref() {
+    warn!(
+      r#"Nextclade detected that reference sequence provided does not exactly match reference (root) sequence in Auspice JSON.
+
+     This could be due to one of the reasons:
+
+     - Nextclade dataset author provided reference sequence and reference tree that are incompatible
+     - The reference tree has been constructed incorrectly
+     - The reference sequence provided using `--input-ref` CLI argument is not compatible with the reference tree in the dataset
+     - The reference tree provided using `--input-tree` CLI argument is not compatible with the reference sequence in the dataset
+     - The reference sequence provided using `&input-ref` parameter in Nextclade Web URL is not compatible with the reference tree in the dataset
+     - The reference tree provided using `&input-tree` parameter in Nextclade Web URL is not compatible with the reference sequence in the dataset
+
+     This warning signals that there is a potential for failures if the mismatch is not intended.
+    "#
+    );
+  }
+
+  Ok(())
 }


### PR DESCRIPTION
Following conversation in https://github.com/nextstrain/nextclade/pull/1455#issuecomment-2146589157

Let's add a warning if the reference sequence provided any of the possible ways (fasta in dataset files, through CLI argument, Web URL param, or Web "Customization" interface) does not exactly match (as in string comparison) the `.root_sequence.nuc` in Auspice JSON.

The warning is emitted:

 - CLI: into console
 - Web: into dev console, for every WebWorker "thread" (we don't currently have a good mechanism to display warnings int he app, especially the ones coming from Rust)

The warning message is the following. Please suggest improvements (paste a full quote into reply message or feel free to modify in the code).

<details>
<summary>Click to expand</summary>

> Nextclade detected that reference sequence provided does not exactly match reference (root) sequence in Auspice JSON.
>
> This could be due to one of the reasons:
>
> - Nextclade dataset author provided reference sequence and reference tree that are incompatible
> - The reference tree has been constructed incorrectly
> - The reference sequence provided using `--input-ref` CLI argument is not compatible with the reference tree in the dataset
> - The reference tree provided using `--input-tree` CLI argument is not compatible with the reference sequence in the dataset
> - The reference sequence provided using `&input-ref` parameter in Nextclade Web URL is not compatible with the reference tree in the dataset
> - The reference tree provided using `&input-tree` parameter in Nextclade Web URL is not compatible with the reference sequence in the dataset
>
> This warning signals that there is a potential for failures if the mismatch is not intended.

</details>

