### PR TITLE
fix: prevent crash when deducing strand of an empty gene

### DIFF
--- a/packages/nextclade/src/gene/gene.rs
+++ b/packages/nextclade/src/gene/gene.rs
@@ -179,6 +179,9 @@ impl Gene {
   }
 
   pub fn strand(&self) -> Result<GeneStrand, Report> {
+    if self.cdses.is_empty() {
+      return Ok(GeneStrand::Forward);
+    }
     try_single_unique_value(&self.cdses, Cds::strand)
   }
 }


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1613

When a query sequence ends up with an empty gene (e.g. entire gene falls to a region which hasn't been sequenced), this results in an empty gene when calculating the output annotation. The affected code crashes in this case, because it cannot find any strand values in CDSes, because there are no CDSes.

Let's handle this case by assuming that empty genes have forward strandedness. They are filtered away later anyways, so this should not affect anything.

