### PR TITLE
fix(sort): use numeric version comparison instead of lexicographic

### DIFF
--- a/packages/nextclade-cli/src/cli/nextclade_seq_sort.rs
+++ b/packages/nextclade-cli/src/cli/nextclade_seq_sort.rs
@@ -50,7 +50,7 @@ pub fn nextclade_seq_sort(args: &NextcladeSortArgs) -> Result<(), Report> {
     let minimizer_index_path = index
       .minimizer_index
       .iter()
-      .find(|minimizer_index| MINIMIZER_INDEX_ALGO_VERSION == minimizer_index.version)
+      .find(|mi| u64::from_str(&mi.version).is_ok_and(|v| v == MINIMIZER_INDEX_ALGO_VERSION))
       .map(|minimizer_index| &minimizer_index.path);
 
     if let Some(minimizer_index_path) = minimizer_index_path {

--- a/packages/nextclade/src/analyze/virus_properties.rs
+++ b/packages/nextclade/src/analyze/virus_properties.rs
@@ -26,8 +26,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use validator::Validate;
 
-const PATHOGEN_JSON_SCHEMA_VERSION_FROM: &str = "3.0.0";
-const PATHOGEN_JSON_SCHEMA_VERSION_TO: &str = "3.0.0";
+const PATHOGEN_JSON_SCHEMA_VERSION_FROM: Version = Version::new(3, 0, 0);
+const PATHOGEN_JSON_SCHEMA_VERSION_TO: Version = Version::new(3, 0, 0);
 
 /// Pathogen metadata attributes with recognized keys and extensibility
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -442,8 +442,8 @@ impl VirusProperties {
       s,
       &SchemaVersionParams {
         name: "pathogen.json",
-        ver_from: Some(PATHOGEN_JSON_SCHEMA_VERSION_FROM),
-        ver_to: Some(PATHOGEN_JSON_SCHEMA_VERSION_TO),
+        ver_from: Some(PATHOGEN_JSON_SCHEMA_VERSION_FROM.clone()),
+        ver_to: Some(PATHOGEN_JSON_SCHEMA_VERSION_TO.clone()),
       },
     );
 

--- a/packages/nextclade/src/io/dataset.rs
+++ b/packages/nextclade/src/io/dataset.rs
@@ -70,8 +70,8 @@ impl DatasetAttributes {
   }
 }
 
-const INDEX_JSON_SCHEMA_VERSION_FROM: &str = "3.0.0";
-const INDEX_JSON_SCHEMA_VERSION_TO: &str = "3.0.0";
+const INDEX_JSON_SCHEMA_VERSION_FROM: Version = Version::new(3, 0, 0);
+const INDEX_JSON_SCHEMA_VERSION_TO: Version = Version::new(3, 0, 0);
 
 /// Top-level dataset index file (index.json). Contains all dataset collections served by a dataset server.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -105,8 +105,8 @@ impl DatasetsIndexJson {
       &s,
       &SchemaVersionParams {
         name: "index.json",
-        ver_from: Some(INDEX_JSON_SCHEMA_VERSION_FROM),
-        ver_to: Some(INDEX_JSON_SCHEMA_VERSION_TO),
+        ver_from: Some(INDEX_JSON_SCHEMA_VERSION_FROM.clone()),
+        ver_to: Some(INDEX_JSON_SCHEMA_VERSION_TO.clone()),
       },
     );
     json_parse(s)

--- a/packages/nextclade/src/io/schema_version.rs
+++ b/packages/nextclade/src/io/schema_version.rs
@@ -3,18 +3,34 @@ use crate::make_error;
 use crate::utils::error::report_to_string;
 use eyre::Report;
 use log::warn;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaVersion {
-  pub schema_version: String,
+  #[serde(with = "semver_string")]
+  pub schema_version: Version,
 }
 
