### PR TITLE
fix: intermittent crash with "dataset not found" or empty results page

### DIFF
--- a/packages/nextclade-web/src/io/fetchDatasets.ts
+++ b/packages/nextclade-web/src/io/fetchDatasets.ts
@@ -133,7 +133,7 @@ export function useUpdatedDatasetIndex() {
   const setMinimizerIndexVersion = useSetRecoilState(minimizerIndexVersionAtom)
 
   useQuery(
-    'refetchDatasetIndex',
+    ['refetchDatasetIndex'],
     async () => {
       if (isNil(datasetServerUrl)) {
         return
@@ -144,12 +144,12 @@ export function useUpdatedDatasetIndex() {
     },
     {
       suspense: false,
-      staleTime: 0,
+      staleTime: 2 * 60 * 60 * 1000, // 2 hours
       refetchInterval: 2 * 60 * 60 * 1000, // 2 hours
-      refetchIntervalInBackground: true,
-      refetchOnMount: true,
-      refetchOnReconnect: true,
-      refetchOnWindowFocus: true,
+      refetchIntervalInBackground: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
       enabled: !isNil(datasetServerUrl),
     },
   )

--- a/packages/nextclade-web/src/pages/_app.tsx
+++ b/packages/nextclade-web/src/pages/_app.tsx
@@ -94,7 +94,6 @@ function RecoilStateInitializer() {
       })
       .then(async () => {
         const datasetServerUrl = await getDatasetServerUrl(urlQuery)
-        set(datasetServerUrlAtom, datasetServerUrl)
         const { datasets, currentDataset, minimizerIndexVersion } = await initializeDatasets(datasetServerUrl, urlQuery)
 
         const datasetInfo = await fetchSingleDataset(urlQuery)
@@ -103,6 +102,8 @@ function RecoilStateInitializer() {
           const { datasets, currentDataset, auspiceJson } = datasetInfo
           return { datasets, currentDataset, minimizerIndexVersion: undefined, auspiceJson }
         }
+
+        set(datasetServerUrlAtom, datasetServerUrl)
         return { datasets, currentDataset, minimizerIndexVersion, auspiceJson: undefined }
       })
       .catch((error) => {


### PR DESCRIPTION
Reported on NeherLab Slack: [1](https://neherlab.slack.com/archives/C015PFP5V44/p1749377885671969), [2](https://neherlab.slack.com/archives/C015PFP5V44/p1749570781197929)

Followup of #1632

The #1632 only made the bug to appear less frequently, and timing-dependent, but did not solve the issue completely.

Here I additionally remove dataset index refresh on all events and make stale time non-zero - all to avoid overwriting list of datasets with the default when using a custom dataset.

Additionally, the `datasetServerUrl` have been toggling from `undefined` to default server URL and then back to `undefined` in case of a custom single dataset or a dataset server. Now I set the value only once per init. Though, double init might still cause some problems here (see #1638)

