### PR TITLE
Revert "chore(deps): bump auspice from 2.59.1 to 2.60.0 in /packages/nextclade-web"

### DIFF
--- a/packages/nextclade-web/package.json
+++ b/packages/nextclade-web/package.json
@@ -90,7 +90,7 @@
     "@hapi/accept": "6.0.3",
     "@hapi/content": "6.0.0",
     "animate.css": "4.1.1",
-    "auspice": "2.60.0",
+    "auspice": "2.59.1",
     "autoprefixer": "10.4.5",
     "awesomplete": "1.1.5",
     "axios": "0.27.1",

--- a/packages/nextclade-web/yarn.lock
+++ b/packages/nextclade-web/yarn.lock
@@ -4608,10 +4608,10 @@ attr-accept@^2.2.2:
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
-auspice@2.60.0:
-  version "2.60.0"
-  resolved "https://registry.yarnpkg.com/auspice/-/auspice-2.60.0.tgz#6f282ab18f41b9fe97008e9cb73fa4a892db2bd0"
-  integrity sha512-2kzfVOiO3h4jjKUlF8vWhyty8UBUoWVP1ES3G65C3XN/0q9xVHHyBH5xHz7KXW4i5MuoUre8xPxVgm9L7+AOxQ==
+auspice@2.59.1:
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/auspice/-/auspice-2.59.1.tgz#f18479b17d09b9f1cf39ef6d19f44c7f4e974f79"
+  integrity sha512-JdfCQ2waAY/BPeIZ58tAUIYWwopY28FuQ3JjG+esa5fPbp5+Ovbx4rl6LqWCscohyojdxgJvJX4l8a1Av2b9ZA==
   dependencies:
     "@babel/core" "^7.3.4"
     "@babel/plugin-proposal-class-properties" "^7.3.4"


### PR DESCRIPTION
Reverts nextstrain/nextclade#1546

Downgrades Auspice for the time being, to unlock users who might be using master deployment.

https://github.com/nextstrain/nextclade/issues/1547#issuecomment-2470987006

https://github.com/nextstrain/auspice/issues/1895