### PR TITLE
feat(sort): multi-reference minimizer scoring for dataset suggestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,6 +2105,7 @@ dependencies = [
 name = "nextclade"
 version = "3.21.2"
 dependencies = [
+ "approx",
  "assert2",
  "auto_ops",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ authors = ["Nextstrain team"]
 
 
 [workspace.dependencies]
+approx = "=0.5.1"
 assert2 = "=0.3.16"
 auto_ops = "=0.3.0"
 base64 = "=0.22.1"

--- a/packages/nextclade-schemas/input-pathogen-json.schema.json
+++ b/packages/nextclade-schemas/input-pathogen-json.schema.json
@@ -185,6 +185,17 @@
         }
       ]
     },
+    "minimizerIndex": {
+      "description": "Reference sequences used to build this dataset's entry in the shared minimizer index for dataset suggestion. Build-time metadata: read when generating the index, ignored during analysis.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MinimizerIndexConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "defaultCds": {
       "description": "CDS shown by default in the Nextclade Web sequence view (e.g. \"S\", \"HA1\").",
       "type": [
@@ -440,6 +451,19 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "MinimizerIndexConfig": {
+      "description": "Configuration for building this dataset's entry in the shared minimizer index used for dataset suggestion (`nextclade sort`).",
+      "type": "object",
+      "properties": {
+        "references": {
+          "description": "FASTA files, relative to the dataset directory, whose sequences all contribute minimizers to this dataset's suggestion fingerprint. When absent, the dataset's main reference sequence is used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/packages/nextclade-schemas/input-pathogen-json.schema.yaml
+++ b/packages/nextclade-schemas/input-pathogen-json.schema.yaml
@@ -119,6 +119,11 @@ properties:
     description: Filenames of other dataset input files (reference FASTA, genome annotation, tree, examples).
     allOf:
     - $ref: '#/definitions/DatasetFiles'
+  minimizerIndex:
+    description: 'Reference sequences used to build this dataset''s entry in the shared minimizer index for dataset suggestion. Build-time metadata: read when generating the index, ignored during analysis.'
+    anyOf:
+    - $ref: '#/definitions/MinimizerIndexConfig'
+    - type: 'null'
   defaultCds:
     description: CDS shown by default in the Nextclade Web sequence view (e.g. "S", "HA1").
     type:
@@ -278,6 +283,15 @@ definitions:
         type:
         - string
         - 'null'
+  MinimizerIndexConfig:
+    description: Configuration for building this dataset's entry in the shared minimizer index used for dataset suggestion (`nextclade sort`).
+    type: object
+    properties:
+      references:
+        description: FASTA files, relative to the dataset directory, whose sequences all contribute minimizers to this dataset's suggestion fingerprint. When absent, the dataset's main reference sequence is used.
+        type: array
+        items:
+          type: string
   LabelledMutationsConfig:
     description: Mapping from specific mutations to human-readable labels (e.g. clade-defining or drug-resistance mutations).
     examples:

--- a/packages/nextclade-schemas/internal-minimizer-index-json.schema.json
+++ b/packages/nextclade-schemas/internal-minimizer-index-json.schema.json
@@ -77,8 +77,18 @@
           "type": "string"
         },
         "nMinimizers": {
+          "description": "Deprecated: prefer `expected_minimizer_hits`. Retained as the integer score denominator for older clients. For indexes that provide both fields it is the rounded `expected_minimizer_hits`; older indexes instead carry the literal count of stored minimizers.",
+          "deprecated": true,
           "type": "integer",
           "format": "int64"
+        },
+        "expectedMinimizerHits": {
+          "description": "Exact fractional expected number of minimizer hits from a single reference. Preferred as the score denominator when present; absent in older indexes, which fall back to `n_minimizers`.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
         }
       }
     }

--- a/packages/nextclade-schemas/internal-minimizer-index-json.schema.yaml
+++ b/packages/nextclade-schemas/internal-minimizer-index-json.schema.yaml
@@ -56,5 +56,13 @@ definitions:
       name:
         type: string
       nMinimizers:
+        description: 'Deprecated: prefer `expected_minimizer_hits`. Retained as the integer score denominator for older clients. For indexes that provide both fields it is the rounded `expected_minimizer_hits`; older indexes instead carry the literal count of stored minimizers.'
+        deprecated: true
         type: integer
         format: int64
+      expectedMinimizerHits:
+        description: Exact fractional expected number of minimizer hits from a single reference. Preferred as the score denominator when present; absent in older indexes, which fall back to `n_minimizers`.
+        type:
+        - number
+        - 'null'
+        format: double

--- a/packages/nextclade-schemas/nextclade-auspice-extensions.schema.json
+++ b/packages/nextclade-schemas/nextclade-auspice-extensions.schema.json
@@ -519,6 +519,17 @@
             }
           ]
         },
