### PR TITLE
feat: Support a NEXTCLADE_EXTRA_CA_CERTS environment variable and --extra-ca-certs option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,11 @@ dependencies = [
  "regex",
  "reqwest",
  "rstest",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "rustls-platform-verifier",
+ "rustls-webpki",
  "schemars",
  "semver 1.0.17",
  "serde",
@@ -2502,6 +2506,7 @@ version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2540,9 +2545,8 @@ checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+version = "0.4.0"
+source = "git+https://github.com/rustls/rustls-platform-verifier.git?rev=ca87571fe47730665917b8c29f14a3989f3cbe57#ca87571fe47730665917b8c29f14a3989f3cbe57"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2555,15 +2559,14 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-roots",
- "winapi",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls-platform-verifier-android"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+source = "git+https://github.com/rustls/rustls-platform-verifier.git?rev=ca87571fe47730665917b8c29f14a3989f3cbe57#ca87571fe47730665917b8c29f14a3989f3cbe57"
 
 [[package]]
 name = "rustls-webpki"
@@ -3474,6 +3477,15 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c6dfa3ac045bc517de14c7b1384298de1dbd229d38e08e169d9ae8c170937c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,11 @@ regex = "=1.8.4"
 reqwest = { version = "=0.12.8", default-features = false, features = ["blocking", "deflate", "gzip", "brotli", "socks", "rustls-tls"] }
 rstest = "=0.17.0"
 rstest_reuse = "=0.5.0"
-rustls-platform-verifier = "=0.3.4"
+rustls = { version = "=0.23.14", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+rustls-platform-verifier = { git = "https://github.com/rustls/rustls-platform-verifier.git", rev = "ca87571fe47730665917b8c29f14a3989f3cbe57" }
+rustls-pemfile = "=2.2.0"
+rustls-pki-types = "=1.9.0"
+rustls-webpki = { version = "=0.102.8", features = ["ring"] }
 schemars = { version = "=0.8.12", features = ["chrono", "either", "enumset", "indexmap"] }
 semver = { version = "=1.0.17", features = ["serde"] }
 serde = { version = "=1.0.164", features = ["derive"] }

--- a/packages/nextclade-cli/Cargo.toml
+++ b/packages/nextclade-cli/Cargo.toml
@@ -41,7 +41,11 @@ pretty_assertions = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 rustls-platform-verifier = { workspace = true }
+rustls-pemfile = { workspace = true }
+rustls-pki-types = { workspace = true }
+rustls-webpki = { workspace = true }
 schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/packages/nextclade-cli/src/io/http_client.rs
+++ b/packages/nextclade-cli/src/io/http_client.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, ValueHint};
 use eyre::{Report, WrapErr};
 use log::info;
+use nextclade::io::file::open_file_or_stdin;
 use nextclade::make_internal_error;
 use nextclade::utils::info::{this_package_name, this_package_version_str};
 use reqwest::blocking::Client;
@@ -10,8 +11,6 @@ use rustls_pemfile;
 use rustls_pki_types::CertificateDer;
 use rustls_platform_verifier::Verifier;
 use std::env;
-use std::io::BufReader;
-use std::fs::File;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -128,12 +127,9 @@ impl HttpClient {
 fn extra_ca_certs<'a>() -> Result<impl IntoIterator<Item = CertificateDer<'a>>, Report> {
   match env::var_os("NEXTCLADE_EXTRA_CA_CERTS") {
     Some(filename) => {
-      let file = File::open(filename.clone())
-        .wrap_err_with(|| format!("When opening NEXTCLADE_EXTRA_CA_CERTS file {filename:?}"))?;
+      let mut file = open_file_or_stdin(&Some(filename))?;
 
-      let mut reader = BufReader::new(file);
-
-      let certs = rustls_pemfile::certs(&mut reader)
+      let certs = rustls_pemfile::certs(&mut file)
         .map(|c| c.wrap_err("When parsing an extra CA certificate"))
         .collect::<Result<Vec<_>, Report>>()?;
 

--- a/packages/nextclade-cli/src/io/http_client.rs
+++ b/packages/nextclade-cli/src/io/http_client.rs
@@ -134,7 +134,7 @@ fn extra_ca_certs<'a>() -> Result<impl IntoIterator<Item = CertificateDer<'a>>, 
       let mut reader = BufReader::new(file);
 
       let certs = rustls_pemfile::certs(&mut reader)
-        .map(|c| c.wrap_err_with(|| "When parsing an extra CA certificate".to_owned()))
+        .map(|c| c.wrap_err("When parsing an extra CA certificate"))
         .collect::<Result<Vec<_>, Report>>()?;
 
       Ok(certs)

--- a/packages/nextclade-cli/src/io/http_client.rs
+++ b/packages/nextclade-cli/src/io/http_client.rs
@@ -125,7 +125,7 @@ impl HttpClient {
   }
 }
 
-fn extra_ca_certs() -> Result<impl IntoIterator<Item = CertificateDer<'static>>, Report> {
+fn extra_ca_certs<'a>() -> Result<impl IntoIterator<Item = CertificateDer<'a>>, Report> {
   match env::var_os("NEXTCLADE_EXTRA_CA_CERTS") {
     Some(filename) => {
       let file = File::open(filename.clone())


### PR DESCRIPTION
Updated to [split](https://github.com/nextstrain/nextclade/pull/1527#issuecomment-2412444123) into two parts:

1. https://github.com/nextstrain/nextclade/pull/1529 to use the platform's certification verification, including system-level trust store
2. This PR to add support for configuration of extra CA certificates to trust.

---

_Previously_

See commit messages: 8816fe28692492f839a58b5e2b71022dd63955f8 and 40055050a8f7f621faa99744f4eb93461f08453c.

Motivated by having to write:

> There is currently no way to configure or modify the trust store without modifying the Nextclade source code.

in the recent [CA certificates doc](https://docs.nextstrain.org/en/latest/reference/ca-certificates.html#nextclade-cli) I wrote.