### PR TITLE
fix(web): crash when no query annotation is calculated

### DIFF
--- a/packages/nextclade/src/types/outputs.rs
+++ b/packages/nextclade/src/types/outputs.rs
@@ -107,7 +107,7 @@ pub struct NextcladeOutputs {
   pub aa_motifs: AaMotifsMap,
   pub aa_motifs_changes: AaMotifsChangesMap,
 
-  #[serde(skip_serializing_if = "GeneMap::is_empty")]
+  #[serde(default, skip_serializing_if = "GeneMap::is_empty")]
   pub annotation: GeneMap,
 }
 


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1601

For samples which, after analysis, end up with in an empty query annotation (corresponding to an empty object of struct type`GeneMap`) the field `annotation` gets omitted from the output of `serde_json` as programmed. However, because the field is not optional (it's `GeneMap`, not `Option<GeneMap>`), `serde_json` fails to deserialize such output later.

Here I add attribute `#serde(default)` to the `annotation` field, such that a missing field gets deserialized into a default (empty) `GeneMap` object.

Perhaps it would be better to make the field optional, but I am hesitating, to not accidentally introduce a breaking change. Also it will require a bunch of null-checks everywhere this field is used at. Another solution is to output the object always during serialization, even if empty.