+        "minimizerIndex": {
+          "description": "Reference sequences used to build this dataset's entry in the shared minimizer index for dataset suggestion. Build-time metadata: read when generating the index, ignored during analysis.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MinimizerIndexConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "defaultCds": {
           "description": "CDS shown by default in the Nextclade Web sequence view (e.g. \"S\", \"HA1\").",
           "type": [
@@ -774,6 +785,19 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "MinimizerIndexConfig": {
+      "description": "Configuration for building this dataset's entry in the shared minimizer index used for dataset suggestion (`nextclade sort`).",
+      "type": "object",
+      "properties": {
+        "references": {
+          "description": "FASTA files, relative to the dataset directory, whose sequences all contribute minimizers to this dataset's suggestion fingerprint. When absent, the dataset's main reference sequence is used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/packages/nextclade-schemas/nextclade-auspice-extensions.schema.yaml
+++ b/packages/nextclade-schemas/nextclade-auspice-extensions.schema.yaml
@@ -339,6 +339,11 @@ definitions:
         description: Filenames of other dataset input files (reference FASTA, genome annotation, tree, examples).
         allOf:
         - $ref: '#/definitions/DatasetFiles'
+      minimizerIndex:
+        description: 'Reference sequences used to build this dataset''s entry in the shared minimizer index for dataset suggestion. Build-time metadata: read when generating the index, ignored during analysis.'
+        anyOf:
+        - $ref: '#/definitions/MinimizerIndexConfig'
+        - type: 'null'
       defaultCds:
         description: CDS shown by default in the Nextclade Web sequence view (e.g. "S", "HA1").
         type:
@@ -497,6 +502,15 @@ definitions:
         type:
         - string
         - 'null'
+  MinimizerIndexConfig:
+    description: Configuration for building this dataset's entry in the shared minimizer index used for dataset suggestion (`nextclade sort`).
+    type: object
+    properties:
+      references:
+        description: FASTA files, relative to the dataset directory, whose sequences all contribute minimizers to this dataset's suggestion fingerprint. When absent, the dataset's main reference sequence is used.
+        type: array
+        items:
+          type: string
   LabelledMutationsConfig:
     description: Mapping from specific mutations to human-readable labels (e.g. clade-defining or drug-resistance mutations).
     examples:

--- a/packages/nextclade/Cargo.toml
+++ b/packages/nextclade/Cargo.toml
@@ -85,6 +85,7 @@ zip = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
+approx = { workspace = true }
 assert2 = { workspace = true }
 criterion = { workspace = true }
 rstest = { workspace = true }

--- a/packages/nextclade/src/analyze/virus_properties.rs
+++ b/packages/nextclade/src/analyze/virus_properties.rs
@@ -79,6 +79,10 @@ pub struct VirusProperties {
   #[serde(default, skip_serializing_if = "DatasetFiles::is_default")]
   pub files: DatasetFiles,
 
+  /// Reference sequences used to build this dataset's entry in the shared minimizer index for dataset suggestion. Build-time metadata: read when generating the index, ignored during analysis.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub minimizer_index: Option<MinimizerIndexConfig>,
+
   /// CDS shown by default in the Nextclade Web sequence view (e.g. "S", "HA1").
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub default_cds: Option<String>,
@@ -133,6 +137,18 @@ pub struct VirusProperties {
   /// Contact and documentation URLs for dataset maintainers.
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub maintenance: Option<DatasetMaintenance>,
+
+  #[serde(flatten)]
+  pub other: serde_json::Value,
+}
+
+/// Configuration for building this dataset's entry in the shared minimizer index used for dataset suggestion (`nextclade sort`).
+#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MinimizerIndexConfig {
+  /// FASTA files, relative to the dataset directory, whose sequences all contribute minimizers to this dataset's suggestion fingerprint. When absent, the dataset's main reference sequence is used.
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub references: Vec<String>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,
@@ -412,6 +428,7 @@ impl VirusProperties {
       shortcuts: vec_of_owned!["flu_h3n2_ha_broad", "nextstrain/flu/h3n2/ha/wisconsin-67-2005"],
       meta: DatasetMeta::default(),
       files: DatasetFiles::default(),
+      minimizer_index: None,
       default_cds: Some(o!("HA1")),
       cds_order_preference: vec_of_owned!["HA1", "HA2"],
       mut_labels: LabelledMutationsConfig::example(),
@@ -455,5 +472,29 @@ impl VirusProperties {
       .compatibility
       .as_ref()
       .is_none_or(|compat| compat.is_cli_compatible(current_cli_version))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use pretty_assertions::assert_eq;
+
+  #[test]
+  fn test_virus_properties_parses_minimizer_index() {
+    let json = r#"{"schemaVersion":"3.0.0","minimizerIndex":{"references":["minimizer_refs/additional_refs.fasta"]}}"#;
+    let props = VirusProperties::from_str(&json).unwrap();
+    let mi = props
+      .minimizer_index
+      .expect("minimizerIndex should parse into the typed field");
+    assert_eq!(vec_of_owned!["minimizer_refs/additional_refs.fasta"], mi.references);
+    assert!(props.other.get("minimizerIndex").is_none());
+  }
+
+  #[test]
+  fn test_virus_properties_minimizer_index_absent_is_none() {
+    let json = r#"{"schemaVersion":"3.0.0"}"#;
+    let props = VirusProperties::from_str(&json).unwrap();
+    assert_eq!(None, props.minimizer_index);
   }
 }

--- a/packages/nextclade/src/sort/minimizer_index.rs
+++ b/packages/nextclade/src/sort/minimizer_index.rs
@@ -1,6 +1,7 @@
 use crate::io::fs::read_file_to_string;
 use crate::io::json::json_parse;
 use crate::io::schema_version::{SchemaVersion, SchemaVersionParams};
+use crate::make_error;
 use eyre::{Report, WrapErr};
 use log::warn;
 use schemars::JsonSchema;
@@ -84,7 +85,17 @@ pub struct MinimizerIndexParams {
 pub struct MinimizerIndexRefInfo {
   pub length: i64,
   pub name: String,
+
+  /// Deprecated: prefer `expected_minimizer_hits`. Retained as the integer score denominator for older
+  /// clients. For indexes that provide both fields it is the rounded `expected_minimizer_hits`; older
+  /// indexes instead carry the literal count of stored minimizers.
+  #[deprecated(note = "use `expected_minimizer_hits`; retained for backward compatibility with older indexes")]
   pub n_minimizers: i64,
+
+  /// Exact fractional expected number of minimizer hits from a single reference. Preferred as the score
+  /// denominator when present; absent in older indexes, which fall back to `n_minimizers`.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub expected_minimizer_hits: Option<f64>,
 
   #[serde(flatten)]
   pub other: serde_json::Value,
@@ -135,14 +146,110 @@ impl MinimizerIndexJson {
       );
     }
 
-    json_parse(s).wrap_err("When parsing minimizer index")
+    let index: Self = json_parse(s).wrap_err("When parsing minimizer index")?;
+    index.validate()?;
+    Ok(index)
+  }
+
+  /// Reject a malformed minimizer index before it reaches scoring. The index is external data (fetched
+  /// from a dataset server or supplied via `--input-minimizer-index-json`), so its numeric fields carry
+  /// no type-level guarantees: a negative `k`/`cutoff` casts to a huge unsigned value, and a
+  /// non-positive or non-finite denominator produces `inf`/`NaN` scores that silently win or vanish from
+  /// dataset selection. Fail loudly instead.
+  fn validate(&self) -> Result<(), Report> {
+    if self.params.k <= 0 {
+      return make_error!(
+        "Minimizer index parameter `k` must be positive, but found {}",
+        self.params.k
+      );
+    }
+    if !(0 < self.params.cutoff && self.params.cutoff <= (1_i64 << 32)) {
+      return make_error!(
+        "Minimizer index parameter `cutoff` must be in (0, 2^32], but found {}",
+        self.params.cutoff
+      );
+    }
+    for reference in &self.references {
+      if reference.length <= 0 {
+        return make_error!(
+          "Minimizer index reference '{}' has non-positive length {}",
+          reference.name,
+          reference.length
+        );
+      }
+      #[allow(deprecated)] // reads the fallback denominator to validate it, same precedence as scoring
+      let denominator = reference
+        .expected_minimizer_hits
+        .unwrap_or(reference.n_minimizers as f64);
+      if !denominator.is_finite() || denominator <= 0.0 {
+        return make_error!(
+          "Minimizer index reference '{}' has a non-positive or non-finite score denominator ({denominator})",
+          reference.name
+        );
+      }
+    }
+    Ok(())
   }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+  use pretty_assertions::assert_eq;
   use rstest::rstest;
+
+  // Minimal minimizer index JSON with one reference. `expected` is spliced verbatim (e.g.
+  // `,"expectedMinimizerHits":436.4375` or empty) so both presence and absence can be tested.
+  fn index_json(k: i64, cutoff: i64, length: i64, n_minimizers: i64, expected: &str) -> String {
+    format!(
+      r#"{{"schemaVersion":"3.0.0","version":"1","params":{{"k":{k},"cutoff":{cutoff}}},"references":[{{"length":{length},"name":"ds","nMinimizers":{n_minimizers}{expected}}}]}}"#
+    )
+  }
+
+  #[test]
+  fn test_minimizer_index_deserializes_expected_minimizer_hits() {
+    let idx = MinimizerIndexJson::from_str(index_json(
+      17,
+      1 << 28,
+      7000,
+      436,
+      r#","expectedMinimizerHits":436.4375"#,
+    ))
+    .unwrap();
+    assert_eq!(Some(436.4375), idx.references[0].expected_minimizer_hits);
+  }
+
+  #[test]
+  fn test_minimizer_index_absent_expected_minimizer_hits_deserializes_to_none() {
+    let idx = MinimizerIndexJson::from_str(index_json(17, 1 << 28, 7000, 436, "")).unwrap();
+    assert_eq!(None, idx.references[0].expected_minimizer_hits);
+    // the camelCase key did not silently land in the flatten catch-all
+    assert!(idx.references[0].other.get("expectedMinimizerHits").is_none());
+  }
+
+  #[test]
+  fn test_minimizer_index_roundtrip_omits_none_expected_minimizer_hits() {
+    let idx = MinimizerIndexJson::from_str(index_json(17, 1 << 28, 7000, 436, "")).unwrap();
+    let serialized = serde_json::to_string(&idx).unwrap();
+    assert!(!serialized.contains("expectedMinimizerHits"));
+  }
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::valid(                 index_json(17, 1 << 28,  7000, 436, r#","expectedMinimizerHits":436.4375"#), true)]
+  #[case::valid_int_fallback(    index_json(17, 1 << 28,  7000, 436, ""),                                     true)]
+  #[case::negative_k(            index_json(-1, 1 << 28,  7000, 436, ""),                                     false)]
+  #[case::zero_k(                index_json(0,  1 << 28,  7000, 436, ""),                                     false)]
+  #[case::negative_cutoff(       index_json(17, -1,       7000, 436, ""),                                     false)]
+  #[case::zero_cutoff(           index_json(17, 0,        7000, 436, ""),                                     false)]
+  #[case::zero_length(           index_json(17, 1 << 28,  0,    436, ""),                                     false)]
+  #[case::zero_denominator(      index_json(17, 1 << 28,  7000, 0,   ""),                                     false)]
+  #[case::negative_expected(     index_json(17, 1 << 28,  7000, 436, r#","expectedMinimizerHits":-1.0"#),     false)]
+  #[case::zero_expected(         index_json(17, 1 << 28,  7000, 436, r#","expectedMinimizerHits":0.0"#),      false)]
+  #[trace]
+  fn test_minimizer_index_validate(#[case] json: String, #[case] ok: bool) {
+    assert_eq!(ok, MinimizerIndexJson::from_str(&json).is_ok(), "for: {json}");
+  }
 
   #[rustfmt::skip]
   #[rstest]

--- a/packages/nextclade/src/sort/minimizer_search.rs
+++ b/packages/nextclade/src/sort/minimizer_search.rs
@@ -62,7 +62,10 @@ pub fn run_minimizer_search(
     let reff = &index.references[i];
 
     let qry_hits = hit_counts[i] as f64;
-    let ref_minimizers = reff.n_minimizers as f64;
+    // Prefer the exact fractional expectation when the index provides it; fall back to the rounded
+    // integer for older indexes that predate the `expectedMinimizerHits` field.
+    #[allow(deprecated)] // deprecated `n_minimizers` read intentionally as the backward-compat fallback
+    let ref_minimizers = reff.expected_minimizer_hits.unwrap_or(reff.n_minimizers as f64);
     let ref_len = reff.length as f64;
     let qry_len = fasta_record.seq.len() as f64;
     scores[i] = (qry_hits / ref_minimizers) * (ref_len / qry_len).max(1.0);
@@ -259,7 +262,7 @@ fn get_hash(kmer: &[u8], params: &MinimizerIndexParams) -> u64 {
       return cutoff + 1; // break out of loop, return hash above cutoff
     }
 
-    // A=11=3, C=10=2, G=00=0, T=01=1
+    // A=11=3, C=01=1, G=00=0, T=10=2
     if "AC".contains(nuc) {
       x += 1 << j;
     }
@@ -294,4 +297,89 @@ pub fn get_ref_search_minimizers(seq: &FastaRecord, params: &MinimizerIndexParam
 
 fn preprocess_seq(seq: impl AsRef<str>) -> String {
   seq.as_ref().to_uppercase().replace('-', "")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::io::fasta::FastaRecord;
+  use crate::sort::minimizer_index::{MinimizerIndexParams, MinimizerIndexRefInfo, MinimizerMap};
+  use crate::sort::params::NextcladeSeqSortParams;
+  use approx::assert_ulps_eq;
+  use rstest::rstest;
+  use serde_json::Value;
+
+  // Deterministic pseudo-random ACGT sequence (LCG), avoids long inline fixtures while producing enough
+  // distinct k-mers to clear the min_hits threshold.
+  fn make_seq(n: usize) -> String {
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut x: u64 = 0x2545_F491_4F6C_DD1D;
+    std::iter::repeat_with(|| {
+      x = x.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+      bases[((x >> 33) & 3) as usize] as char
+    })
+    .take(n)
+    .collect()
+  }
+
+  // Score a single reference whose stored minimizer set matches every query minimizer, with
+  // ref_len == qry_len so the length factor is 1. The score reduces to qry_hits / denominator, where the
+  // denominator is expected_minimizer_hits when present, else n_minimizers. Denominators are expressed as
+  // multiples of the realized query hit count so the expected score is exact regardless of that count.
+  fn single_ref_score(expected_mult: Option<f64>, n_minimizers_mult: f64) -> f64 {
+    let params = MinimizerIndexParams {
+      k: 17,
+      cutoff: 1 << 28,
+      other: Value::Null,
+    };
+    let seq = make_seq(4000);
+    let record = FastaRecord {
+      seq_name: "q".to_owned(),
+      seq: seq.clone(),
+      index: 0,
+    };
+
+    let mzs = get_ref_search_minimizers(&record, &params);
+    let n_hits = mzs.len() as f64;
+    assert!(n_hits >= 10.0, "fixture must clear min_hits, got {n_hits}");
+    let minimizers: MinimizerMap = mzs.into_iter().map(|m| (m, vec![0_usize])).collect();
+
+    #[allow(deprecated)] // constructs the deprecated `n_minimizers` to exercise the fallback path
+    let index = MinimizerIndexJson {
+      schema: String::new(),
+      schema_version: "3.0.0".to_owned(),
+      version: "1".to_owned(),
+      params,
+      minimizers,
+      references: vec![MinimizerIndexRefInfo {
+        length: seq.len() as i64,
+        name: "ref".to_owned(),
+        n_minimizers: (n_hits * n_minimizers_mult) as i64,
+        expected_minimizer_hits: expected_mult.map(|m| m * n_hits),
+        other: Value::Null,
+      }],
+      normalization: vec![],
+      other: Value::Null,
+    };
+
+    let result = run_minimizer_search(&record, &index, &NextcladeSeqSortParams::default()).unwrap();
+    result.datasets[0].score
+  }
+
+  // Denominator selection. The `prefers` case models the multi-reference regime: `n_minimizers = 4*hits`
+  // stands for the merged-union count and `expected = 2*hits` for the per-reference expectation; the
+  // score `0.5` proves the union denominator is not used (that would give `0.25`). The `falls_back` case
+  // exercises an older index with no `expectedMinimizerHits`.
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::prefers_expected_hits(      Some(2.0), 4.0, 0.5)]
+  #[case::falls_back_to_n_minimizers( None,      2.0, 0.5)]
+  #[trace]
+  fn test_minimizer_search_denominator(
+    #[case] expected_mult: Option<f64>,
+    #[case] n_minimizers_mult: f64,
+    #[case] expected_score: f64,
+  ) {
+    assert_ulps_eq!(single_ref_score(expected_mult, n_minimizers_mult), expected_score, max_ulps = 4);
+  }
 }


### PR DESCRIPTION
# PR: multi-reference minimizer scoring for dataset suggestion

`feat/multiref` -> `master`

Paired with `nextstrain/nextclade_data` branch `feat/multiref` ([PR #404](https://github.com/nextstrain/nextclade_data/pull/404)), which produces the index this change consumes. Test with CVA16 dataset using branch `cva16-testing-sample` in `nextclade_data`.

### Related

- [Meeting notes: multi-reference minimizer](https://docs.google.com/document/d/1EGIaSpCdSfgnPO0m4h9_OweGnw8wSGCio3ATK-xfof8/edit?hl=en) -- original design discussion
- nextclade_data [PR #404](https://github.com/nextstrain/nextclade_data/pull/404) -- data-side multi-ref PR
- nextclade_data [PR #412](https://github.com/nextstrain/nextclade_data/pull/412) -- initial CVA16 dataset upload
- nextclade_data [PR #442](https://github.com/nextstrain/nextclade_data/pull/442) -- prior `minimizerReferences` refactoring (superseded)
- nextclade [PR #1639](https://github.com/nextstrain/nextclade/pull/1639) -- prior fix to dataset suggestion scoring for short references
- nextclade [PR #1409](https://github.com/nextstrain/nextclade/pull/1409) -- minimizer threshold tuning (0.3 -> 0.1)
- nextclade [issue #1554](https://github.com/nextstrain/nextclade/issues/1554) -- sort without pre-calculated index

## What this enables

A single dataset can now be built from several reference sequences and still be suggested correctly by `nextclade sort`. This matters for genetically diverse pathogens (for example enteroviruses), where one reference is not close enough to every circulating sequence for reliable auto-detection, and where splitting the pathogen into several datasets only creates ambiguity about which one to analyze a sequence with.

## The problem

Dataset suggestion sketches a query into a set of minimizers and, for each candidate dataset, counts how many of the query's minimizers appear in that dataset's stored set. The count is turned into a score by dividing by the dataset's stored minimizer count, `nMinimizers`.

When a dataset is built from several references, the index stores the _union_ of the references' minimizers. A query only ever resembles one of those references, so its hit count stays roughly constant while `nMinimizers` grows with every reference added. Dividing by the union count therefore drives the score _down_ as a dataset is given better coverage, which is exactly backwards: the datasets best able to recognize a sequence are penalized for it.

## The fix

Divide by the expected number of hits from a _single_ reference instead of by the union size. For a reference of length $L$, k-mer length $k$, and acceptance cutoff $c$ over a $b$-bit hash space, the expected count is

$$E = (L - k)\,\frac{c}{2^{b}}$$

which is the number of scanned k-mers times the fraction retained by the cutoff. $E$ is invariant to how many references the dataset merges, so a query that matches one reference scores the same whether the dataset carries one reference or ten. Dividing by the union size would instead penalize a dataset purely for describing more of its own diversity.

The index now stores $E$ as a new optional `expectedMinimizerHits` field, computed per reference at index-build time. A separate field is preferred over repurposing `nMinimizers` because:

- `nMinimizers` is an integer -- rounding the fractional $E$ loses precision that can affect score ordering between close datasets
- Older clients read `nMinimizers` as the denominator; a new field lets them keep working unchanged

For single-reference datasets $E \approx$ `nMinimizers`, so the fallback to the integer field is safe and keeps older indexes scoring correctly. `nMinimizers` is deprecated but kept required for older clients.

The index is also validated when loaded: a non-positive `k`, `cutoff`, or reference length, and a non-finite or non-positive denominator, are rejected with an error rather than silently producing infinite or negative scores.

## What changes in each repository

- **nextclade (this PR)**: consume `expectedMinimizerHits` as the score denominator with a `nMinimizers` fallback, deprecate `nMinimizers`, validate the index on load, regenerate the index JSON schema, and recognize the `minimizerIndex` config in the pathogen.json schema so dataset builds no longer flag it as an unknown property.
- **nextclade_data** (`feat/multiref`): author `minimizerIndex.references` (union of several FASTA files per dataset), compute and store `expectedMinimizerHits` as the denominator, and guard degenerate inputs during the build.

## Deviations from agreed plan

- **Code change, not data-only**: the agreed plan was a data-side-only fix. The implementation adds a new `expectedMinimizerHits` field (`f64`) to the Nextclade index schema because `nMinimizers` is `i64` -- rounding the fractional analytic denominator loses precision that affects score ordering between close datasets. Older clients fall back to `nMinimizers` (same value, rounded).
- **+77% CVA16 improvement is confounded**: the before/after comparison bundles two effects: (1) the denominator fix (`expectedMinimizerHits` replacing union-count `nMinimizers`) and (2) seven additional CVA16 references in the test index (denominator drops ~2020 -> ~462 due to shorter per-reference expectation). The test does not isolate the multi-reference contribution alone.

## Backward compatibility

The two changes are backward compatible and can be reviewed independently, but they must reach production together: until the data side emits `expectedMinimizerHits`, this consumer falls back to `nMinimizers`, which on a multi-reference index is the union count and therefore the deflated denominator. No runtime warning distinguishes a healthy single-reference index from a deflated multi-reference one, so the pairing is enforced by coordinating the merge, not by the code.

## Verification

The scoring and validation paths are covered by serde round-trip tests over both the old and new index formats and by rejection tests for each validation rule. Full unit suite and clippy pass.

### CLI: end-to-end `nextclade sort` comparison

Before/after comparison using the CVA16 dataset (Coxsackievirus A16, lineages B1a/B1b/B1c/C/D/E/F) -- the motivating use case for multi-reference scoring.

<details>
<summary>Setup: build before/after binaries and indexes</summary>

Four artifacts needed. Assumes `nextclade` and `nextclade_data` repos are checked out side by side.

| Artifact                      | Repo           | Branch                 | Role                                             |
| ----------------------------- | -------------- | ---------------------- | ------------------------------------------------ |
| `nextclade-master`            | nextclade      | `master`               | Before binary (scores by `nMinimizers`)          |
| `nextclade-multiref`          | nextclade      | `feat/multiref`        | After binary (scores by `expectedMinimizerHits`) |
| `minimizer_index_before.json` | nextclade_data | `master`               | Before index (single-ref)                        |
| `minimizer_index_after.json`  | nextclade_data | `cva16-testing-sample` | After index (multi-ref, 7 additional CVA16 refs) |

```bash
# -- nextclade: build "before" binary from master --
cd nextclade
OUT="$PWD/tmp/multiref-test"
mkdir -p "$OUT"
git checkout master
./docker/dev b nextclade
cp .build/docker/debug/nextclade "$OUT/nextclade-master"

# -- nextclade: build "after" binary from feat/multiref --
git checkout feat/multiref
./docker/dev b nextclade
cp .build/docker/debug/nextclade "$OUT/nextclade-multiref"

# -- nextclade_data: rebuild "before" index from master --
cd ../nextclade_data
git checkout master
./scripts/rebuild --input-dir data/ --output-dir data_output/ \
  --no-pull --allow-dirty \
  --nextclade-schemas-dir=../nextclade/packages/nextclade-schemas
cp data_output/minimizer_index.json "../nextclade/$OUT/minimizer_index_before.json"

# -- nextclade_data: rebuild "after" index from cva16-testing-sample --
# (test branch with CVA16 multi-ref dataset configured on top of feat/multiref)
git checkout cva16-testing-sample
./scripts/rebuild --input-dir data/ --output-dir data_output/ \
  --no-pull --allow-dirty \
  --nextclade-schemas-dir=../nextclade/packages/nextclade-schemas
cp data_output/minimizer_index.json "../nextclade/$OUT/minimizer_index_after.json"

# -- copy query files --
cp data/enpen/enterovirus/cva16/sequences.fasta "../nextclade/$OUT/cva16_examples.fasta"
cp tests/minimizers/data/queries.fasta "../nextclade/$OUT/queries.fasta"

cd ../nextclade
```

</details>

#### Test 1: CVA16 example sequences (36 full-length genomes, ~7300-7400 bp)

<details>
<summary>Commands</summary>

```bash
# from nextclade repo root
./docker/dev $OUT/nextclade-master sort \
  -m $OUT/minimizer_index_before.json \
  -r $OUT/sort_cva16_before.tsv \
  $OUT/cva16_examples.fasta

./docker/dev $OUT/nextclade-multiref sort \
  -m $OUT/minimizer_index_after.json \
  -r $OUT/sort_cva16_after.tsv \
  $OUT/cva16_examples.fasta
```

</details>

All 36 sequences correctly classified as `enpen/enterovirus/cva16` in both runs. Scores improved across the board:

| Metric     | Before (single-ref) | After (multi-ref) | Delta          |
| ---------- | ------------------- | ----------------- | -------------- |
| Mean score | 0.352               | 0.625             | +0.273 (+77%)  |
| Min score  | 0.281 (OQ091684)    | 0.501 (PX448982)  | +0.220 (+78%)  |
| Max score  | 0.420 (OQ091677)    | 0.987 (OP562190)  | +0.567 (+135%) |

<details>
<summary>Per-sequence scores (36 sequences, sorted by delta)</summary>

```
seqName           before   after    delta
OQ091677            0.420   0.595   +0.175
PX448982            0.316   0.501   +0.185
KY792582            0.370   0.571   +0.201
PX449037            0.313   0.520   +0.207
PP585416            0.344   0.550   +0.207
PX448882            0.323   0.536   +0.214
PX448985            0.350   0.565   +0.215
PX448865            0.337   0.554   +0.216
PX449023            0.316   0.534   +0.218
MN541006            0.332   0.553   +0.222
PX449025            0.314   0.538   +0.224
PX448962            0.351   0.582   +0.231
PX448850            0.324   0.556   +0.232
KY792581            0.354   0.589   +0.235
MT641429            0.341   0.588   +0.248
PX448978            0.367   0.614   +0.248
OP562200            0.394   0.648   +0.254
OQ091684            0.281   0.536   +0.255
MG571837            0.333   0.594   +0.261
PQ182742            0.308   0.569   +0.261
PQ182744            0.366   0.639   +0.273
MW036460            0.356   0.633   +0.277
MW999270            0.362   0.676   +0.281
MF189180            0.352   0.635   +0.283
MH361019            0.350   0.636   +0.286
MT212012            0.379   0.671   +0.292
MW999256            0.360   0.650   +0.291
OQ791560            0.356   0.658   +0.302
MW999270            0.362   0.676   +0.313
MW030435            0.352   0.676   +0.323
MT212004            0.364   0.688   +0.324
MW030431            0.366   0.699   +0.333
MT212000            0.370   0.712   +0.342
KY425537            0.398   0.766   +0.368
KP751558            0.418   0.846   +0.428
OP562190            0.375   0.987   +0.612
```

OP562190 scores 0.987 -- it is one of the lineage references in the multi-ref set.

</details>

#### Test 2: Regression check -- mixed-pathogen queries (177 sequences)

9 CVA16 fragments (120 bp), 28 HBV, 12 HIV, 128 SARS-CoV-2.

<details>
<summary>Commands</summary>

```bash
./docker/dev $OUT/nextclade-master sort \
  -m $OUT/minimizer_index_before.json \
  -r $OUT/sort_before.tsv \
  $OUT/queries.fasta

./docker/dev $OUT/nextclade-multiref sort \
  -m $OUT/minimizer_index_after.json \
  -r $OUT/sort_after.tsv \
  $OUT/queries.fasta
```

</details>

| Dataset                               | Before | After |
| ------------------------------------- | ------ | ----- |
| nextstrain/sars-cov-2/wuhan-hu-1/orfs | 95     | 95    |
| nextstrain/sars-cov-2/BA.2.86         | 32     | 32    |
| community/neherlab/hiv-1/hxb2         | 12     | 12    |
| (unclassified)                        | 38     | 38    |

**0** assignment changes across all 177 sequences. **0** hit-count differences for the 138 classified sequences. The 9 CVA16-named queries are 120 bp fragments -- too short for minimizer matching (k=17). The 28 HBV sequences have no dataset in the index.

#### Conclusions

1. Multi-ref: +77% mean score improvement for CVA16 (0.352 -> 0.625) with zero regressions on other datasets
2. `expectedMinimizerHits` correctly compensates for union size inflation -- verified by zero hit-count differences for non-CVA16 datasets
3. Short query fragments (<500 bp) are below the practical threshold for minimizer-based sorting regardless of multi-ref support

### Work items

- [x] Divide the suggestion score by `expectedMinimizerHits`, falling back to `nMinimizers` when absent
- [x] Add optional `expectedMinimizerHits` to the minimizer index schema (regenerated JSON and YAML)
- [x] Deprecate `nMinimizers` while keeping it required for older clients
- [x] Validate the minimizer index on load (reject non-positive `k`, `cutoff`, length, and non-finite or non-positive denominator)
- [x] Add serde round-trip and validation-rejection tests; add the `approx` dev-dependency for float assertions
- [x] Add a typed `minimizerIndex` field (`references`) to the pathogen.json config so the generated schema documents it instead of leaving it in the untyped catch-all
