### PR TITLE
fix: allow numeric keys in Auspice coloring scale

### DIFF
--- a/packages/nextclade/src/tree/tree.rs
+++ b/packages/nextclade/src/tree/tree.rs
@@ -608,6 +608,13 @@ impl AuspiceMetaExtensions {
   }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum ScaleKey {
+  Num(f64),
+  Str(String),
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, schemars::JsonSchema, Validate)]
 pub struct AuspiceColoring {
   #[serde(rename = "type")]
@@ -619,7 +626,7 @@ pub struct AuspiceColoring {
 
   #[serde(skip_serializing_if = "Vec::is_empty")]
   #[serde(default)]
-  pub scale: Vec<[String; 2]>,
+  pub scale: Vec<(ScaleKey, String)>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,

--- a/packages/nextclade/src/tree/tree_preprocess.rs
+++ b/packages/nextclade/src/tree/tree_preprocess.rs
@@ -9,7 +9,7 @@ use crate::coord::position::{AaRefPosition, NucRefGlobalPosition, PositionLike};
 use crate::graph::node::GraphNodeKey;
 use crate::make_error;
 use crate::translate::translate_genes::Translation;
-use crate::tree::tree::{AuspiceColoring, AuspiceGraph, AuspiceGraphNodePayload, AuspiceTreeMeta};
+use crate::tree::tree::{AuspiceColoring, AuspiceGraph, AuspiceGraphNodePayload, AuspiceTreeMeta, ScaleKey};
 use crate::utils::collections::concat_to_vec;
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
@@ -247,8 +247,8 @@ fn map_aa_muts_for_one_cds(
   }
 }
 
-fn pair(key: &str, val: &str) -> [String; 2] {
-  [key.to_owned(), val.to_owned()]
+fn pair(key: &str, val: &str) -> (ScaleKey, String) {
+  (ScaleKey::Str(key.to_owned()), val.to_owned())
 }
 
 pub fn add_auspice_metadata_in_place(meta: &mut AuspiceTreeMeta, has_pcr_primers: bool) {


### PR DESCRIPTION
The Auspice v2 JSON schema specifies that scale entries are two-element arrays where the first item can be either string (categorical) or numeric (continuous).¹ The previous type did not allow numeric keys and would fail to deserialize Auspice JSONs with continuous colorings.

¹ https://nextstrain.org/schemas/auspice/config/v2#/properties/colorings/items/properties/scale

Feel free to make any edits!

Closes https://github.com/nextstrain/rsv/issues/129