### PR TITLE
fix: prevent duplicate node names in output auspice json

### DIFF
--- a/packages/nextclade/src/tree/tree_builder.rs
+++ b/packages/nextclade/src/tree/tree_builder.rs
@@ -371,7 +371,13 @@ pub fn knit_into_graph(
       }
       set_branch_attrs_aa_labels(&mut new_internal_node);
 
-      new_internal_node.name = format!("{target_key}_internal");
+      new_internal_node.name = {
+        let qry_name = &result.seq_name;
+        let qry_index = &result.index;
+        let target_name = &target_node_auspice.name;
+        format!("nextclade__copy_of_{target_name}_for_placement_of_{qry_name}_#{qry_index}")
+      };
+
       new_internal_node
     };
 


### PR DESCRIPTION
When new nodes are placed onto a ref node, sometimes we create an intermediate new node as a copy of the existing ref node. They are all named the same - `{node_key}_internal`. This is insufficient to provide uniqueness when multiple new nodes are placed onto the same ref node.

To address that, here I change names to also include query name and index.

