### PR TITLE
ci: Add PR previews via Github action

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -102,6 +102,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
+      - name: "Set PR_NUMBER for preview builds"
+        if: github.event_name == 'pull_request'
+        run: echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
       - name: "Get docker build checksum"
         id: docker-build-checksum
         run: echo "checksum=$(./scripts/docker_build_checksum.sh)" >> $GITHUB_OUTPUT
@@ -148,6 +152,7 @@ jobs:
           cp .env.example .env
           sed -i -e "s|FULL_DOMAIN=autodetect|FULL_DOMAIN=${FULL_DOMAIN}|g" .env
           sed -i -e "s|DATA_FULL_DOMAIN=https://data.master.clades.nextstrain.org/v3|DATA_FULL_DOMAIN=${DATA_FULL_DOMAIN}|g" .env
+          if [ -n "${PR_NUMBER:-}" ]; then echo "PR_NUMBER=${PR_NUMBER}" >> .env; fi
 
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
@@ -269,3 +274,25 @@ jobs:
 
           git tag "web-${version}"
           git push origin "web-${version}"
+
+  deploy-preview:
+    name: "Deploy PR Preview"
+    if: github.event_name == 'pull_request'
+    needs: [ build-web ]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Download build artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: "out" # Must match the artifact name from build-web
+          path: "preview-build"
+      - name: "Deploy PR Preview to GitHub Pages"
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: "preview-build" # Must match path from download-artifact
+          preview-branch: "gh-pages"

--- a/packages/nextclade-web/config/next/next.config.ts
+++ b/packages/nextclade-web/config/next/next.config.ts
@@ -66,7 +66,13 @@ const clientEnv = {
   BLOCK_SEARCH_INDEXING: DOMAIN === RELEASE_URL ? '0' : '1',
 }
 
+const { PR_NUMBER } = process.env
+const previewNumber = PR_NUMBER
+const basePath = previewNumber ? `/nextclade/pr-preview/pr-${previewNumber}` : ''
+const assetPrefix = basePath || undefined
 const nextConfig: NextConfig = {
+  basePath,
+  assetPrefix,
   distDir: `.build/${process.env.NODE_ENV}/tmp`,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx', 'all-contributorsrc'],
   onDemandEntries: {


### PR DESCRIPTION
To make this work, we'd need to:
- allowlist `rossjrw/pr-preview-action@v1` for nextstrain org
- Add `.nojekyll` to root of `gh-pages` branch
- Enable serving Github pages from `gh-pages` branch