### PR TITLE
chore(ci): fix x86_64-unknown-linux-gnu build

### DIFF
--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -13,6 +13,7 @@ ARG YARN_VERSION="1.22.18"
 # Install required packages if running CentOS
 RUN set -euxo pipefail >/dev/null \
 && if [[ "$DOCKER_BASE_IMAGE" != centos* ]] && [[ "$DOCKER_BASE_IMAGE" != *manylinux2014* ]]; then exit 0; fi \
+&& sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
 && sed -i "s/enabled=1/enabled=0/g" "/etc/yum/pluginconf.d/fastestmirror.conf" \
 && sed -i "s/enabled=1/enabled=0/g" "/etc/yum/pluginconf.d/ovl.conf" \
 && yum clean all \


### PR DESCRIPTION
Related: https://github.com/pypa/manylinux/issues/1641

CentOS 7 went EOL and yum can no longer find its package repos . Let's move to the archive repos then.

(Not sure why every distro needs to move things around after EOL. Can't files just stay where they are? Is it like a tradition or is actually useful? Wastes so much time and effort of the dev collective)

