### PR TITLE
fix(dev): Use a buildx builder instance we control instead of the default

### DIFF
--- a/docker/dev
+++ b/docker/dev
@@ -430,7 +430,18 @@ if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER
   export -f docker_image_maybe_pull
   parallel docker_image_maybe_pull ::: "${images[@]}"
 
+  BUILDX_BUILDER=nextclade-builder
+
+  if ! docker buildx inspect "${BUILDX_BUILDER}" &>/dev/null; then
+      # Using a persistent builder allows for faster local development.
+      # However, if this is changed and it was previously run on your machine,
+      # you may need to remove the builder manually before running the script:
+      #     docker buildx rm "nextclade-builder"
+      docker buildx create --name "${BUILDX_BUILDER}" --driver docker-container --driver-opt network=host
+  fi
+
   ${NICE} docker buildx build \
+    --builder="${BUILDX_BUILDER}" \
     --file="docker/docker-dev.dockerfile" \
     --target="${DOCKER_TARGET}" \
     --tag="${DOCKER_REPO}:${DOCKER_TARGET}" \


### PR DESCRIPTION
We require the "docker-container" driver (via options we pass to `docker buildx build`, e.g. --cache-to) but the default builder instance may use the "docker" driver, leading to errors on dev machines like:

    ERROR: cache export feature is currently not supported for docker
    driver. Please switch to a different driver (eg. "docker buildx
    create --use")

Being explicit about our builder avoids that.

This same pattern is used in nextstrain/docker-base's devel/build.¹

¹ <https://github.com/nextstrain/docker-base/commit/fac834e5>
  <https://github.com/nextstrain/docker-base/blob/0acdc799/devel/build#L48-L56>

Related-to: <https://github.com/nextstrain/nextclade/pull/1529#issuecomment-2414459858>

