### PR TITLE
chore: bump mambaforge to 23.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-22.9"
+    python: "mambaforge-23.11"
 
 conda:
   environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - make
   - recommonmark
   - requests
-  - sphinx=7.2
+  - sphinx
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2022.5


### PR DESCRIPTION
## Description of proposed changes

This includes the fix to UTF-8 errors when extracting packages.¹

¹ <https://github.com/mamba-org/mamba/releases/tag/2023.07.06>

## Related issue(s)

- https://github.com/nextstrain/docs.nextstrain.org/issues/209
