### PR TITLE
fix: improve dataset suggestions and sorting for short references

### DIFF
--- a/packages/nextclade/src/sort/minimizer_search.rs
+++ b/packages/nextclade/src/sort/minimizer_search.rs
@@ -61,11 +61,11 @@ pub fn run_minimizer_search(
   for i in 0..n_refs {
     let reff = &index.references[i];
 
-    let ref_hits = hit_counts[i] as f64;
-    let qry_hits = reff.n_minimizers as f64;
+    let qry_hits = hit_counts[i] as f64;
+    let ref_minimizers = reff.n_minimizers as f64;
     let ref_len = reff.length as f64;
     let qry_len = fasta_record.seq.len() as f64;
-    scores[i] = (ref_hits / qry_hits) * (ref_len / qry_len).max(1.0);
+    scores[i] = (qry_hits / ref_minimizers) * (ref_len / qry_len).max(1.0);
   }
 
   let max_score = scores.iter().copied().fold(0.0, f64::max);


### PR DESCRIPTION
Updates minimizer-based scoring to better handle cases where the reference sequence is much shorter than the query sequence. The previous approach assumed full-genome references and could underestimate scores for partial references such as single genes. The revised method adjusts the normalization to avoid penalizing such cases, improving robustness without requiring changes to the index format.  This resolves issues observed in datasets like yellow fever.

Context on Slack:

https://neherlab.slack.com/archives/C015PFP5V44/p1746199454048499?thread_ts=1746018281.390139&cid=C015PFP5V44

https://neherlab.slack.com/archives/C015PFP5V44/p1746201515676919

