### PR TITLE
fix(web): clear duplicate sequence name mappings on analysis reset

### DIFF
--- a/packages/nextclade-web/src/state/results.state.ts
+++ b/packages/nextclade-web/src/state/results.state.ts
@@ -139,6 +139,14 @@ export const analysisResultsAtom = jotaiAtom(
   (get, set, results: NextcladeResult[]) => {
     const seqIndices = get(seqIndicesAtom)
 
+    // Clear duplicate mappings for all old sequence names before resetting
+    seqIndices.forEach((index) => {
+      const oldResult = get(analysisResultInternalAtom(index))
+      if (oldResult?.seqName) {
+        set(seqNameDuplicatesAtom(oldResult.seqName), [])
+      }
+    })
+
     // Remove all results - reset to empty arrays
     seqIndices.forEach((index) => {
       set(analysisResultInternalAtom(index), {} as NextcladeResult)


### PR DESCRIPTION
The seqNameDuplicatesAtom (Jotai atom family) was not cleared between analysis runs, causing stale index references in duplicate indicators.

