### PR TITLE
fix(web): initialize and autorun only once at a time

### DIFF
--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -172,7 +172,7 @@ function RecoilStateInitializer() {
         snapShotRelease()
       })
     },
-    [initialized, run, setInitialized, urlQuery],
+    [initialized, run, setInitialized, suggest, urlQuery],
   )
 
   useEffect(() => {


### PR DESCRIPTION
resolves #989

note: Prettier gave me a massive diff so I had to disable it to keep it reviewable (and show how small the changes are)

We were running the initialization code on each render, so we ended up auto-running the analysis multiple times.

`run()` seems to have been the only stateful part of the initialization function, that's why we didn't really have any issues except for the autorun duplication bug

preview: https://corneliusroemer.github.io/nextclade/pr-preview/pr-5

preview doing autorun: https://corneliusroemer.github.io/nextclade/pr-preview/pr-5?dataset=mpox&input-fasta=https%3A%2F%2Flapis.pathoplexus.org%2Fmpox%2Fsample%2FunalignedNucleotideSequences%3FdownloadAsFile%3Dtrue%26downloadFileBasename%3Dmpox_nuc_2025-05-13T1648%26dataUseTerms%3DOPEN%26dataFormat%3Dfasta%26versionStatus%3DLATEST_VERSION%26isRevocation%3Dfalse%26lengthTo%3D300
