### PR TITLE
feat: use existing gene range if present in ref annotation

### DIFF
--- a/packages/nextclade/src/features/feature_group.rs
+++ b/packages/nextclade/src/features/feature_group.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use crate::coord::range::NucRefGlobalRange;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -92,6 +93,10 @@ impl FeatureGroup {
   #[inline]
   pub fn name_and_type(&self) -> String {
     format!("{} '{}'", shorten_feature_type(&self.feature_type), self.name)
+  }
+
+  pub fn range(&self) -> NucRefGlobalRange {
+    NucRefGlobalRange::new(self.start(), self.end())
   }
 
   #[must_use]

--- a/packages/nextclade/src/gene/auspice_annotations.rs
+++ b/packages/nextclade/src/gene/auspice_annotations.rs
@@ -53,6 +53,7 @@ pub fn convert_auspice_annotations_to_genes(anns: &AuspiceGenomeAnnotations) -> 
         index,
         id: gene_name.to_owned(),
         name: gene_name.to_owned(),
+        range: cds.range(),
         cdses: vec![cds],
         exceptions: vec![],
         attributes: IndexMap::default(),

--- a/packages/nextclade/src/gene/cds.rs
+++ b/packages/nextclade/src/gene/cds.rs
@@ -1,5 +1,5 @@
 use crate::coord::position::NucRefGlobalPosition;
-use crate::coord::range::{NucRefLocalRange, Range};
+use crate::coord::range::{NucRefGlobalRange, NucRefLocalRange, Range};
 use crate::features::feature::Feature;
 use crate::features::feature_group::FeatureGroup;
 use crate::gene::cds_segment::{CdsSegment, Truncation, WrappingPart};
@@ -191,6 +191,10 @@ impl Cds {
 
   pub fn name_and_type(&self) -> String {
     format!("CDS '{}'", self.name)
+  }
+
+  pub fn range(&self) -> NucRefGlobalRange {
+    NucRefGlobalRange::new(self.start(), self.end())
   }
 
   pub fn start(&self) -> NucRefGlobalPosition {

--- a/packages/nextclade/src/run/nextclade_run_one.rs
+++ b/packages/nextclade/src/run/nextclade_run_one.rs
@@ -526,6 +526,17 @@ pub fn calculate_qry_annotation(
       gene.attributes.insert(o!("product"), vec![gene.name.clone()]);
     }
 
+    // Take only the part of the gene range which is within the alignment range
+    let included_range = intersect(alignment_range, &gene.range);
+
+    // Convert included segment range from reference to query coordinates
+    let aln_range = coord_map_global.ref_to_qry_range(&included_range);
+    // HACK: the type of the range is incorrect here: GeneMap expects NucRefGlobalRange, i.e. range in reference
+    // coordinates, because it was initially designed for reference annotations only. Here we dangerously "cast"
+    // the NucAlnGlobalRange to the NucRefGlobalRange to satisfy this limitation.
+    // TODO: modify GeneMap class to allow for different range types, or just use plain range without subtyping.
+    gene.range = NucRefGlobalRange::from_range(aln_range);
+
     for cds in &mut gene.cdses {
       cds.attributes.extend(additional_attributes.clone());
 


### PR DESCRIPTION
This reuses gene start and end from ref annotation if they are present. Otherwise we calculate gene range as maximum extent of child CDSes.

In all cases ranges are clamped to alignment range an are transformed from reference to query coordinates.

