### PR TITLE
fix: calculate seed cover correctly when query is shorter than reference

### DIFF
--- a/packages/nextclade/src/align/seed_match.rs
+++ b/packages/nextclade/src/align/seed_match.rs
@@ -481,14 +481,15 @@ pub fn get_seed_matches2(
   // write_matches_to_file(&seed_matches, "chained_matches.csv");
 
   let sum_of_seed_length: usize = seed_matches.iter().map(|sm| sm.length).sum();
-  if (sum_of_seed_length as f64 / qry_seq.len() as f64) < *params.min_seed_cover {
-    let query_knowns = qry_seq.iter().filter(|n| n.is_acgt()).count();
-    if (sum_of_seed_length as f64 / query_knowns as f64) < *params.min_seed_cover {
+  let max_seed_cover = qry_seq.len().min(ref_seq.len()) as f64;
+  if (sum_of_seed_length as f64 / max_seed_cover) < *params.min_seed_cover {
+    let max_known_seed_cover = qry_seq.iter().filter(|n| n.is_acgt()).count().min(ref_seq.len()) as f64;
+    if (sum_of_seed_length as f64 / max_known_seed_cover) < *params.min_seed_cover {
       return make_error!(
         "Unable to align: seed alignment covers {:.2}% of the query sequence, which is less than expected {:.2}% \
         (configurable using 'min seed cover' CLI flag or dataset property). This is likely due to low quality of the \
         provided sequence, or due to using incorrect reference sequence.",
-        100.0 * (sum_of_seed_length as f64) / (query_knowns as f64),
+        100.0 * (sum_of_seed_length as f64) / (max_known_seed_cover),
         100.0 * *params.min_seed_cover
       );
     }


### PR DESCRIPTION
the seed matching algorithm requires that a certain fraction of the query sequences is covered by seed matches. When the reference is shorter than the query sequence, the fraction that can be covered by seed matches is limited by the length of the reference sequence. Here we change the calculation of the fraction covered by seeds to the fraction of the sum of all seed length and minimum of qry and ref length. This won't change the behavior for datasets where the reference is complete, but results in the intended behavior when partial sequences are used as references. Previously, dataset maintainers had to set the min_seed_cover to unreasonably low values in cases the reference was much short than the queries.

