### PR TITLE
chore: switch off LTO for profiling profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,7 @@ lto = "off"
 inherits = "release"
 debug = 1
 strip = false
+lto = "off"
 
 # Optimize dependencies even in debug mode
 [profile.dev.package."*"]


### PR DESCRIPTION
With lto on, I didn't get any insight into what was going on inside `sort`, everything was apparently inlined by LTO.

With lto off, I now see what's going on.
