### PR TITLE
fix: allow truncation on both ends (enum version)

### DIFF
--- a/packages/nextclade/src/gene/cds_segment.rs
+++ b/packages/nextclade/src/gene/cds_segment.rs
@@ -32,6 +32,7 @@ pub enum Truncation {
   None,
   FivePrime(usize),
   ThreePrime(usize),
+  Both((usize, usize)),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]

--- a/packages/nextclade/src/gene/phase.rs
+++ b/packages/nextclade/src/gene/phase.rs
@@ -35,9 +35,8 @@ impl Phase {
     }
   }
 
-  pub fn shifted_by<P: PositionLike>(self, amount: P) -> Result<Phase, Report> {
+  pub fn shifted_by(self, amount: usize) -> Result<Phase, Report> {
     let original_phase = self.to_usize();
-    let amount = amount.as_usize();
     let begin = NucRefLocalPosition::from(original_phase + amount);
     Phase::from_begin(begin)
   }

--- a/packages/nextclade/src/io/genbank_tbl.rs
+++ b/packages/nextclade/src/io/genbank_tbl.rs
@@ -93,15 +93,12 @@ impl<W: Write + Send> GenbankTblWriter<W> {
 
       // If there is a truncation on 5' or 3' end, prefix the start/end position with "<" or ">",
       // as an incomplete feature
-      match seg.truncation {
-        Truncation::FivePrime(_) => {
-          start = format!("<{start}");
-        }
-        Truncation::ThreePrime(_) => {
-          end = format!(">{end}");
-        }
-        Truncation::None => {}
-      };
+      if matches!(seg.truncation, Truncation::FivePrime(_) | Truncation::Both(_)) {
+        start = format!("<{start}");
+      }
+      if matches!(seg.truncation, Truncation::ThreePrime(_) | Truncation::Both(_)) {
+        end = format!(">{end}");
+      }
 
       // Write a line with feature's boundaries and feature's kind
       // Example:


### PR DESCRIPTION
Compared to bitflags:

Advantages:
 - allows to store truncation amount
 - requires no custom (de-)serialization code

Disadvantages:
 - main logic is slightly more complex

