### PR TITLE
feat(web): add download svg button on tree page

### DIFF
--- a/packages/nextclade-web/src/components/Tree/ButtonSvg.tsx
+++ b/packages/nextclade-web/src/components/Tree/ButtonSvg.tsx
@@ -1,0 +1,67 @@
+import { AuspiceState } from 'auspice'
+import React, { useCallback, useMemo } from 'react'
+import { FaDownload } from 'react-icons/fa'
+import { useDispatch, useSelector } from 'react-redux'
+import { publications } from 'auspice/src/components/download/downloadModal'
+import { SVG } from 'auspice/src/components/download/helperFunctions'
+import { ButtonTransparent } from 'src/components/Common/ButtonTransparent'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import styled from 'styled-components'
+
+export function ButtonSvg() {
+  const { t } = useTranslationSafe()
+
+  const colorBy = useSelector((state: AuspiceState) => state.controls?.colorBy)
+  const metadata = useSelector((state: AuspiceState) => state.metadata)
+  const nodes = useSelector((state: AuspiceState) => state.tree?.nodes)
+  const visibility = useSelector((state: AuspiceState) => state.tree?.visibility)
+  const panelsToDisplay = useSelector((state: AuspiceState) => state.controls?.panelsToDisplay)
+  const panelLayout = useSelector((state: AuspiceState) => state.controls?.panelLayout)
+
+  const dispatch = useDispatch()
+
+  const relevantPublications = useMemo(() => {
+    const relevantPublications = [
+      {
+        author: 'Aksamentov et al.',
+        title: 'Nextclade: clade assignment, mutation calling and quality control for viral genomes',
+        year: '2021',
+        journal: 'Journal of Open Source Software, 6(67), 3773',
+        href: 'https://doi.org/10.21105/joss.03773',
+      },
+      publications.nextstrain,
+      publications.treetime,
+    ]
+    if (['cTiter', 'rb', 'ep', 'ne'].some((x) => !!colorBy?.includes(x))) {
+      relevantPublications.push(publications.titers)
+    }
+    return relevantPublications
+  }, [colorBy])
+
+  const onClick = useCallback(
+    () =>
+      SVG(dispatch, t, metadata, nodes, visibility, 'nextclade', panelsToDisplay, panelLayout, relevantPublications),
+    [dispatch, metadata, nodes, panelLayout, panelsToDisplay, relevantPublications, t, visibility],
+  )
+
+  return (
+    <SvgButton onClick={onClick} title={t('Download a screenshot of the current page in SVG format')}>
+      <SvgButtonContent>
+        <FaDownload fill="#aaa" />
+        <span className="pl-1">{t('SVG')}</span>
+      </SvgButtonContent>
+    </SvgButton>
+  )
+}
+
+const SvgButton = styled(ButtonTransparent)`
+  height: 16px;
+  margin: auto 0.5rem;
+  margin-right: 22px;
+`
+
+const SvgButtonContent = styled.div`
+  display: flex;
+  align-items: center;
+  color: #aaa;
+`

--- a/packages/nextclade-web/src/components/Tree/Tree.tsx
+++ b/packages/nextclade-web/src/components/Tree/Tree.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
-
 import styled from 'styled-components'
 import AutoSizer from 'react-virtualized-auto-sizer'
-
-import AuspiceTree from 'auspice/src/components/tree'
 import AuspiceEntropy from 'auspice/src/components/entropy'
+import AuspiceTree from 'auspice/src/components/tree'
 
 // HACK: For some reason, auspice tree requests space larger than the width and height passed into it.
 //  So we pretend the container is smaller, by multiplying by this numbers.

--- a/packages/nextclade-web/src/components/Tree/TreePageContent.tsx
+++ b/packages/nextclade-web/src/components/Tree/TreePageContent.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil'
 import { Provider as ReactReduxProvider, useSelector } from 'react-redux'
 import { I18nextProvider } from 'react-i18next'
 import { Store } from 'redux'
+import { ButtonSvg } from 'src/components/Tree/ButtonSvg'
 import styled, { ThemeProvider } from 'styled-components'
 import type { AuspiceState } from 'auspice'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
@@ -131,6 +132,7 @@ export default function TreePageContent() {
                   <FiltersSummary />
                 </FiltersSummaryWrapper>
                 <GisaidLogoWidget />
+                <ButtonSvg />
               </TreeTopPanel>
               <Tree />
             </TreeContainer>

--- a/packages/nextclade-web/src/types/auspice/src/components/download/downloadModal.d.ts
+++ b/packages/nextclade-web/src/types/auspice/src/components/download/downloadModal.d.ts
@@ -1,0 +1,18 @@
+declare module 'auspice/src/components/download/downloadModal' {
+  export interface Publication {
+    author: string
+    title: string
+    year: string
+    journal: string
+    href: string
+  }
+
+  export interface Publications {
+    nextstrain: Publication
+    treetime: Publication
+    titers: Publication
+    [k: string]: Publication
+  }
+
+  export const publications: Publications
+}

--- a/packages/nextclade-web/src/types/auspice/src/components/download/helperFunctions.d.ts
+++ b/packages/nextclade-web/src/types/auspice/src/components/download/helperFunctions.d.ts
@@ -1,0 +1,15 @@
+declare module 'auspice/src/components/download/helperFunctions' {
+  import type { Publication } from 'auspice/src/components/download/downloadModal'
+
+  export function SVG(
+    dispatch: unknown,
+    t: unknown,
+    metadata: unknown,
+    nodes: unknown,
+    visibility: unknown,
+    filePrefix: unknown,
+    panelsInDOM: unknown,
+    panelLayout: unknown,
+    publications: Publication[],
+  ): void
+}


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1268

This uses existing "SVG screenshot" functionality from Auspice's "Download data" dialog box.

The entire dialog box content is not necessarily relevant and working (it seems to be assuming metadata, charon server etc.), but this particular SVG functionality is useful and I thought I just add it as a separate button in the top right corner of the page.

![screenshot](https://github.com/user-attachments/assets/362b816f-be55-4175-8011-3e52336d3392)

