### PR TITLE
refactor: reduce duplication in read_one_fasta* family of function

### DIFF
--- a/packages/nextclade-cli/src/dataset/dataset_download.rs
+++ b/packages/nextclade-cli/src/dataset/dataset_download.rs
@@ -8,7 +8,7 @@ use log::{warn, LevelFilter};
 use nextclade::analyze::virus_properties::VirusProperties;
 use nextclade::gene::gene_map::{filter_gene_map, GeneMap};
 use nextclade::io::dataset::{Dataset, DatasetsIndexJson};
-use nextclade::io::fasta::{read_one_fasta, read_one_fasta_str};
+use nextclade::io::fasta::{read_one_fasta_from_file, read_one_fasta_from_str};
 use nextclade::io::file::create_file_or_stdout;
 use nextclade::io::fs::{ensure_dir, has_extension, read_file_to_string};
 use nextclade::run::nextclade_wasm::{NextcladeParams, NextcladeParamsOptional};
@@ -123,7 +123,7 @@ pub fn dataset_zip_load(
     .ok_or_else(|| eyre!("Pathogen JSON must always be present in the dataset but not found."))?;
 
   let ref_record = read_from_path_or_zip(&run_args.inputs.input_ref, &mut zip, &virus_properties.files.reference)?
-    .map_ref_fallible(read_one_fasta_str)
+    .map_ref_fallible(read_one_fasta_from_str)
     .wrap_err("When reading reference sequence from dataset")?
     .ok_or_else(|| eyre!("Reference sequence must always be present in the dataset but not found."))?;
 
@@ -254,7 +254,7 @@ pub fn dataset_dir_load(
     })
     .expect("Reference sequence is required but it is neither declared in the dataset's pathogen.json `.files` section, nor provided as a separate file");
 
-  let ref_record = read_one_fasta(input_ref).wrap_err("When reading reference sequence")?;
+  let ref_record = read_one_fasta_from_file(input_ref).wrap_err("When reading reference sequence")?;
 
   let gene_map = input_annotation
     .clone()
