### PR TITLE
feat: customize built-in clade search items

### DIFF
--- a/packages/nextclade-schemas/output-json.schema.json
+++ b/packages/nextclade-schemas/output-json.schema.json
@@ -123,6 +123,16 @@
           "items": {
             "$ref": "#/definitions/AuspiceRefNodeSearchDesc"
           }
+        },
+        "builtins": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -240,6 +250,60 @@
         "ancestor-earliest",
         "full"
       ]
+    },
+    "AuspiceRefNodeBuiltinsConfig": {
+      "description": "Configuration for all built-in reference node types",
+      "type": "object",
+      "properties": {
+        "__root__": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "__parent__": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "__clade_founder__": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "AuspiceRefNodeBuiltinConfig": {
+      "description": "Configuration for built-in reference node types display names and descriptions",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "NextcladeOutputs": {
       "title": "ResultJson",

--- a/packages/nextclade-schemas/output-json.schema.yaml
+++ b/packages/nextclade-schemas/output-json.schema.yaml
@@ -88,6 +88,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/AuspiceRefNodeSearchDesc'
+      builtins:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinsConfig'
+        - type: 'null'
   AuspiceRefNodeSearchDesc:
     description: Describes a criteria for selecting a reference node for "Relative to" feature
     type: object
@@ -163,6 +167,34 @@ definitions:
     - ancestor-nearest
     - ancestor-earliest
     - full
+  AuspiceRefNodeBuiltinsConfig:
+    description: Configuration for all built-in reference node types
+    type: object
+    properties:
+      __root__:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinConfig'
+        - type: 'null'
+      __parent__:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinConfig'
+        - type: 'null'
+      __clade_founder__:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinConfig'
+        - type: 'null'
+  AuspiceRefNodeBuiltinConfig:
+    description: Configuration for built-in reference node types display names and descriptions
+    type: object
+    properties:
+      displayName:
+        type:
+        - string
+        - 'null'
+      description:
+        type:
+        - string
+        - 'null'
   NextcladeOutputs:
     title: ResultJson
     description: Single element in `.results` array in nextclade.json file, produced by `nextclade run --output-json`. This corresponds to a single sequence in the inputs.

--- a/packages/nextclade-schemas/output-ndjson.schema.json
+++ b/packages/nextclade-schemas/output-ndjson.schema.json
@@ -1144,6 +1144,16 @@
           "items": {
             "$ref": "#/definitions/AuspiceRefNodeSearchDesc"
           }
+        },
+        "builtins": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -1261,6 +1271,60 @@
         "ancestor-earliest",
         "full"
       ]
+    },
+    "AuspiceRefNodeBuiltinsConfig": {
+      "description": "Configuration for all built-in reference node types",
+      "type": "object",
+      "properties": {
+        "__root__": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "__parent__": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "__clade_founder__": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuspiceRefNodeBuiltinConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "AuspiceRefNodeBuiltinConfig": {
+      "description": "Configuration for built-in reference node types display names and descriptions",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "AncestralSearchResult": {
       "description": "Represents the result of searching for ancestral nodes of interest in the graph",

--- a/packages/nextclade-schemas/output-ndjson.schema.yaml
+++ b/packages/nextclade-schemas/output-ndjson.schema.yaml
@@ -841,6 +841,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/AuspiceRefNodeSearchDesc'
+      builtins:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinsConfig'
+        - type: 'null'
   AuspiceRefNodeSearchDesc:
     description: Describes a criteria for selecting a reference node for "Relative to" feature
     type: object
@@ -916,6 +920,34 @@ definitions:
     - ancestor-nearest
     - ancestor-earliest
     - full
+  AuspiceRefNodeBuiltinsConfig:
+    description: Configuration for all built-in reference node types
+    type: object
+    properties:
+      __root__:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinConfig'
+        - type: 'null'
+      __parent__:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinConfig'
+        - type: 'null'
+      __clade_founder__:
+        anyOf:
+        - $ref: '#/definitions/AuspiceRefNodeBuiltinConfig'
+        - type: 'null'
+  AuspiceRefNodeBuiltinConfig:
+    description: Configuration for built-in reference node types display names and descriptions
+    type: object
+    properties:
+      displayName:
+        type:
+        - string
+        - 'null'
+      description:
+        type:
+        - string
+        - 'null'
   AncestralSearchResult:
     description: Represents the result of searching for ancestral nodes of interest in the graph
     type: object

--- a/packages/nextclade-web/src/components/Results/ColumnMutations.tsx
+++ b/packages/nextclade-web/src/components/Results/ColumnMutations.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil'
 import { REF_NODE_CLADE_FOUNDER, REF_NODE_PARENT, REF_NODE_ROOT } from 'src/constants'
 import { findCladeNodeAttrFounderInfo, getAaMutations, getNucMutations } from 'src/helpers/relativeMuts'
 import { viewedDatasetNameAtom } from 'src/state/dataset.state'
-import { currentRefNodeNameAtom } from 'src/state/results.state'
+import { currentRefNodeNameAtom, refNodesAtom } from 'src/state/results.state'
 import type { ColumnCladeProps } from 'src/components/Results/ColumnClade'
 import { getSafeId } from 'src/helpers/getSafeId'
 import { TableSlim } from 'src/components/Common/TableSlim'
@@ -23,19 +23,30 @@ export function ColumnMutations({ analysisResult }: ColumnCladeProps) {
   const id = getSafeId('mutations-label', { index, seqName })
 
   const datasetName = useRecoilValue(viewedDatasetNameAtom)
+  const refNodes = useRecoilValue(refNodesAtom({ datasetName }))
   const nodeSearchName = useRecoilValue(currentRefNodeNameAtom({ datasetName }))
   const nucMuts = getNucMutations(analysisResult, nodeSearchName ?? REF_NODE_ROOT)
   const aaMuts = getAaMutations(analysisResult, nodeSearchName ?? REF_NODE_ROOT)
 
   const { searchNameFriendly, nodeName } = useMemo(() => {
+    const builtins = refNodes?.builtins
     if (nodeSearchName === REF_NODE_ROOT) {
-      return { searchNameFriendly: t('reference'), nodeName: refName }
+      return {
+        searchNameFriendly: builtins?.[REF_NODE_ROOT]?.displayName ?? t('reference'),
+        nodeName: refName,
+      }
     }
     if (nodeSearchName === REF_NODE_PARENT) {
-      return { searchNameFriendly: t('parent'), nodeName: nearestNodeName }
+      return {
+        searchNameFriendly: builtins?.[REF_NODE_PARENT]?.displayName ?? t('parent'),
+        nodeName: nearestNodeName,
+      }
     }
     if (nodeSearchName === REF_NODE_CLADE_FOUNDER) {
-      return { searchNameFriendly: t('clade founder'), nodeName: cladeFounderInfo?.nodeName }
+      return {
+        searchNameFriendly: builtins?.[REF_NODE_CLADE_FOUNDER]?.displayName ?? t('clade founder'),
+        nodeName: cladeFounderInfo?.nodeName,
+      }
     }
     const cladeNodeAttr = findCladeNodeAttrFounderInfo(cladeNodeAttrFounderInfo, nodeSearchName ?? REF_NODE_ROOT)
     if (cladeNodeAttr) {
@@ -53,6 +64,7 @@ export function ColumnMutations({ analysisResult }: ColumnCladeProps) {
     nodeSearchName,
     cladeNodeAttrFounderInfo,
     refNodeSearchResults,
+    refNodes?.builtins,
     t,
     refName,
     nearestNodeName,

--- a/packages/nextclade-web/src/components/Results/RefNodeSelector.tsx
+++ b/packages/nextclade-web/src/components/Results/RefNodeSelector.tsx
@@ -53,21 +53,24 @@ export function RefNodeSelector({ disabled }: RefNodeSelectorProps) {
           }
         }) ?? []
 
+    const builtins = refNodes?.builtins
     const builtinRefs: Option[] = [
       {
         value: REF_NODE_ROOT,
-        label: t('Reference'),
-        description: t('Reference sequence'),
+        label: builtins?.[REF_NODE_ROOT]?.displayName ?? t('Reference'),
+        description: builtins?.[REF_NODE_ROOT]?.description ?? t('Reference sequence'),
       },
       {
         value: REF_NODE_PARENT,
-        label: t('Parent'),
-        description: t('Nearest node on reference tree'),
+        label: builtins?.[REF_NODE_PARENT]?.displayName ?? t('Parent'),
+        description: builtins?.[REF_NODE_PARENT]?.description ?? t('Nearest node on reference tree'),
       },
       {
         value: REF_NODE_CLADE_FOUNDER,
-        label: t('Clade founder'),
-        description: t('Earliest ancestor node with the same clade on reference tree'),
+        label: builtins?.[REF_NODE_CLADE_FOUNDER]?.displayName ?? t('Clade founder'),
+        description:
+          builtins?.[REF_NODE_CLADE_FOUNDER]?.description ??
+          t('Earliest ancestor node with the same clade on reference tree'),
       },
     ]
 
@@ -75,7 +78,7 @@ export function RefNodeSelector({ disabled }: RefNodeSelectorProps) {
     const currentOption = options.find((o) => o.value === currentRefNodeName)
 
     return { options, currentOption }
-  }, [cladeNodeAttrDescs, currentRefNodeName, refNodes?.search, t])
+  }, [cladeNodeAttrDescs, currentRefNodeName, refNodes?.search, refNodes?.builtins, t])
 
   const handleChange = useCallback(
     (option: OnChangeValue<DropdownOption<string>, IsMultiValue>, _actionMeta: ActionMeta<DropdownOption<string>>) => {

--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -441,6 +441,36 @@ pub struct AuspiceRefNodeSearchDesc {
   pub other: serde_json::Value,
 }
 
+/// Configuration for built-in reference node types display names and descriptions
+#[derive(Clone, Default, Serialize, Deserialize, Eq, PartialEq, schemars::JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AuspiceRefNodeBuiltinConfig {
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub display_name: Option<String>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub description: Option<String>,
+}
+
+/// Configuration for all built-in reference node types
+#[derive(Clone, Default, Serialize, Deserialize, Eq, PartialEq, schemars::JsonSchema, Debug)]
+pub struct AuspiceRefNodeBuiltinsConfig {
+  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "__root__")]
+  pub root: Option<AuspiceRefNodeBuiltinConfig>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "__parent__")]
+  pub parent: Option<AuspiceRefNodeBuiltinConfig>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "__clade_founder__")]
+  pub clade_founder: Option<AuspiceRefNodeBuiltinConfig>,
+
+  #[serde(flatten)]
+  pub other: serde_json::Value,
+}
+
 impl AuspiceRefNodeSearchDesc {
   pub fn display_name_or_name(&self) -> &str {
     self.display_name.as_ref().unwrap_or(&self.name)
@@ -456,6 +486,9 @@ pub struct AuspiceRefNodesDesc {
 
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub search: Vec<AuspiceRefNodeSearchDesc>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub builtins: Option<AuspiceRefNodeBuiltinsConfig>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,


### PR DESCRIPTION
Resolves: https://github.com/nextstrain/nextclade/issues/1683

Allows dataset authors to customize display names and descriptions for the builtin entries "reference", "parent" and "clade founder" in the "Relative to" dropdown of Nextclade Web.

Introduces a new optional field (type object) `.meta.extensions.nextclade.ref_nodes.builtins`, where one can customize display of the said entries.

Example: https://nextstrain--nextclade--pr-1684.previews.neherlab.click/?dataset-name=nextstrain/flu/h3n2/ha/EPI1857216&input-tree=gh:nextstrain/nextclade_data@feat/search-node-desc@data/nextstrain/flu/h3n2/ha/EPI1857216/tree.json&input-fasta=example

Example json snippet to insert to `.meta.extensions.nextclade.ref_nodes`
```json
{
  "default": "__root__",
  "builtins": {
    "__root__": {
      "displayName": "Forest Root",
      "description": "Just a big underground boss: feeds everyone, never moves, and rolls its eyes at every flashy branch thinking it's self-made."
    },
    "__parent__": {
      "displayName": "Phylogenetic Mom",
      "description": "Yells: 'I raised you better than this!' every time a lineage picks up a questionable mutation."
    },
    "__clade_founder__": {
      "displayName": "CEO (Founder) of \"Clade\" ",
      "description": "Pitched natural selection, went viral, and suddenly spawned an entire clade of wannabe disruptors."
    }
  },
  "search": [
     "..."
  ] 
}
```
(GPT-5 is quite good at phylogenetic jokes apparently :) )


Screenshot:

<img width="532" height="508" alt="Image" src="https://github.com/user-attachments/assets/7bbd21af-cab9-463e-a439-0e4c7a021966" />

