### PR TITLE
fix: collapse -0.0 to 0.0 in phenotype values

### DIFF
--- a/packages/nextclade/src/run/nextclade_run_one.rs
+++ b/packages/nextclade/src/run/nextclade_run_one.rs
@@ -51,6 +51,7 @@ use crate::translate::translate_genes::{translate_genes, Translation};
 use crate::tree::tree_find_ancestors_of_interest::{graph_find_ancestors_of_interest, AncestralSearchResult};
 use crate::tree::tree_find_nearest_node::graph_find_nearest_nodes;
 use crate::types::outputs::{NextcladeOutputs, PeptideWarning, PhenotypeValue};
+use crate::utils::num::float_collapse_zero;
 use eyre::Report;
 use indexmap::indexmap;
 use itertools::{izip, Itertools};
@@ -280,7 +281,7 @@ pub fn nextclade_run_one(
           PhenotypeValue {
             name: name.clone(),
             cds: cds.clone(),
-            value: phenotype,
+            value: float_collapse_zero(phenotype),
           }
         })
         .collect_vec()

--- a/packages/nextclade/src/utils/num.rs
+++ b/packages/nextclade/src/utils/num.rs
@@ -1,5 +1,16 @@
+use num_traits::Float;
+
 /// Checks if a float can be represented as an integer without loss
 #[allow(clippy::float_cmp)]
 pub fn is_int(x: f64) -> bool {
   x == (x as i64) as f64
+}
+
+/// Collapse -0.0 to +0.0
+pub fn float_collapse_zero<T: Float>(x: T) -> T {
+  // -0.0 == 0.0
+  if x == T::zero() {
+    return T::zero();
+  }
+  x
 }


### PR DESCRIPTION
Convert phenotype values `-0.0` to `0.0` to make output cleaner