### PR TITLE
fix(web): error when selecting a cds fragment in annotation viz

### DIFF
--- a/packages/nextclade-web/src/components/GeneMap/GeneMap.tsx
+++ b/packages/nextclade-web/src/components/GeneMap/GeneMap.tsx
@@ -117,7 +117,7 @@ export function CdsSegmentView({
   const openTooltip = useCallback(() => setHoveredSmart(true), [setHoveredSmart])
   const closeTooltip = useCallback(() => setHoveredSmart(false), [setHoveredSmart])
 
-  const { name, color, range, rangeLocal, frame, phase, strand } = cdsSeg
+  const { color, range, rangeLocal, frame, phase, strand } = cdsSeg
   const lengthNucsOrCodons = global ? cdsSegmentNucLength(cdsSeg) : cdsSegmentAaLength(cdsSeg)
   const width = Math.max(BASE_MIN_WIDTH_PX, lengthNucsOrCodons * pixelsPerBase) - 1 // `-1` to make border visible
   const x = (global ? range.begin : rangeLocal.begin / 3) * pixelsPerBase + 1 // `+1 to make border visible`

--- a/packages/nextclade-web/src/components/GeneMap/GeneMap.tsx
+++ b/packages/nextclade-web/src/components/GeneMap/GeneMap.tsx
@@ -134,8 +134,8 @@ export function CdsSegmentView({
   const onClick = useCallback(() => {
     clearInterval(timeoutId)
     setHovered(false)
-    setViewedGene(name)
-  }, [name, setViewedGene, timeoutId])
+    setViewedGene(cds.name)
+  }, [cds.name, setViewedGene, timeoutId])
 
   return (
     <rect


### PR DESCRIPTION
The annotation visualization component were setting name of the CDS fragment as current CDS on click. This is incorrect: CDS name needs to be set instead (like it's done in the dropdown selector).

This lead to an error displayed in the peptide view when clicking on annotation viz and when name of CDS and CDS segment is different, which is always the case for Auspice datasets - Nextclade generates fragment names, as well as for multi-fragment CDSes.

Here I fix the problem by setting CDS name as current CDS on click, rather than fragment name.

