### PR TITLE
fix(web): workaround double init by forcing the effect to run only once

### DIFF
--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -167,7 +167,12 @@ function RecoilStateInitializer() {
 
   useEffect(() => {
     initialize()
-  })
+
+    // HACK: empty deps array means that this effect will run only once. This is to mitigate the issue with
+    // double (triple, ..., N-tuple) initialization of the app and associated redundant multiple data
+    // fetches, automatic worker launches and data races.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   if (!initialized && !isNil(error)) {
     throw error


### PR DESCRIPTION
Resolves #989
Resolves #1634 
Resolves #1636

Related #1619

HACK: this does not solve the actual problem of double render/init/auto-run, but hides it to avoid problems with redundant network requests (results of whose are not guaranteed to be repeatable or ordered as mentioned in #1636), launching multiple workers unnecessarily and associated data races.

The mitigation here relies on `useEffect()` call with an empty dependency array, which is guaranteed to run only once per component mount, if my understanding is correct. And I believe (although cannot find proofs in the docs) that Next.js app component only ever mounts once per app load.

The actual solution might need to be worked on more thoroughly. One possible action plan is described [here](https://github.com/nextstrain/nextclade/pull/1619#issuecomment-2916761726).

This change here is easy to toggle on and off (for further debugging) by removing the said empty array.

Let's see how it goes.

