### PR TITLE
fix: show "Has PCR primer changes" coloring only when primers exist

### DIFF
--- a/packages/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -25,7 +25,7 @@ pub fn create_new_auspice_node(
     result.alignment_range.begin, result.alignment_range.end, result.alignment_score
   );
 
-  let (has_pcr_primer_changes, pcr_primer_changes) = if result.total_pcr_primer_changes > 0 {
+  let (has_pcr_primer_changes, pcr_primer_changes) = if result.total_pcr_primer_changes == 0 {
     (Some(TreeNodeAttr::new("No")), None)
   } else {
     (

--- a/packages/nextclade/src/tree/tree_builder.rs
+++ b/packages/nextclade/src/tree/tree_builder.rs
@@ -43,7 +43,8 @@ pub fn graph_attach_new_nodes_in_place(
 
   graph.ladderize().wrap_err("When ladderizing the resulting tree")?;
 
-  add_auspice_metadata_in_place(&mut graph.data.meta);
+  let has_pcr_primers = results.iter().any(|result| !result.pcr_primer_changes.is_empty());
+  add_auspice_metadata_in_place(&mut graph.data.meta, has_pcr_primers);
 
   Ok(())
 }

--- a/packages/nextclade/src/tree/tree_preprocess.rs
+++ b/packages/nextclade/src/tree/tree_preprocess.rs
@@ -245,8 +245,8 @@ fn pair(key: &str, val: &str) -> [String; 2] {
   [key.to_owned(), val.to_owned()]
 }
 
-pub fn add_auspice_metadata_in_place(meta: &mut AuspiceTreeMeta) {
-  let new_colorings: Vec<AuspiceColoring> = vec![
+pub fn add_auspice_metadata_in_place(meta: &mut AuspiceTreeMeta, has_pcr_primers: bool) {
+  let mut new_colorings: Vec<AuspiceColoring> = vec![
     AuspiceColoring {
       key: "Node type".to_owned(),
       title: "Node type".to_owned(),
@@ -265,14 +265,17 @@ pub fn add_auspice_metadata_in_place(meta: &mut AuspiceTreeMeta) {
       ],
       other: serde_json::Value::default(),
     },
-    AuspiceColoring {
+  ];
+
+  if has_pcr_primers {
+    new_colorings.push(AuspiceColoring {
       key: "Has PCR primer changes".to_owned(),
       title: "Has PCR primer changes".to_owned(),
       type_: "categorical".to_owned(),
       scale: vec![pair("Yes", "#6961ff"), pair("No", "#999999")],
       other: serde_json::Value::default(),
-    },
-  ];
+    });
+  }
 
   meta.colorings = concat_to_vec(&new_colorings, &meta.colorings);
 
@@ -292,12 +295,13 @@ pub fn add_auspice_metadata_in_place(meta: &mut AuspiceTreeMeta) {
 
   meta.panels = vec!["tree".to_owned(), "entropy".to_owned()];
 
-  let new_filters = vec![
+  let mut new_filters = vec![
     "clade_membership".to_owned(),
     "Node type".to_owned(),
     "QC Status".to_owned(),
-    "Has PCR primer changes".to_owned(),
   ];
+
+  new_filters.push("Has PCR primer changes".to_owned());
 
   meta.filters = concat_to_vec(&new_filters, &meta.filters);
 


### PR DESCRIPTION
Reported on Slack: https://neherlab.slack.com/archives/C015PFP5V44/p1749132912576769

"Has PCR primer changes" coloring and values "Has PCR primer changes": "Yes", appear on the output tree, erroneously, when neither PCR primers provided, nor matches are detected.

In this PR I:
 - only add coloring and filter for "Has PCR primer changes" if any primer results actually exist after analysis
 - fix a bug where "Yes" and "No" values for "Has PCR primer changes" node attribute were actually swapped erroneously

This should remove "Has PCR primer changes" coloring in auspice interface in most cases (I don't think we use PCR primers in any datasets nowadays).
