### PR TITLE
fix(ci): Upload all CLI build outputs

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -180,6 +180,7 @@ jobs:
         with:
           name: out-${{ matrix.arch }}
           path: ./.out/*
+          include-hidden-files: true
 
 
   run-unit-tests:


### PR DESCRIPTION
Include hidden files since our sole path pattern is a hidden "file". Apparently this counts even though the files the pattern matches aren't hidden.

GitHub made this big breaking change of excluding hidden files without bumping the major version number of actions/upload-artifact.¹  It, rightfully so, caused a ruckus at the time and continues to be a gift that keeps on giving.

The only other actions/upload-artifacts usage, in
.github/workflows/web.yml, seemingly isn't affected even though the path contains a hidden directory.  Perhaps because in that case there are a few more directory components after it?

¹ <https://github.com/actions/upload-artifact/releases/tag/v4.4.0>

Resolves: <https://github.com/nextstrain/nextclade/issues/1532>

