### PR TITLE
fix(web): use semver comparison for update notification version check

### DIFF
--- a/packages/nextclade-web/src/components/Layout/UpdateNotification.tsx
+++ b/packages/nextclade-web/src/components/Layout/UpdateNotification.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 import { isNil } from 'lodash'
+import semver from 'semver'
 import urljoin from 'url-join'
 import { useAxiosQueryOrUndefined } from 'src/helpers/useAxiosQuery'
 import {
@@ -66,7 +67,7 @@ export function UpdateNotification() {
     }
   }, [appJson, setLastNotifiedAppVersion])
 
-  if (isNil(appJson) || !(appJson.version > (lastNotifiedAppVersion ?? PACKAGE_VERSION ?? ''))) {
+  if (isNil(appJson) || !semver.gt(appJson.version, lastNotifiedAppVersion ?? PACKAGE_VERSION ?? '0.0.0')) {
     return null
   }
 


### PR DESCRIPTION
## PR: fix(web): use semver comparison for update notification version check

`fix/web-version-comparison` -> `master`

### Summary

`UpdateNotification.tsx` compared app versions with JavaScript string `>`, which fails for multi-digit semver components (`"3.10.0" < "3.9.0"` lexicographically). Replaced with `semver.gt()` -- the `semver` package is already a dependency and used correctly in `fetchDatasetsIndex.ts`.

### Changes

- Import `semver` in `UpdateNotification.tsx`
- Replace `appJson.version > (lastNotifiedAppVersion ?? PACKAGE_VERSION ?? '')` with `semver.gt(appJson.version, lastNotifiedAppVersion ?? PACKAGE_VERSION ?? '0.0.0')`
- Fallback changed from `''` to `'0.0.0'` (valid semver required by `semver.gt()`)

### Related

Follow-up to: #1769 (same defect class, Rust side)
