### PR TITLE
fix: ensure trailing newline is included when parsing GFF3 region

### DIFF
--- a/packages/nextclade/src/features/feature_tree.rs
+++ b/packages/nextclade/src/features/feature_tree.rs
@@ -76,7 +76,7 @@ fn read_gff3_feature_tree_str(content: impl AsRef<str>) -> Result<Vec<SequenceRe
       .tuple_windows()
       .map(|(content_begin, content_end)| {
         #[allow(clippy::string_slice)]
-        let content = &content[content_begin..content_end - 1];
+        let content = &content[content_begin..content_end];
         (content, content_begin, content_end)
       })
       .collect_vec()
@@ -88,8 +88,6 @@ fn read_gff3_feature_tree_str(content: impl AsRef<str>) -> Result<Vec<SequenceRe
     .into_iter()
     .enumerate()
     .map(|(index,(content, content_begin, _))| {
-      let content = content.trim();
-
       // Extract '##sequence-region' header line
       let header_line = content
         .lines()


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1572

When parsing GFF3, we split up the file on `#sequence-region` pragma blocks. As per specification, there could be multiple of them, and we want to know about this.

The `bio` crate's `GffReader` does not support regions, so we do the splitting manually and then pass each region's slice to `bio` `GffReader`. However, due to mistakenly trimmed trailing newlines in the regions on our side, `bio` GFF3 parser would fail when it encounters a commented line as a last line of the region. The error and repro is described in https://github.com/nextstrain/nextclade/issues/1572.

In this PR I:
 - [x] make sure that the region content string is properly extracted, including the trailing newline character
 - [x] remove `.trim()` call such that this newline isn't removed

This way `bio` can understand our GFF3 blocks even when they have comments.

