### PR TITLE
fix: ensure CSV column and category selection is additive

### DIFF
--- a/packages/nextclade/src/io/nextclade_csv_column_config.rs
+++ b/packages/nextclade/src/io/nextclade_csv_column_config.rs
@@ -52,7 +52,7 @@ impl CsvColumnConfig {
       });
 
     individual.iter().try_for_each(|header| {
-      if !CSV_POSSIBLE_COLUMNS.contains(header) && !CSV_POSSIBLE_CATEGORIES.contains(header) {
+      if !CSV_POSSIBLE_COLUMNS.contains(header) {
         let categories = CSV_POSSIBLE_CATEGORIES.join(", ");
         let individual = CSV_POSSIBLE_COLUMNS.join(", ");
 


### PR DESCRIPTION
Remove erroneous check of individual columns against categories list to enable proper additive behavior when mixing individual columns and categories in `--output-columns-selection`

