### PR TITLE
fix(web): correct behavior of reset button on main page

### DIFF
--- a/packages/nextclade-web/src/components/Main/SuggestionPanel.tsx
+++ b/packages/nextclade-web/src/components/Main/SuggestionPanel.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil'
 import styled from 'styled-components'
 import { Toggle } from 'src/components/Common/Toggle'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { useResetSuggestionsAndDatasets } from 'src/hooks/useResetSuggestions'
+import { useResetSuggestionsAndCurrentDataset } from 'src/hooks/useResetSuggestions'
 import { useRunSeqAutodetect } from 'src/hooks/useRunSeqAutodetect'
 import { useRecoilToggle } from 'src/hooks/useToggle'
 import {
@@ -83,7 +83,7 @@ export function ButtonSuggest() {
 
 export function ButtonSuggestionsReset() {
   const { t } = useTranslationSafe()
-  const resetAutodetectResults = useResetSuggestionsAndDatasets()
+  const resetAutodetectResults = useResetSuggestionsAndCurrentDataset()
   const hasAutodetectResults = useRecoilValue(hasAutodetectResultsAtom)
   const hasTopSuggestedDatasets = useRecoilValue(hasTopSuggestedDatasetsAtom)
   const isAutodetectRunning = useRecoilValue(isAutodetectRunningAtom)

--- a/packages/nextclade-web/src/hooks/useResetSuggestions.ts
+++ b/packages/nextclade-web/src/hooks/useResetSuggestions.ts
@@ -6,6 +6,7 @@ import {
   autodetectResultsAtom,
   autodetectRunStateAtom,
 } from 'src/state/autodetect.state'
+import { datasetSelectionAtom } from 'src/state/dataset.state'
 
 export function useResetSuggestions() {
   const resetAutodetectResultsAtom = useResetRecoilState(autodetectResultsAtom)
@@ -26,4 +27,16 @@ export function useResetSuggestionsAndDatasets() {
     resetSuggestions()
     resetAllDatasetSuggestionResultsAtom()
   }, [resetAllDatasetSuggestionResultsAtom, resetSuggestions])
+}
+
+export function useResetSuggestionsAndCurrentDataset() {
+  const resetSuggestions = useResetSuggestions()
+  const resetAllDatasetSuggestionResultsAtom = useResetRecoilState(allDatasetSuggestionResultsAtom)
+  const resetDatasetSelection = useResetRecoilState(datasetSelectionAtom)
+
+  return useCallback(() => {
+    resetSuggestions()
+    resetAllDatasetSuggestionResultsAtom()
+    resetDatasetSelection()
+  }, [resetAllDatasetSuggestionResultsAtom, resetSuggestions, resetDatasetSelection])
 }


### PR DESCRIPTION
The "Reset" button in the "Select dataset" section on main page now correctly clears the currently selected dataset(s) in single- and multi-dataset modes.

