### PR TITLE
fix: treat deletions as undetermined in nearest node distance

### DIFF
--- a/packages/nextclade/src/run/nextclade_run_one.rs
+++ b/packages/nextclade/src/run/nextclade_run_one.rs
@@ -327,7 +327,8 @@ pub fn nextclade_run_one(
     nearest_node_name,
     nearest_nodes,
   } = if let Some(graph) = graph {
-    let nearest_node_candidates = graph_find_nearest_nodes(graph, &substitutions, &missing, &alignment_range)?;
+    let nearest_node_candidates =
+      graph_find_nearest_nodes(graph, &substitutions, &missing, &deletions, &alignment_range)?;
     let nearest_node_id = nearest_node_candidates[0].node_key;
     let nearest_node = graph.get_node(nearest_node_id)?.payload();
     let nearest_node_name = nearest_node.name.clone();

--- a/packages/nextclade/src/tree/tree_find_nearest_node.rs
+++ b/packages/nextclade/src/tree/tree_find_nearest_node.rs
@@ -1,6 +1,7 @@
 use crate::alphabet::nuc::Nuc;
 use crate::analyze::is_sequenced::is_nuc_sequenced;
 use crate::analyze::letter_ranges::NucRange;
+use crate::analyze::nuc_del::NucDelRange;
 use crate::analyze::nuc_sub::NucSub;
 use crate::coord::range::NucRefGlobalRange;
 use crate::graph::node::GraphNodeKey;
@@ -21,6 +22,7 @@ pub fn graph_find_nearest_nodes(
   graph: &AuspiceGraph,
   qry_nuc_subs: &[NucSub],
   qry_missing: &[NucRange],
+  qry_deletions: &[NucDelRange],
   aln_range: &NucRefGlobalRange,
 ) -> Result<Vec<TreePlacementInfo>, Report> {
   let masked_ranges = graph.data.meta.placement_mask_ranges();
@@ -29,7 +31,14 @@ pub fn graph_find_nearest_nodes(
   let nodes_by_placement_score = DftPre::new(graph.get_exactly_one_root()?, |node| graph.iter_children_of(node))
     .map(|(_, node)| {
       let node_payload = node.payload();
-      let distance = tree_calculate_node_distance(node_payload, qry_nuc_subs, qry_missing, aln_range, masked_ranges);
+      let distance = tree_calculate_node_distance(
+        node_payload,
+        qry_nuc_subs,
+        qry_missing,
+        qry_deletions,
+        aln_range,
+        masked_ranges,
+      );
       let prior = get_prior(node_payload);
       TreePlacementInfo {
         node_key: node.key(),
@@ -69,6 +78,7 @@ fn tree_calculate_node_distance(
   node: &AuspiceGraphNodePayload,
   qry_nuc_subs: &[NucSub],
   qry_missing: &[NucRange],
+  qry_deletions: &[NucDelRange],
   aln_range: &NucRefGlobalRange,
   masked_ranges: &[NucRefGlobalRange],
 ) -> i64 {
@@ -105,11 +115,13 @@ fn tree_calculate_node_distance(
     }
   }
 
-  // determine the number of sites that are mutated in the node but missing in seq.
+  // determine the number of sites that are mutated in the node but missing or deleted in seq.
   // for these we can't tell whether the node agrees with seq
   let mut undetermined_sites = 0_i64;
   for pos in node.tmp.substitutions.keys() {
-    if !is_nuc_sequenced(*pos, &masked_qry_missing, aln_range) {
+    if !is_nuc_sequenced(*pos, &masked_qry_missing, aln_range)
+      || qry_deletions.iter().any(|del| del.range().contains(*pos))
+    {
       undetermined_sites += 1;
     }
   }

--- a/packages/nextclade/src/tree/tree_find_nearest_node.rs
+++ b/packages/nextclade/src/tree/tree_find_nearest_node.rs
@@ -246,7 +246,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 100);
     let masked_ranges = vec![];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 0);
 
@@ -261,7 +269,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 100);
     let masked_ranges = vec![];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 3);
 
@@ -276,7 +292,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 100);
     let masked_ranges = vec![];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 5);
 
@@ -291,7 +315,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 100);
     let masked_ranges = vec![];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 5);
 
