### PR TITLE
fix: fetch custom input files as plaintext

### DIFF
--- a/packages/nextclade-web/src/io/axiosFetch.ts
+++ b/packages/nextclade-web/src/io/axiosFetch.ts
@@ -113,7 +113,13 @@ export async function axiosFetchOrUndefined<TData = unknown>(
  * This version skips any transforms (such as JSON parsing) and returns plain string
  */
 export async function axiosFetchRaw(url: string | undefined, options?: RequestConfig): Promise<string> {
-  return axiosFetch(url, { ...options, transformResponse: [] })
+  return axiosFetch(url, {
+    ...options,
+    transformResponse: [],
+    headers: {
+      Accept: 'text/plain, */*',
+    },
+  })
 }
 
 export async function axiosFetchRawMaybe(url?: string): Promise<string | undefined> {


### PR DESCRIPTION
Resolves #1565

Overrides default behavior of `axios` of adding header `Accept: application/json, text/plain, */*` when making `GET` HTTP requests. This caused problems when fetching customized inputs (sequences and dataset files)  from sources which allow to choose between different formats using `Accept` header - they would come in JSON format and this is not what we want. Now we preferentially fetch all inputs as plaintext, as intended.

