### PR TITLE
chore(ci): mirror missing musl gcc binaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 # produce it. Refer to osxcross documentation for more info.
 # This is only needed if you are on Linux and want to produce binaries for macOS.
 OSXCROSS_URL=http://example.com/osxcross/osxcross.tar.xz
+MUSL_CC_AARCH64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz
+MUSL_CC_X86_64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz
 
 FULL_DOMAIN=autodetect
 

--- a/.github/workflows/builder-docker-image.yml
+++ b/.github/workflows/builder-docker-image.yml
@@ -61,4 +61,6 @@ jobs:
         run: |
           cp .env.example .env
           sed -i -e "s|OSXCROSS_URL=http://example.com/osxcross/osxcross.tar.xz|OSXCROSS_URL=${{ secrets.OSXCROSS_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_AARCH64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz|MUSL_CC_AARCH64_URL=${{ secrets.MUSL_CC_AARCH64_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_X86_64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz|MUSL_CC_X86_64_URL=${{ secrets.MUSL_CC_X86_64_URL }}|g" .env
           ./docker/dev docker-image-build-push

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -158,6 +158,8 @@ jobs:
 
           cp .env.example .env
           sed -i -e "s|OSXCROSS_URL=http://example.com/osxcross/osxcross.tar.xz|OSXCROSS_URL=${{ secrets.OSXCROSS_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_AARCH64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz|MUSL_CC_AARCH64_URL=${{ secrets.MUSL_CC_AARCH64_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_X86_64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz|MUSL_CC_X86_64_URL=${{ secrets.MUSL_CC_X86_64_URL }}|g" .env
           sed -i -e "s|DATA_FULL_DOMAIN=https://data.master.clades.nextstrain.org/v3|DATA_FULL_DOMAIN=${DATA_FULL_DOMAIN}|g" .env
 
       - name: "Login to Docker Hub"
@@ -226,6 +228,8 @@ jobs:
         run: |
           cp .env.example .env
           sed -i -e "s|OSXCROSS_URL=http://example.com/osxcross/osxcross.tar.xz|OSXCROSS_URL=${{ secrets.OSXCROSS_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_AARCH64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz|MUSL_CC_AARCH64_URL=${{ secrets.MUSL_CC_AARCH64_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_X86_64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz|MUSL_CC_X86_64_URL=${{ secrets.MUSL_CC_X86_64_URL }}|g" .env
 
       - name: "Run unit tests"
         run: |
@@ -275,6 +279,8 @@ jobs:
         run: |
           cp .env.example .env
           sed -i -e "s|OSXCROSS_URL=http://example.com/osxcross/osxcross.tar.xz|OSXCROSS_URL=${{ secrets.OSXCROSS_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_AARCH64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz|MUSL_CC_AARCH64_URL=${{ secrets.MUSL_CC_AARCH64_URL }}|g" .env
+          sed -i -e "s|MUSL_CC_X86_64_URL=http://example.com/musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz|MUSL_CC_X86_64_URL=${{ secrets.MUSL_CC_X86_64_URL }}|g" .env
 
       - name: "Run lints"
         run: |

--- a/docker/dev
+++ b/docker/dev
@@ -405,6 +405,16 @@ if ! docker inspect --format '{{.Id}}' "${DOCKER_REPO}:${DOCKER_TARGET}-${DOCKER
     ADDITIONAL_DOCKER_BUILD_ARGS="--build-arg OSXCROSS_URL=${OSXCROSS_URL}"
   fi
 
+  if [[ "${DOCKER_TARGET}" == *aarch64-unknown-linux-musl* ]]; then
+    # shellcheck disable=SC2089
+    ADDITIONAL_DOCKER_BUILD_ARGS="--build-arg MUSL_CC_AARCH64_URL=${MUSL_CC_AARCH64_URL}"
+  fi
+
+  if [[ "${DOCKER_TARGET}" == *x86_64-unknown-linux-musl* ]]; then
+    # shellcheck disable=SC2089
+    ADDITIONAL_DOCKER_BUILD_ARGS="--build-arg MUSL_CC_X86_64_URL=${MUSL_CC_X86_64_URL}"
+  fi
+
   if [ "${DOCKER_IMAGE_PUSH}" == "1" ]; then
     ADDITIONAL_DOCKER_BUILD_ARGS="${ADDITIONAL_DOCKER_BUILD_ARGS} --push"
   else

--- a/docker/docker-dev.dockerfile
+++ b/docker/docker-dev.dockerfile
@@ -303,12 +303,15 @@ ENV CXX_x86_64-unknown-linux-gnu=g++
 # Cross-compilation for Linux x86_64 with libmusl
 FROM base as cross-x86_64-unknown-linux-musl
 
+ARG MUSL_CC_X86_64_URL
+ENV MUSL_CC_X86_64_URL="${MUSL_CC_X86_64_URL}"
+
 USER 0
 
 SHELL ["bash", "-euxo", "pipefail", "-c"]
 
 RUN set -euxo pipefail >/dev/null \
-&& curl -fsSL "https://more.musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz" | tar -C "/usr" -xz --strip-components=1
+&& curl -fsSL "${MUSL_CC_X86_64_URL}" | tar -C "/usr" -xz --strip-components=1
 
 USER ${UID}
 
@@ -363,12 +366,15 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 # Cross-compilation for Linux ARM64 with libmusl
 FROM base as cross-aarch64-unknown-linux-musl
 
+ARG MUSL_CC_AARCH64_URL
+ENV MUSL_CC_AARCH64_URL=${MUSL_CC_AARCH64_URL}
+
 USER 0
 
 SHELL ["bash", "-euxo", "pipefail", "-c"]
 
 RUN set -euxo pipefail >/dev/null \
-&& curl -fsSL "https://more.musl.cc/11/x86_64-linux-musl/aarch64-linux-musl-cross.tgz" | tar -C "/usr" -xz --strip-components=1
+&& curl -fsSL "${MUSL_CC_AARCH64_URL}" | tar -C "/usr" -xz --strip-components=1
 
 USER ${UID}
 


### PR DESCRIPTION
[musl.cc](https://musl.cc) no longer allows using their binaries from GitHub Actions. Quote from the website:

> 2025-05-27: GitHub Actions has been blocked wholesale due to [abuse similar to this](https://github.com/orgs/community/discussions/27906#discussioncomment-3332440)

Let's self-host them on S3. These GitHub secrets will contain urls:
```
MUSL_CC_AARCH64_URL
MUSL_CC_X86_64_URL
```

