### PR TITLE
chore(ci): add gff validation of output query gff files to ci

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -298,6 +298,8 @@ jobs:
 
       - name: "Install dependencies"
         run: |
+          sudo apt-get install -yqq genometools
+
           mkdir -p "${HOME}/bin"
           export PATH="${HOME}/bin:${PATH}"
           curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64" -o ${HOME}/bin/jq && chmod +x ${HOME}/bin/jq
@@ -313,6 +315,10 @@ jobs:
         run: |
           chmod +x ./.out/*
           JOBS=2 ./tests/run-smoke-tests ./.out/nextclade-x86_64-unknown-linux-gnu
+
+      - name: "Validate output query GFF files (linux)"
+        run: |
+          ./scripts/validate-gff "tmp/smoke-tests/result/"
 
   #  run-smoke-tests-mac:
   #    name: "Run smoke tests (mac)"


### PR DESCRIPTION
Note: this PR targets branch `feat/qry-annotation` (https://github.com/nextstrain/nextclade/pull/1578), not `master`.

Let's validate gff files produced during smoke tests. Smoke tests run on all datasets, so we cover a decent variety of outputs and this can help to catch some bugs early.

The validation script [`./scrips/validate-gff`](https://github.com/nextstrain/nextclade/blob/8ca161c290aa02cad510fe83dfdd51c460f764f1/scripts/validate-gff) (introduced earlier) is based on [genometools](https://github.com/genometools/genometools).

Currently the warnings due to missing `##sequence-region` pragmas are silenced. We are working on introducing them into the output.


### How to run locally

Install genometools:

On Debian-based:
```bash
apt-get install genometools
```
otherwise from releases page https://github.com/genometools/genometools/releases

Then run
```bash
# Validate 1 file
./scripts/validate-gff "data/annotation.gff"

# Validate all .gff and .gff3 files in a directory, recursively
./scripts/validate-gff "data/"

# If you don't want to deal with the scripts, run the tool directly
gt gff3validator "data/annotation.gff"
```


