### PR TITLE
fix: error with `?multi-dataset` URL param

### DIFF
--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -143,8 +143,10 @@ function RecoilStateInitializer() {
         if (!isEmpty(inputFastas)) {
           set(qrySeqInputsStorageAtom, inputFastas)
           if (isMultiDataset) {
-            await suggest()
-            run({ isSingle: false })
+            const suggestionResults = await suggest()
+            if (suggestionResults && !isEmpty(suggestionResults.suggestions)) {
+              run({ isSingle: false })
+            }
           } else if (!isEmpty(dataset)) {
             run({ isSingle: true })
           }


### PR DESCRIPTION
Reported on Slack:
https://neherlab.slack.com/archives/C015PFP5V44/p1748977753734039


This fixes problems in app init logic when using `?multi-dataset` URL param:
- The data race in `useRunSeqAutodetect()`: `datasetServerUrl` was obtained outside of the `userRecoilCallback`but used asynchronously in its body, with a stale value potentially. Now it's read inside the callback.
- If suggestion run resulted in no datasets detected, it would still proceed to the analysis run, which it should not. Now it checks whether results are empty before proceeding.