@@ -306,7 +338,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 100);
     let masked_ranges = vec![];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 4);
 
@@ -321,7 +361,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 20);
     let masked_ranges = vec![];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 3);
 
@@ -336,7 +384,15 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 100);
     let masked_ranges = vec![NucRefGlobalRange::from_usize(0, 100)];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 0);
 
@@ -355,7 +411,15 @@ mod tests {
       NucRefGlobalRange::from_usize(30, 50),
     ];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 3);
 
@@ -370,9 +434,50 @@ mod tests {
     let aln_range = NucRefGlobalRange::from_usize(0, 30);
     let masked_ranges = vec![NucRefGlobalRange::from_usize(12, 13)];
 
-    let result = tree_calculate_node_distance(&node, &qry_nuc_subs, &qry_missing, &aln_range, &masked_ranges);
+    let qry_deletions: Vec<NucDelRange> = vec![];
+    let result = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
 
     assert_eq!(result, 3);
+
+    Ok(())
+  }
+
+  #[rstest]
+  fn deletion_covering_node_mutations_reduces_distance() -> Result<(), Report> {
+    let node = node_with_simple_nuc_subs();
+    let qry_nuc_subs: Vec<NucSub> = vec![];
+    let qry_missing: Vec<NucRange> = vec![];
+    let aln_range = NucRefGlobalRange::from_usize(0, 100);
+    let masked_ranges = vec![];
+
+    let no_deletions: Vec<NucDelRange> = vec![];
+    let distance_without_del = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &no_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
+    assert_eq!(distance_without_del, 5);
+
+    let qry_deletions = vec![NucDelRange::from_usize(10, 25)];
+    let distance_with_del = tree_calculate_node_distance(
+      &node,
+      &qry_nuc_subs,
+      &qry_missing,
+      &qry_deletions,
+      &aln_range,
+      &masked_ranges,
+    );
+    assert_eq!(distance_with_del, 2);
 
     Ok(())
   }


### PR DESCRIPTION
- Related: https://neherlab.slack.com/archives/C015PFP5V44/p1777319589953279

Sequences with large internal deletions are placed near the root of the reference tree instead of near their true closest relatives. The nearest node distance metric counts node mutations at deleted positions as mismatches (the query "has reference" there), making the root -- which has zero mutations -- appear closest. Replacing gaps with N produces correct placement because N positions are already excluded from the distance as undetermined.

This PR adds query deletion ranges as a separate parameter to the distance calculation and counts node mutations at deleted positions as undetermined. The fix is limited to placement; private mutation calling already handles deletions correctly via a separate code path.

### Work items

- [x] Add `qry_deletions: &[NucDelRange]` parameter to [`graph_find_nearest_nodes`](https://github.com/nextstrain/nextclade/blob/3004cda11b044866131731610246752533f9f646/packages/nextclade/src/tree/tree_find_nearest_node.rs#L21) and [`tree_calculate_node_distance`](https://github.com/nextstrain/nextclade/blob/3004cda11b044866131731610246752533f9f646/packages/nextclade/src/tree/tree_find_nearest_node.rs#L77)
- [x] Count node mutations at deleted positions as undetermined in the [distance loop](https://github.com/nextstrain/nextclade/blob/3004cda11b044866131731610246752533f9f646/packages/nextclade/src/tree/tree_find_nearest_node.rs#L121-L126)
- [x] Pass `&deletions` from [`nextclade_run_one`](https://github.com/nextstrain/nextclade/blob/3004cda11b044866131731610246752533f9f646/packages/nextclade/src/run/nextclade_run_one.rs#L330)
- [x] Add unit test verifying deletion-covered node mutations reduce distance
- [x] Update existing tests for new parameter signature