### PR TITLE
fix(web): clamp default number of threads to 3

### DIFF
--- a/packages/nextclade-web/src/helpers/getNumThreads.ts
+++ b/packages/nextclade-web/src/helpers/getNumThreads.ts
@@ -52,7 +52,7 @@ export function getNumThreads() {
   }
 
   let numThreads = navigator?.hardwareConcurrency ?? DEFAULT_NUM_THREADS
-  numThreads = Math.max(numThreads, DEFAULT_NUM_THREADS)
+  numThreads = clamp(numThreads, DEFAULT_NUM_THREADS, MAXIMUM_NUM_THREADS)
 
   // Detect how much memory is available and adjust number of threads if per-thread memory is too low
   const guess = guessNumThreads()


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1511

Firefox returns some random number for `navigator?.hardwareConcurrency`. In my case is was `16`, which does not correspond to the avaialble hardware in any way.

Here I additionally clamp the value obtained from `navigator?.hardwareConcurrency` to a range from `DEFAULT_NUM_THREADS` to `MAXIMUM_NUM_THREADS` (currently  from 2 to 3).

This solves it for Firefox, but I don't have a physical mac handy to test Safari. Not sure if testing on Browserstack is accurate - it probably runs on a VM.