-pub struct SchemaVersionParams<'s> {
-  pub name: &'s str,
-  pub ver_from: Option<&'s str>,
-  pub ver_to: Option<&'s str>,
+pub struct SchemaVersionParams {
+  pub name: &'static str,
+  pub ver_from: Option<Version>,
+  pub ver_to: Option<Version>,
+}
+
+mod semver_string {
+  use semver::Version;
+  use serde::{Deserialize, Deserializer, Serializer};
+
+  pub fn serialize<S: Serializer>(version: &Version, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&version.to_string())
+  }
+
+  pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Version, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    Version::parse(&s).map_err(serde::de::Error::custom)
+  }
 }
 
 impl SchemaVersion {
@@ -25,26 +41,26 @@ impl SchemaVersion {
   ) -> Result<SchemaVersion, Report> {
     let sv: SchemaVersion = json_parse(json_str)?;
 
-    if let Some(ver_to) = ver_to
-      && sv.schema_version.as_str() > *ver_to
-    {
-      return make_error!(
-        "The format version of '{}' file (schemaVersion={}) is newer than maximum version supported by this version of Nextclade (schemaVersion={}). This likely means that there are newer versions of Nextclade available which support this new format. In case of issues, please upgrade Nextclade to avoid incompatibility and to receive the latest features and bug fixes. Alternatively, you might try to use earlier versions of the dataset (not recommended).",
-        name,
-        sv.schema_version,
-        ver_to
-      );
+    if let Some(ver_to) = ver_to {
+      if sv.schema_version > *ver_to {
+        return make_error!(
+          "The format version of '{}' file (schemaVersion={}) is newer than maximum version supported by this version of Nextclade (schemaVersion={}). This likely means that there are newer versions of Nextclade available which support this new format. In case of issues, please upgrade Nextclade to avoid incompatibility and to receive the latest features and bug fixes. Alternatively, you might try to use earlier versions of the dataset (not recommended).",
+          name,
+          sv.schema_version,
+          ver_to
+        );
+      }
     }
 
-    if let Some(ver_from) = ver_from
-      && sv.schema_version.as_str() < *ver_from
-    {
-      return make_error!(
-        "The format version of '{}' file (schemaVersion={}) is older than minimum version supported by this version of Nextclade (schemaVersion={}). This likely means that this version of Nextclade will have problems reading and understanding this file. In case of issues, please upgrade the dataset to avoid incompatibility and to receive the latest features and bug fixes. Alternatively, you might try to use earlier versions of Nextclade (not recommended).",
-        name,
-        sv.schema_version,
-        ver_from
-      );
+    if let Some(ver_from) = ver_from {
+      if sv.schema_version < *ver_from {
+        return make_error!(
+          "The format version of '{}' file (schemaVersion={}) is older than minimum version supported by this version of Nextclade (schemaVersion={}). This likely means that this version of Nextclade will have problems reading and understanding this file. In case of issues, please upgrade the dataset to avoid incompatibility and to receive the latest features and bug fixes. Alternatively, you might try to use earlier versions of Nextclade (not recommended).",
+          name,
+          sv.schema_version,
+          ver_from
+        );
+      }
     }
 
     Ok(sv)
@@ -55,5 +71,63 @@ impl SchemaVersion {
     if let Err(report) = Self::check_err(json_str, params) {
       warn!("{}", report_to_string(&report));
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use rstest::rstest;
+
+  fn json_with_version(ver: &str) -> String {
+    format!(r#"{{"schemaVersion": "{ver}"}}"#)
+  }
+
+  fn params(name: &'static str, ver_from: Option<Version>, ver_to: Option<Version>) -> SchemaVersionParams {
+    SchemaVersionParams { name, ver_from, ver_to }
+  }
+
+  fn ver(s: &str) -> Version {
+    Version::parse(s).unwrap()
+  }
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::equal_to_max(          "3.0.0",  Some("3.0.0"),  true)]
+  #[case::below_max(             "2.9.0",  Some("3.0.0"),  true)]
+  #[case::above_max(             "4.0.0",  Some("3.0.0"),  false)]
+  #[case::multi_digit_below_max( "3.9.0",  Some("3.10.0"), true)]
+  #[case::multi_digit_above_max( "3.10.0", Some("3.9.0"),  false)]
+  #[case::no_max(                "99.0.0", None,           true)]
+  #[trace]
+  fn test_schema_version_check_err_upper_bound(
+    #[case] version: &str,
+    #[case] ver_to: Option<&str>,
+    #[case] expect_ok: bool,
+  ) {
+    let json = json_with_version(version);
+    let p = params("test.json", None, ver_to.map(ver));
+    let result = SchemaVersion::check_err(&json, &p);
+    assert_eq!(expect_ok, result.is_ok(), "version={version}, ver_to={ver_to:?}, result={result:?}");
+  }
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::equal_to_min(          "3.0.0",  Some("3.0.0"),  true)]
+  #[case::above_min(             "4.0.0",  Some("3.0.0"),  true)]
+  #[case::below_min(             "2.0.0",  Some("3.0.0"),  false)]
+  #[case::multi_digit_above_min( "3.10.0", Some("3.9.0"),  true)]
+  #[case::multi_digit_below_min( "3.9.0",  Some("3.10.0"), false)]
+  #[case::no_min(                "0.0.1",  None,           true)]
+  #[trace]
+  fn test_schema_version_check_err_lower_bound(
+    #[case] version: &str,
+    #[case] ver_from: Option<&str>,
+    #[case] expect_ok: bool,
+  ) {
+    let json = json_with_version(version);
+    let p = params("test.json", ver_from.map(ver), None);
+    let result = SchemaVersion::check_err(&json, &p);
+    assert_eq!(expect_ok, result.is_ok(), "version={version}, ver_from={ver_from:?}, result={result:?}");
   }
 }

--- a/packages/nextclade/src/sort/minimizer_index.rs
+++ b/packages/nextclade/src/sort/minimizer_index.rs
@@ -4,15 +4,16 @@ use crate::io::schema_version::{SchemaVersion, SchemaVersionParams};
 use eyre::{Report, WrapErr};
 use log::warn;
 use schemars::JsonSchema;
+use semver::Version;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::str::FromStr;
 
-pub const MINIMIZER_INDEX_SCHEMA_VERSION_FROM: &str = "3.0.0";
-pub const MINIMIZER_INDEX_SCHEMA_VERSION_TO: &str = "3.0.0";
-pub const MINIMIZER_INDEX_ALGO_VERSION: &str = "1";
+const MINIMIZER_INDEX_SCHEMA_VERSION_FROM: Version = Version::new(3, 0, 0);
+const MINIMIZER_INDEX_SCHEMA_VERSION_TO: Version = Version::new(3, 0, 0);
+pub const MINIMIZER_INDEX_ALGO_VERSION: u64 = 1;
 
 pub type MinimizerMap = BTreeMap<u64, Vec<usize>>;
 
@@ -98,6 +99,11 @@ pub struct VersionCheck {
   pub other: serde_json::Value,
 }
 
+pub fn check_algo_version(version: &str) -> Result<bool, Report> {
+  let data_version = u64::from_str(version).wrap_err_with(|| format!("Invalid minimizer index version: {version}"))?;
+  Ok(data_version > MINIMIZER_INDEX_ALGO_VERSION)
+}
+
 impl MinimizerIndexJson {
   fn default_schema() -> String {
     "https://raw.githubusercontent.com/nextstrain/nextclade/refs/heads/release/packages/nextclade-schemas/internal-minimizer-index-json.schema.json".to_owned()
@@ -117,18 +123,49 @@ impl MinimizerIndexJson {
       s,
       &SchemaVersionParams {
         name: "minimizer_index.json",
-        ver_from: Some(MINIMIZER_INDEX_SCHEMA_VERSION_FROM),
-        ver_to: Some(MINIMIZER_INDEX_SCHEMA_VERSION_TO),
+        ver_from: Some(MINIMIZER_INDEX_SCHEMA_VERSION_FROM.clone()),
+        ver_to: Some(MINIMIZER_INDEX_SCHEMA_VERSION_TO.clone()),
       },
     );
 
     let VersionCheck { version, .. } = json_parse(s)?;
-    if version.as_str() > MINIMIZER_INDEX_ALGO_VERSION {
+    if check_algo_version(&version)? {
       warn!(
         "Version of the minimizer index data ({version}) is greater than maximum supported by this version of Nextclade ({MINIMIZER_INDEX_ALGO_VERSION}). This may lead to errors or incorrect results. Please try to update your version of Nextclade and/or contact dataset maintainers for more details."
       );
     }
 
     json_parse(s).wrap_err("When parsing minimizer index")
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use rstest::rstest;
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::equal(           "1",  false)]
+  #[case::below(           "0",  false)]
+  #[case::above(           "2",  true)]
+  #[case::multi_digit(     "10", true)]
+  #[case::large(           "99", true)]
+  #[trace]
+  fn test_minimizer_index_check_algo_version(#[case] version: &str, #[case] expect_above_max: bool) {
+    let result = check_algo_version(version).unwrap();
+    assert_eq!(expect_above_max, result, "version={version}");
+  }
+
+  #[test]
+  fn test_minimizer_index_check_algo_version_rejects_non_numeric() {
+    drop(check_algo_version("abc").unwrap_err());
+  }
+
+  #[test]
+  fn test_minimizer_index_multi_digit_not_lexicographic() {
+    // "10" < "2" lexicographically, but 10 > 2 numerically.
+    // With MINIMIZER_INDEX_ALGO_VERSION = "1", version "10" must be detected as above max.
+    assert!(check_algo_version("10").unwrap());
   }
 }


### PR DESCRIPTION
## PR: fix(sort): use numeric version comparison instead of lexicographic

`fix/minimizer-index-version-comparison` -> `master`

### Summary

Version comparisons for schema versions and minimizer index algo versions used lexicographic string ordering. This is correct only while all version components are single digits -- `"3.10.0" < "3.9.0"` lexicographically, and `"10" < "2"`. The bug is latent with current data (`"3.0.0"` and `"1"`) but would silently produce wrong results as soon as any component exceeds 9.

### Changes

**Schema version checking** (`schema_version.rs`)

- `SchemaVersion.schema_version` field type changed from `String` to `semver::Version`, deserialized via a `#[serde(with)]` helper module
- `SchemaVersionParams` bounds changed from `Option<&str>` to `Option<Version>` -- comparisons now use `Version`'s derived `Ord`, which orders `3.10.0 > 3.9.0` correctly
- All callers updated: `virus_properties.rs`, `dataset.rs`, `minimizer_index.rs` -- constants converted from `&str` literals to `Version::new(3, 0, 0)`

**Minimizer index algo version** (`minimizer_index.rs`)

- `MINIMIZER_INDEX_ALGO_VERSION` changed from `&str = "1"` to `u64 = 1`
- Extracted `check_algo_version()` function: parses the JSON string to `u64` and compares numerically
- CLI lookup in `nextclade_seq_sort.rs` updated to parse version string before comparing against the typed constant

### Tests

- `test_schema_version_check_err_upper_bound` -- 6 parameterized cases including multi-digit (`"3.10.0"` vs `"3.9.0"`)
- `test_schema_version_check_err_lower_bound` -- 6 parameterized cases including multi-digit
- `test_minimizer_index_check_algo_version` -- 5 parameterized cases
- `test_minimizer_index_check_algo_version_rejects_non_numeric` -- error path
- `test_minimizer_index_multi_digit_not_lexicographic` -- explicit regression guard for the original bug

### Related

Same defect class exists in the web app: `UpdateNotification.tsx` compares semver strings with JavaScript `>` instead of using the `semver` npm package (already a dependency, used correctly in `fetchDatasetsIndex.ts`). Not addressed in this PR -- Rust-only scope.
