### PR TITLE
fix: country colorings in output tree json

### DIFF
--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -15,16 +15,12 @@ use eyre::{eyre, Report, WrapErr};
 use log::warn;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::slice::Iter;
-use serde_json::json;
 use traversal::{Bft, DftPost, DftPre};
 use validator::Validate;
-
-// HACK: keep space at the end: workaround for Auspice filtering out "Unknown"
-// https://github.com/nextstrain/auspice/blob/797090f8092ffe1291b58efd113d2c5def8b092a/src/util/globals.js#L182
-pub const AUSPICE_UNKNOWN_VALUE: &str = "Unknown ";
 
 #[derive(Clone, schemars::JsonSchema, Validate, Debug)]
 pub struct AuspiceGraphEdgePayload; // Edge payload is empty. Branch attributes are currently stored on nodes.

--- a/packages/nextclade/src/tree/tree_attach_new_nodes.rs
+++ b/packages/nextclade/src/tree/tree_attach_new_nodes.rs
@@ -4,7 +4,6 @@ use crate::io::nextclade_csv_row::{
 };
 use crate::tree::tree::{
   AuspiceGraphNodePayload, TreeBranchAttrs, TreeBranchAttrsLabels, TreeNodeAttr, TreeNodeAttrs, TreeNodeTempData,
-  AUSPICE_UNKNOWN_VALUE,
 };
 use crate::tree::tree_builder::{
   convert_private_mutations_to_node_branch_attrs, convert_private_mutations_to_node_branch_attrs_aa_labels,
@@ -70,9 +69,9 @@ pub fn create_new_auspice_node(
       div: Some(new_divergence),
       clade_membership: result.clade.as_ref().map(|clade| TreeNodeAttr::new(clade)),
       node_type: Some(TreeNodeAttr::new("New")),
-      region: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
-      country: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
-      division: Some(TreeNodeAttr::new(AUSPICE_UNKNOWN_VALUE)),
+      region: None,
+      country: None,
+      division: None,
       placement_prior: None,
       alignment: Some(TreeNodeAttr::new(&alignment)),
       missing: Some(TreeNodeAttr::new(&format_missings(&result.missing, ", "))),

--- a/packages/nextclade/src/tree/tree_preprocess.rs
+++ b/packages/nextclade/src/tree/tree_preprocess.rs
@@ -9,9 +9,7 @@ use crate::coord::position::{AaRefPosition, NucRefGlobalPosition, PositionLike};
 use crate::graph::node::GraphNodeKey;
 use crate::make_error;
 use crate::translate::translate_genes::Translation;
-use crate::tree::tree::{
-  AuspiceColoring, AuspiceGraph, AuspiceGraphNodePayload, AuspiceTreeMeta, AUSPICE_UNKNOWN_VALUE,
-};
+use crate::tree::tree::{AuspiceColoring, AuspiceGraph, AuspiceGraphNodePayload, AuspiceTreeMeta};
 use crate::utils::collections::concat_to_vec;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
@@ -278,16 +276,6 @@ pub fn add_auspice_metadata_in_place(meta: &mut AuspiceTreeMeta, has_pcr_primers
   }
 
   meta.colorings = concat_to_vec(&new_colorings, &meta.colorings);
-
-  meta.colorings.iter_mut().for_each(|coloring| {
-    let key: &str = &coloring.key;
-    match key {
-      "region" | "country" | "division" => {
-        coloring.scale = concat_to_vec(&[pair(AUSPICE_UNKNOWN_VALUE, "#999999")], &coloring.scale);
-      }
-      _ => {}
-    }
-  });
 
   meta.display_defaults.branch_label = Some("clade".to_owned());
   meta.display_defaults.color_by = Some("clade_membership".to_owned());


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade/issues/1265

This removes the special value "Unknown " (with a space) attached to the "region", "country" and "division" node attributes for new nodes, as well as a color scale for this value.

This way:
- the fields no longer appear in the json (for newly attached nodes)
- the "Region": "Unknown" etc. lines no longer show up in the popup in Auspice interface when clicking on a new node
- colors are displayed correctly, with new nodes in grey

