### PR TITLE
chore(ci): trigger nextstrain/docker-base rebuild on release

### DIFF
--- a/.github/workflows/nextstrain-docker-base.yml
+++ b/.github/workflows/nextstrain-docker-base.yml
@@ -6,13 +6,6 @@ on:
     types:
       - released
 
-  repository_dispatch:
-    types: nextstrain-docker-base
-
-  workflow_dispatch:
-
-  workflow_call:
-
 concurrency:
   group: nextstrain-docker-base-${{ github.workflow }}-${{ github.ref_type }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/652

Other changes made:

- [x] Added nextclade to list of repos that have permission to use org secret `GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH`