@@ -326,7 +326,7 @@ pub fn dataset_json_load(
       .wrap_err("When parsing pathogen JSON")?;
 
     let ref_record = input_ref
-      .map_ref_fallible(read_one_fasta)
+      .map_ref_fallible(read_one_fasta_from_file)
       .wrap_err("When parsing reference sequence")?;
 
     let tree = input_tree
@@ -370,7 +370,7 @@ pub fn dataset_individual_files_load(
         .wrap_err("When reading pathogen JSON")?
         .unwrap_or_default();
 
-      let ref_record = read_one_fasta(input_ref).wrap_err("When reading reference sequence")?;
+      let ref_record = read_one_fasta_from_file(input_ref).wrap_err("When reading reference sequence")?;
 
       let gene_map = run_args
         .inputs
@@ -445,7 +445,7 @@ pub fn dataset_str_download_and_load(
   .ok_or_else(|| eyre!("Required file not found in dataset: 'pathogen.json'. Please report it to dataset authors."))?;
 
   let ref_record = read_from_path_or_url(&http, &dataset, &run_args.inputs.input_ref, &dataset.files.reference)?
-    .map_ref_fallible(read_one_fasta_str)?
+    .map_ref_fallible(read_one_fasta_from_str)?
     .wrap_err("When reading reference sequence from dataset")?;
 
   let gene_map = read_from_path_or_url(

--- a/packages/nextclade-web/src/wasm/main.rs
+++ b/packages/nextclade-web/src/wasm/main.rs
@@ -2,7 +2,7 @@ use crate::wasm::jserr::jserr;
 use eyre::WrapErr;
 use itertools::Itertools;
 use nextclade::analyze::virus_properties::{AaMotifsDesc, PhenotypeAttrDesc};
-use nextclade::io::fasta::{read_one_fasta_str, FastaReader, FastaRecord};
+use nextclade::io::fasta::{read_one_fasta_from_str, FastaReader, FastaRecord};
 use nextclade::io::json::{json_parse, json_stringify, JsonPretty};
 use nextclade::io::nextclade_csv::{results_to_csv_string, CsvColumnConfig};
 use nextclade::io::results_json::{results_to_json_string, results_to_ndjson_string};
@@ -98,7 +98,7 @@ impl NextcladeWasm {
 
   /// Checks that a string containing ref sequence in FASTA format is correct
   pub fn parse_ref_seq_fasta(ref_seq_str: &str) -> Result<String, JsError> {
-    let record = jserr(read_one_fasta_str(ref_seq_str))?;
+    let record = jserr(read_one_fasta_from_str(ref_seq_str))?;
     jserr(json_stringify(&record, JsonPretty(false)))
   }
 

--- a/packages/nextclade/src/io/fasta.rs
+++ b/packages/nextclade/src/io/fasta.rs
@@ -5,7 +5,9 @@ use crate::io::compression::Decompressor;
 use crate::io::concat::Concat;
 use crate::io::file::{create_file_or_stdout, open_file_or_stdin, open_stdin};
 use crate::translate::translate_genes::CdsTranslation;
+use crate::utils::string::truncate_with_ellipsis;
 use crate::{make_error, make_internal_error};
+use color_eyre::{Section, SectionExt};
 use eyre::{Report, WrapErr};
 use log::{info, trace};
 use serde::{Deserialize, Serialize};
@@ -140,29 +142,13 @@ impl<'a> FastaReader<'a> {
   }
 }
 
-pub fn read_one_fasta(filepath: impl AsRef<Path>) -> Result<FastaRecord, Report> {
-  let filepath = filepath.as_ref();
-  let mut reader = FastaReader::from_path(filepath)?;
-  let mut record = FastaRecord::default();
-  reader.read(&mut record)?;
-  if record.is_empty() {
-    return make_error!("Expected exactly one FASTA record, but found none")
-      .wrap_err_with(|| format!("When reading file {filepath:?}"));
-  }
-  if record.seq.is_empty() {
-    return make_error!("Sequence is empty, but a non-empty sequence was expected")
-      .wrap_err_with(|| format!("When reading file {filepath:?}"));
-  }
-  Ok(record)
-}
-
 pub fn read_many_fasta<P: AsRef<Path>>(filepaths: &[P]) -> Result<Vec<FastaRecord>, Report> {
   let mut reader = FastaReader::from_paths(filepaths)?;
   let mut fasta_records = Vec::<FastaRecord>::new();
 
   loop {
     let mut record = FastaRecord::default();
-    reader.read(&mut record).unwrap();
+    reader.read(&mut record)?;
     if record.is_empty() {
       break;
     }
@@ -172,8 +158,26 @@ pub fn read_many_fasta<P: AsRef<Path>>(filepaths: &[P]) -> Result<Vec<FastaRecor
   Ok(fasta_records)
 }
 
-pub fn read_one_fasta_str(contents: impl AsRef<str>) -> Result<FastaRecord, Report> {
-  let mut reader = FastaReader::from_str(&contents)?;
+pub fn read_one_fasta_from_file(filepath: impl AsRef<Path>) -> Result<FastaRecord, Report> {
+  let filepath = filepath.as_ref();
+  let reader = FastaReader::from_path(filepath)?;
+  read_one_fasta_from_fasta_reader(reader).wrap_err_with(|| format!("When reading file {filepath:?}"))
+}
+
+pub fn read_one_fasta_from_str(contents: impl AsRef<str>) -> Result<FastaRecord, Report> {
+  let contents = contents.as_ref();
+  let reader = FastaReader::from_str(&contents)?;
+  read_one_fasta_from_fasta_reader(reader)
+    .wrap_err("When reading FASTA string")
+    .with_section(|| truncate_with_ellipsis(contents, 100).header("FASTA string was:"))
+}
+
+pub fn read_one_fasta_from_reader(reader: impl BufRead) -> Result<FastaRecord, Report> {
+  let reader = FastaReader::new(Box::new(reader));
+  read_one_fasta_from_fasta_reader(reader)
+}
+
+pub fn read_one_fasta_from_fasta_reader(mut reader: FastaReader) -> Result<FastaRecord, Report> {
   let mut record = FastaRecord::default();
   reader.read(&mut record)?;
   if record.is_empty() {

--- a/packages/nextclade/src/run/nextclade_wasm.rs
+++ b/packages/nextclade/src/run/nextclade_wasm.rs
@@ -9,7 +9,7 @@ use crate::analyze::phenotype::get_phenotype_attr_descs;
 use crate::analyze::virus_properties::{AaMotifsDesc, PhenotypeAttrDesc, VirusProperties};
 use crate::gene::gene_map::{filter_gene_map, GeneMap};
 use crate::graph::graph::Graph;
-use crate::io::fasta::{read_one_fasta_str, FastaRecord};
+use crate::io::fasta::{read_one_fasta_from_str, FastaRecord};
 use crate::io::nextclade_csv::CsvColumnConfig;
 use crate::io::nwk_writer::convert_graph_to_nwk_string;
 use crate::run::nextclade_run_one::nextclade_run_one;
@@ -120,7 +120,7 @@ impl NextcladeParams {
 
           let ref_record = raw
             .ref_seq
-            .map_ref_fallible(read_one_fasta_str)
+            .map_ref_fallible(read_one_fasta_from_str)
             .wrap_err("When parsing reference sequence")?;
 
           let tree = raw
@@ -153,7 +153,7 @@ impl NextcladeParams {
         let virus_properties =
           VirusProperties::from_str(&raw.virus_properties).wrap_err("When parsing pathogen JSON")?;
 
-        let ref_record = read_one_fasta_str(&raw.ref_seq).wrap_err("When parsing reference sequence")?;
+        let ref_record = read_one_fasta_from_str(&raw.ref_seq).wrap_err("When parsing reference sequence")?;
 
         let tree = raw
           .tree


### PR DESCRIPTION
While working on https://github.com/nextstrain/nextclade/pull/1583, I noticed there's a lot of code duplication in the `read_one_fasta*` family of functions. Let's refactor a bit.

FASTA parser, as one of the oldest parts of the codebase can use some more love in general.

