### PR TITLE
feat: upgrade auspice and add polyfills

### DIFF
--- a/packages/nextclade-web/package.json
+++ b/packages/nextclade-web/package.json
@@ -90,7 +90,7 @@
     "@hapi/accept": "6.0.3",
     "@hapi/content": "6.0.0",
     "animate.css": "4.1.1",
-    "auspice": "2.54.3",
+    "auspice": "2.55.0",
     "autoprefixer": "10.4.5",
     "awesomplete": "1.1.5",
     "axios": "0.27.1",

--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-
+import 'core-js'
 import 'css.escape'
 
 import { isEmpty, isNil } from 'lodash'

--- a/packages/nextclade-web/yarn.lock
+++ b/packages/nextclade-web/yarn.lock
@@ -4608,10 +4608,10 @@ attr-accept@^2.2.2:
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
-auspice@2.54.3:
-  version "2.54.3"
-  resolved "https://registry.yarnpkg.com/auspice/-/auspice-2.54.3.tgz#b6de4e2f65ddc4b4b9f132ff4564acfb2f21fa11"
-  integrity sha512-HYnI+pl2+s6kEXkk2I4LIuR5ecI4Vd0GJyFrhwCVTZTS1XNxmAZKEusV4pDkxwXnTOoCX/8TjyIrO0hGXlCQeg==
+auspice@2.55.0:
+  version "2.55.0"
+  resolved "https://registry.yarnpkg.com/auspice/-/auspice-2.55.0.tgz#c9e5890e3fbbf45bf723fb54fcd5c9cfbcae905c"
+  integrity sha512-KMg3NycBB1F3ruYUVy2kxXrkoyChVR6JfXp8D9RhOGVxt9HAYzLNYCQuHM/bQ8dpF7PR5xzbC9G76PWv/yLQNg==
   dependencies:
     "@babel/core" "^7.3.4"
     "@babel/plugin-proposal-class-properties" "^7.3.4"


### PR DESCRIPTION
This upgrades auspice [again](https://github.com/nextstrain/nextclade/releases/tag/3.7.3) to v2.55.0, while avoiding crash with error

```
choose-branch-labelling.js:116 Uncaught TypeError: (intermediate value).union is not a function
    at Function.eval [as mapToProps] (choose-branch-labelling.js:116:73)
```
[here](https://github.com/nextstrain/auspice/blob/5afe5814b7304b65b3856df136ceeac88cf4690e/src/components/controls/choose-branch-labelling.js#L15-L16) due to `Set.union()` not available in older browsers ([caniuse](https://caniuse.com/mdn-javascript_builtins_set_union), [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/union))

The root of the problem, I think, was migration to Next.js 12 along with swc and removing babel. I am not sure if babel would correctly polyfill this, but I believe that [babel-preset-env](https://babeljs.io/docs/babel-preset-env) would have added relevant core-js fills. The current setup does not. There is only a [handful of polyfills applied](https://nextjs.org/docs/architecture/supported-browsers) by Next.js nowadays.

Considering that we might have other modern code in the codebase which is also crashing on older browsers, I chose to include `core-js` explicitly to be safe. It adds a lot of code to the bundle though and all other drawbacks of polyfills.

Maybe newer versions of Next.js improve situation (I doubt it, they've been pitching "modern" browsers for years now), or maybe there are additional tools for swc similar to what [babel-preset-env](https://babeljs.io/docs/babel-preset-env) offered, then explicit import of `core-js` can be reconsidered.

