### PR TITLE
perf: speed up dataset-suggestion minimizer search

### DIFF
--- a/dev/profile
+++ b/dev/profile
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Usage: $0 [options] <program> [args...]
+#
+# Sampling performance profiling on the host (not in the container).
+#
+# Builds the given binary with the `profiling` cargo profile (optimized release build with debug
+# symbols kept, not stripped; see `.cargo/config.toml`), then samples it with a profiler.
+#
+# Two output modes:
+#   * samply (default): records with samply (https://github.com/mstange/samply) and opens the
+#     Firefox Profiler UI (https://profiler.firefox.com) in the browser. For interactive use.
+#   * --report: records with perf and prints a text hotspot report to stdout. For headless,
+#     scripted, or CI use where a browser is not available.
+#
+# For meaningful results the workload should run for at least a few seconds; a sampling profiler
+# collects ~1000 samples/second. Profile single-threaded first (e.g. `nextclade sort -j 1 ...`) so
+# samples are not spread across worker threads.
+#
+# Options:
+#   -h, --help     Show this help
+#   --report       Use perf and print a text report to stdout instead of opening samply UI
+#   --rate <hz>    Sampling rate in Hz (default: 1234)
+#
+# Examples:
+#   $0 nextclade sort -j 1 -m index.json queries.fasta -r /dev/null
+#   $0 --report nextclade sort -j 1 -m index.json queries.fasta -r /dev/null
+#
+# Requirements:
+#   * cargo, and the host toolchain from rust-toolchain.toml
+#   * samply (`cargo install samply`) for the default mode
+#   * perf (https://perf.wiki.kernel.org) for --report mode and as the samply backend on Linux
+#   * unprivileged access to performance events (otherwise results may be incomplete):
+#       echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null
+#       echo  0 | sudo tee /proc/sys/kernel/kptr_restrict        >/dev/null
+#     Learn the security implications first:
+#       https://www.kernel.org/doc/html/latest/admin-guide/perf-security.html
+#
+set -euo pipefail
+trap "exit" INT
+
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PROJECT_DIR="$(dirname "${THIS_DIR}")"
+
+readonly PERF_DATA="${PROJECT_DIR}/tmp/perf.data"
+readonly SAMPLY_JSON="${PROJECT_DIR}/tmp/samply.json"
+
+build_binary() {
+  local bin="${1}"
+  if ! cargo build --quiet --profile=profiling --manifest-path="${PROJECT_DIR}/Cargo.toml" --bin="${bin}"; then
+    printf "Failed to build binary '%s' with the profiling profile\n" "${bin}" >&2
+    exit 1
+  fi
+}
+
+profile_samply() {
+  local rate="${1}" bin_path="${2}"
+  shift 2
+  samply record --rate="${rate}" -o "${SAMPLY_JSON}" -- "${bin_path}" "$@"
+}
+
+profile_perf_report() {
+  local rate="${1}" bin_path="${2}"
+  shift 2
+  mkdir -p "${PROJECT_DIR}/tmp"
+  if ! perf record -F "${rate}" --call-graph dwarf -o "${PERF_DATA}" -- "${bin_path}" "$@"; then
+    printf "perf record failed; check /proc/sys/kernel/perf_event_paranoid (see --help)\n" >&2
+    exit 1
+  fi
+  # Self-time hotspots (where the CPU actually spent time), most expensive first.
+  perf report -i "${PERF_DATA}" --stdio --percent-limit=1 --sort=overhead,symbol -g none
+}
+
+main() {
+  show_help() {
+    sed -n '2,${/^#/!q; s/^# \?//p}' "${BASH_SOURCE[0]}" | sed "s|\$0|${0##*/}|g"
+  }
+
+  [[ "${1:-}" =~ ^(-h|--help)$ ]] && {
+    show_help
+    exit 0
+  }
+
+  local report=false
+  local rate=1234
+
+  # shfmt:off
+  while (($# > 0)); do
+    case "${1}" in
+      -h | --help)
+        show_help
+        exit 0
+        ;;
+      --report)
+        report=true
+        shift
+        ;;
+      --rate)
+        rate="${2}"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        printf "Unknown option: %s\n" "${1}" >&2
+        exit 1
+        ;;
+      *) break ;;
+    esac
+  done
+  # shfmt:on
+
+  if (($# == 0)); then
+    printf "Expected a program name. See --help.\n" >&2
+    exit 1
+  fi
+
+  local bin="${1}"
+  shift
+
+  build_binary "${bin}"
+
+  local bin_path="${PROJECT_DIR}/target/profiling/${bin}"
+  if [[ ! -x "${bin_path}" ]]; then
+    printf "Built binary not found at %s\n" "${bin_path}" >&2
+    exit 1
+  fi
+
+  mkdir -p "${PROJECT_DIR}/tmp"
+
+  if "${report}"; then
+    profile_perf_report "${rate}" "${bin_path}" "$@"
+  else
+    profile_samply "${rate}" "${bin_path}" "$@"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/kb/tickets/perf-minimizer-search-lookup-map.md
+++ b/kb/tickets/perf-minimizer-search-lookup-map.md
@@ -1,0 +1,61 @@
+# Speed up minimizer-search lookups with a hash map
+
+## Motivation
+
+Raising a dataset's `minimizerIndex.cutoff` forces the global `params.cutoff` in the shared minimizer index up to the maximum across all datasets (the client hashes each query once, before it knows which dataset matches, so it must hash at the widest cutoff any dataset needs). A wider global cutoff makes the `sort` dataset-suggestion step slower for every query and every dataset, not just the one that requested the wider cutoff. PR [#1772](https://github.com/nextstrain/nextclade/pull/1772) reported +67% sort runtime for a global cutoff of `1<<31` and asked where the time goes; a PR review comment (rneher) asked specifically whether the larger span of map keys makes lookups less efficient.
+
+This ticket records the profiling result and proposes the remaining optimization. The two dominant costs (the SipHash dedup and the per-hit reference scan) were already fixed; see "Resolved on this branch". The remaining item is the map lookup itself.
+
+## Profiling result
+
+Measured with a criterion benchmark isolating `run_minimizer_search` from CLI startup and IO, over a mixed 235-sequence query set against the real production index (103 references, 44508 entries, k=17). The index is identical between the two columns; only the global `params.cutoff` differs (`1<<28` vs `1<<31`), which is exactly what one dataset raising its cutoff produces. Attribution splits the per-query cost into the hashing/dedup stage (`get_ref_search_minimizers`) and the map-lookup + hit-count stage.
+
+Baseline (before the fixes on this branch), per full query set:
+
+| Stage                  | cutoff 1<<28 | cutoff 1<<31 | delta    |
+| ---------------------- | ------------ | ------------ | -------- |
+| hashing + dedup        | 351.8 ms     | 432.5 ms     | +80.7 ms |
+| map lookup + hit count | 94.7 ms      | 103.3 ms     | +8.6 ms  |
+| full search            | 446.5 ms     | 535.8 ms     | +89.3 ms |
+
+Key finding, correcting the hypothesis in the PR comment thread: the wider-cutoff slowdown is **not** dominated by extra `BTreeMap::get` lookups. 90% of the added cost (+80.7 of +89.3 ms) is in `get_ref_search_minimizers`. The k-mer hashing there runs for every k-mer regardless of cutoff, so the cutoff-scaling cost was the handling of the ~8x more surviving minimizers: `Itertools::unique`, which allocates a SipHash-keyed `HashSet` to deduplicate.
+
+The extra `BTreeMap` lookups the PR comment worried about are real but secondary. They were masked in the baseline by an even more expensive per-hit reference scan; once that scan is removed (see below), the pure lookup cost of the extra (mostly missing) c31 query k-mers becomes visible at roughly +30 ms, and an isolated comparison shows a `HashMap` view resolves them ~44% faster than the `BTreeMap` (53.6 ms vs 30.1 ms for the c31 lookup stage).
+
+## Resolved on this branch
+
+Both are correctness-preserving (byte-identical `sort` output on the 235-sequence set for both cutoffs, verified against a captured baseline) and are covered by unit tests in `packages/nextclade/src/sort/minimizer_search.rs`.
+
+1. Dedup query minimizers via `sort_unstable` + `dedup` instead of `Itertools::unique`. Removes the SipHash `HashSet` allocation. Cut the wider-cutoff hashing-stage penalty from ~80 ms to ~31 ms; the consumer needs only the distinct set, so iteration order is irrelevant.
+2. Count hits by iterating the references stored in each matched map entry, instead of scanning all `n_refs` and testing `Vec::contains` per entry (`O(n_refs * mz.len())` per hit, reduced to `O(mz.len())`). Cut the hit-count cost ~75%.
+
+Combined: full search -18% at cutoff 1<<28 and -22% at cutoff 1<<31; the wider-cutoff penalty dropped from +89 ms to +54 ms.
+
+## Proposal: hash-map lookups
+
+Replace the `BTreeMap<u64, Vec<usize>>` lookups in `run_minimizer_search` with a hash map. On `u64` hash keys this turns each lookup from `O(log N)` (with cache-unfriendly tree traversal) into `O(1)`, and directly addresses both the extra c31 misses and the review comment about key-span. An isolated benchmark measured -44% on the c31 lookup stage even with the standard-library SipHash map; a faster hasher (`rustc-hash` / `FxHashMap`) on these trusted keys would improve on that.
+
+The serialized index format must stay deterministic (sorted keys, so dataset builds are reproducible and diffable), so the on-disk `MinimizerMap = BTreeMap<u64, Vec<usize>>` and its custom serializer are kept. The hash map is a search-time view only.
+
+Design axes (independent choices):
+
+- **Hasher**: standard-library `HashMap` (no new dependency, SipHash, already -44%) vs `FxHashMap` from `rustc-hash` (faster on `u64`, adds a workspace dependency; justified for a profiled hot path with trusted keys).
+- **Ownership**: the WASM caller (`packages/nextclade-web/src/wasm/seq_autodetect.rs:82`) holds the index in a long-lived struct and calls `run_minimizer_search` per record. A borrowed view (`HashMap<u64, &[usize]>`) built once would be self-referential with the stored index. Options: (a) store an owned `HashMap<u64, Vec<usize>>` search view built at load and search against it (one-time O(N) clone of the small per-hash vectors); (b) restructure so the index and its search view are constructed together and the view borrows; (c) build the view once per `sort` run in the CLI/WASM caller and pass it into `run_minimizer_search` as a parameter.
+
+Cross-repo note: `MinimizerMap` is defined in the `nextclade` crate and consumed by the `nextclade_data` builder. Keeping the on-disk type unchanged confines this change to the `nextclade` repo. Changing the stored type would require coordinated `nextclade_data` changes.
+
+## Per-dataset cutoff feasibility
+
+PR #1772 sets the global cutoff to `max(all per-dataset cutoffs)` and notes it could not scope the client cost to the requesting dataset. This is structurally unavoidable: the client hashes each query once, before dataset assignment, so it must hash at the widest cutoff any dataset needs. The stored index already enforces per-dataset cutoffs correctly (each dataset stores only hashes below its own cutoff, so a query hash above a dataset's cutoff never hits it), so results are already correct; only the client-side hashing volume is global.
+
+The practical consequence changes with the profiling result: the global client cost was dominated by the SipHash dedup, not by anything fundamental to hashing more k-mers. With that removed, the residual wider-cutoff penalty is small, and the hash-map lookup proposal removes most of what remains. Per-dataset scoping of the client cost is therefore not necessary to make wider cutoffs cheap.
+
+## Verification
+
+- Criterion benchmark `packages/nextclade/benches/bench_minimizer_search.rs` (self-contained, deterministic synthetic data). Splits hashing vs lookup and compares `BTreeMap` vs `HashMap` lookups; re-run before and after any lookup change.
+- `sort` output must remain byte-identical across the change for both cutoffs (capture a baseline TSV on a mixed query set and diff).
+
+## Related
+
+- PR [#1772](https://github.com/nextstrain/nextclade/pull/1772) - per-dataset minimizer cutoff exponent (this branch's base)
+- PR [#1649](https://github.com/nextstrain/nextclade/pull/1649) - earlier sort-perf work (bit-packed k-mer conversion), not merged

--- a/kb/tickets/perf-minimizer-search-lookup-map.md
+++ b/kb/tickets/perf-minimizer-search-lookup-map.md
@@ -22,6 +22,22 @@ Key finding, correcting the hypothesis in the PR comment thread: the wider-cutof
 
 The extra `BTreeMap` lookups the PR comment worried about are real but secondary. They were masked in the baseline by an even more expensive per-hit reference scan; once that scan is removed (see below), the pure lookup cost of the extra (mostly missing) c31 query k-mers becomes visible at roughly +30 ms, and an isolated comparison shows a `HashMap` view resolves them ~44% faster than the `BTreeMap` (53.6 ms vs 30.1 ms for the c31 lookup stage).
 
+### Confirmed with a sampling profiler
+
+Cross-checked with `samply`/`perf` on the host (`dev/profile`, `profiling` cargo profile), sampling the single-threaded `sort` on the c31 workload. Inclusive share of total samples, `run_minimizer_search` at ~95%:
+
+| Symbol                                                | pre-fix | post-fix |
+| ----------------------------------------------------- | ------- | -------- |
+| `get_ref_search_minimizers`                           | 75%     | 81%      |
+| `get_hash` (per-k-mer hashing, incl. char membership) | 57%     | 72%      |
+| `Itertools::unique` dedup (SipHash `HashSet`)         | 14%     | 0%       |
+| ...of which `hashbrown` resize/rehash                 | 9%      | -        |
+| ...of which `SipHash` hashing                         | 6%      | -        |
+| sort + dedup (`quicksort`), post-fix replacement      | -       | 5%       |
+| `BTreeMap::get` (map lookup)                          | 10%     | 12%      |
+
+The profiler localizes the pre-fix dedup cost concretely: the SipHash `HashSet` behind `Itertools::unique` spends most of its time in `hashbrown` reserve/rehash as it grows to hold the ~8x more surviving minimizers at the wider cutoff. Post-fix these symbols are absent, replaced by a ~5% `quicksort`. It also confirms `BTreeMap::get` is a stable ~10-12% (secondary, not the driver), and that the remaining dominant cost is the intrinsic per-k-mer `get_hash` -- which is cutoff-independent and is the target of the unmerged bit-packing work in PR [#1649](https://github.com/nextstrain/nextclade/pull/1649).
+
 ## Resolved on this branch
 
 Both are correctness-preserving (byte-identical `sort` output on the 235-sequence set for both cutoffs, verified against a captured baseline) and are covered by unit tests in `packages/nextclade/src/sort/minimizer_search.rs`.

--- a/packages/nextclade/Cargo.toml
+++ b/packages/nextclade/Cargo.toml
@@ -101,3 +101,7 @@ harness = false
 [[bench]]
 name = "bench_seed_alignment"
 harness = false
+
+[[bench]]
+name = "bench_minimizer_search"
+harness = false

--- a/packages/nextclade/benches/bench_minimizer_search.rs
+++ b/packages/nextclade/benches/bench_minimizer_search.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nextclade::io::fasta::FastaRecord;
+use nextclade::sort::minimizer_index::{MinimizerIndexJson, MinimizerIndexParams, MinimizerIndexRefInfo, MinimizerMap};
+use nextclade::sort::minimizer_search::{get_ref_search_minimizers, run_minimizer_search};
+use nextclade::sort::params::NextcladeSeqSortParams;
+use serde_json::Value;
+
+// Attribution benchmark for the dataset-suggestion minimizer search.
+//
+// Isolates the per-query search cost (`run_minimizer_search`) from CLI startup and IO, and
+// attributes the runtime of the wider-cutoff scenario to concrete code paths:
+//
+//   - `hash`   : `get_ref_search_minimizers` only  (k-mer hashing + cutoff filter + dedup)
+//   - `search` : full `run_minimizer_search`        (hashing + map lookups + hit counting)
+//
+// The `search - hash` difference is the map-lookup + hit-count cost.
+//
+// The `c28` / `c31` suffixes vary only the global `params.cutoff` (1<<28 vs 1<<31) over one index
+// that is always built at cutoff 1<<28 -- exactly the situation a per-dataset cutoff creates: one
+// dataset raises the global cutoff, so every query hashes and looks up ~8x more k-mers while the
+// stored index barely grows. Data is generated deterministically in-code so the benchmark is
+// self-contained and reproducible.
+//
+// `lookup_btree_c31` vs `lookup_hashmap_c31` isolates the map-lookup cost of the extra (mostly
+// missing) c31 query k-mers, comparing the on-disk `BTreeMap` against a `HashMap` view.
+
+const K: usize = 17;
+const CUTOFF_28: i64 = 1 << 28;
+const CUTOFF_31: i64 = 1 << 31;
+const N_REFS: usize = 100;
+const REF_LEN: usize = 2000;
+const N_QUERIES: usize = 60;
+const QRY_LEN: usize = 4000;
+
+pub fn bench_minimizer_search(c: &mut Criterion) {
+  let params = NextcladeSeqSortParams::default();
+  let queries = make_queries();
+
+  let index_c28 = build_index(CUTOFF_28);
+  let index_c31 = build_index(CUTOFF_31);
+
+  let mut group = c.benchmark_group("minimizer_search");
+
+  group.bench_function("hash_c28", |b| {
+    b.iter(|| {
+      for q in &queries {
+        black_box(get_ref_search_minimizers(q, &index_c28.params));
+      }
+    });
+  });
+
+  group.bench_function("hash_c31", |b| {
+    b.iter(|| {
+      for q in &queries {
+        black_box(get_ref_search_minimizers(q, &index_c31.params));
+      }
+    });
+  });
+
+  group.bench_function("search_c28", |b| {
+    b.iter(|| {
+      for q in &queries {
+        black_box(run_minimizer_search(q, &index_c28, &params).unwrap());
+      }
+    });
+  });
+
+  group.bench_function("search_c31", |b| {
+    b.iter(|| {
+      for q in &queries {
+        black_box(run_minimizer_search(q, &index_c31, &params).unwrap());
+      }
+    });
+  });
+
+  let mzs_per_query: Vec<Vec<u64>> = queries
+    .iter()
+    .map(|q| get_ref_search_minimizers(q, &index_c31.params))
+    .collect();
+  let btree = &index_c31.minimizers;
+  let hashmap: HashMap<u64, Vec<usize>> = btree.iter().map(|(k, v)| (*k, v.clone())).collect();
+
+  group.bench_function("lookup_btree_c31", |b| {
+    b.iter(|| black_box(count_hits(&mzs_per_query, |m| btree.get(m).map(Vec::as_slice))));
+  });
+
+  group.bench_function("lookup_hashmap_c31", |b| {
+    b.iter(|| black_box(count_hits(&mzs_per_query, |m| hashmap.get(m).map(Vec::as_slice))));
+  });
+
+  group.finish();
+}
+
+// Count per-reference hits over precomputed query minimizer streams, using the provided lookup.
+fn count_hits<'a>(mzs_per_query: &[Vec<u64>], lookup: impl Fn(&u64) -> Option<&'a [usize]>) -> u64 {
+  let mut total = 0;
+  for mzs in mzs_per_query {
+    let mut hit_counts = vec![0_u64; N_REFS];
+    for m in mzs {
+      if let Some(mz) = lookup(m) {
+        for &ri in mz {
+          if let Some(hc) = hit_counts.get_mut(ri) {
+            *hc += 1;
+          }
+        }
+      }
+    }
+    total += hit_counts.iter().sum::<u64>();
+  }
+  total
+}
+
+// Index built at cutoff 1<<28 from `N_REFS` deterministic reference sequences; `params.cutoff` is set
+// to `cutoff` to model the global client cutoff independently of the stored index.
+fn build_index(cutoff: i64) -> MinimizerIndexJson {
+  let build_params = MinimizerIndexParams {
+    k: K as i64,
+    cutoff: CUTOFF_28,
+    other: Value::Null,
+  };
+
+  let mut minimizers = MinimizerMap::new();
+  let mut references = Vec::with_capacity(N_REFS);
+  for ri in 0..N_REFS {
+    let seq = make_seq(REF_LEN, 0x51ED_270B_u64.wrapping_add(ri as u64));
+    let record = FastaRecord {
+      seq_name: format!("ref{ri}"),
+      seq,
+      index: ri,
+    };
+    let mzs = get_ref_search_minimizers(&record, &build_params);
+    for m in &mzs {
+      minimizers.entry(*m).or_default().push(ri);
+    }
+    #[allow(deprecated)] // `n_minimizers` is a required struct field; scoring uses `expected_minimizer_hits`
+    references.push(MinimizerIndexRefInfo {
+      length: REF_LEN as i64,
+      name: format!("ref{ri}"),
+      n_minimizers: mzs.len() as i64,
+      expected_minimizer_hits: Some(mzs.len() as f64),
+      other: Value::Null,
+    });
+  }
+
+  MinimizerIndexJson {
+    schema: String::new(),
+    schema_version: "3.0.0".to_owned(),
+    version: "1".to_owned(),
+    params: MinimizerIndexParams {
+      k: K as i64,
+      cutoff,
+      other: Value::Null,
+    },
+    minimizers,
+    references,
+    normalization: vec![],
+    other: Value::Null,
+  }
+}
+
+// Queries overlap the reference seeds (guaranteeing real hits) but are longer and use different
+// seeds for the tail, producing both hits and misses like a real mixed query set.
+fn make_queries() -> Vec<FastaRecord> {
+  (0..N_QUERIES)
+    .map(|qi| FastaRecord {
+      seq_name: format!("q{qi}"),
+      seq: make_seq(QRY_LEN, 0x51ED_270B_u64.wrapping_add((qi % N_REFS) as u64)),
+      index: qi,
+    })
+    .collect()
+}
+
+// Deterministic pseudo-random ACGT sequence via a linear congruential generator.
+fn make_seq(n: usize, seed: u64) -> String {
+  let bases = [b'A', b'C', b'G', b'T'];
+  let mut x = seed ^ 0x2545_F491_4F6C_DD1D;
+  std::iter::repeat_with(|| {
+    x = x.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    bases[((x >> 33) & 3) as usize] as char
+  })
+  .take(n)
+  .collect()
+}
+
+criterion_group!(benches, bench_minimizer_search);
+criterion_main!(benches);

--- a/packages/nextclade/src/sort/minimizer_search.rs
+++ b/packages/nextclade/src/sort/minimizer_search.rs
@@ -296,7 +296,13 @@ pub fn get_ref_search_minimizers(seq: &FastaRecord, params: &MinimizerIndexParam
       minimizers.push(mhash);
     }
   }
-  minimizers.into_iter().unique().collect_vec()
+  // Deduplicate distinct minimizers via sort + dedup. The consumer only needs the set of distinct
+  // hashes (order is irrelevant), so this avoids `Itertools::unique`, which allocates a SipHash-keyed
+  // `HashSet`. A wider `cutoff` admits proportionally more surviving hashes, and the SipHash dedup
+  // dominated that cost; sort + dedup on `u64` keys removes the allocation and hashing overhead.
+  minimizers.sort_unstable();
+  minimizers.dedup();
+  minimizers
 }
 
 fn preprocess_seq(seq: impl AsRef<str>) -> String {

--- a/packages/nextclade/src/sort/minimizer_search.rs
+++ b/packages/nextclade/src/sort/minimizer_search.rs
@@ -392,4 +392,108 @@ mod tests {
   ) {
     assert_ulps_eq!(single_ref_score(expected_mult, n_minimizers_mult), expected_score, max_ulps = 4);
   }
+
+  // `get_ref_search_minimizers` returns the distinct set of surviving hashes. The dedup is done by
+  // sort + dedup, so the result must be strictly increasing (sorted, no duplicates). The consumer
+  // relies only on distinctness; this test pins the sorted-unique postcondition.
+  #[test]
+  fn test_minimizer_search_get_ref_search_minimizers_are_sorted_and_unique() {
+    let params = MinimizerIndexParams {
+      k: 17,
+      cutoff: 1 << 28,
+      other: Value::Null,
+    };
+    let record = FastaRecord {
+      seq_name: "q".to_owned(),
+      seq: make_seq(4000),
+      index: 0,
+    };
+
+    let mzs = get_ref_search_minimizers(&record, &params);
+    assert!(
+      mzs.len() >= 10,
+      "fixture must produce enough minimizers, got {}",
+      mzs.len()
+    );
+    assert!(
+      mzs.iter().tuple_windows().all(|(a, b)| a < b),
+      "minimizers must be strictly increasing (sorted and deduplicated)"
+    );
+  }
+
+  // Hit counting must increment exactly the references listed in each map entry, once per distinct
+  // query minimizer. This pins the multi-reference case: a minimizer shared by several references
+  // increments all of them, and only them. Guards the direct-iteration counting path.
+  #[test]
+  fn test_minimizer_search_counts_each_reference_in_multiref_entry() {
+    let params = MinimizerIndexParams {
+      k: 17,
+      cutoff: 1 << 28,
+      other: Value::Null,
+    };
+    let seq = make_seq(4000);
+    let record = FastaRecord {
+      seq_name: "q".to_owned(),
+      seq: seq.clone(),
+      index: 0,
+    };
+
+    let mzs = get_ref_search_minimizers(&record, &params);
+    let n = mzs.len();
+    assert!(n >= 10, "fixture must clear min_hits, got {n}");
+    let half = n / 2;
+
+    // ref 0 carries every query minimizer; ref 1 carries the first half; ref 2 carries none.
+    // Entries in the first half list two references, exercising multi-reference counting.
+    let minimizers: MinimizerMap = mzs
+      .iter()
+      .enumerate()
+      .map(|(i, &m)| (m, if i < half { vec![0, 1] } else { vec![0] }))
+      .collect();
+
+    #[allow(deprecated)] // `n_minimizers` is a required struct field; scoring uses `expected_minimizer_hits`
+    let ref_info = |name: &str| MinimizerIndexRefInfo {
+      length: seq.len() as i64,
+      name: name.to_owned(),
+      n_minimizers: n as i64,
+      expected_minimizer_hits: Some(n as f64),
+      other: Value::Null,
+    };
+
+    let index = MinimizerIndexJson {
+      schema: String::new(),
+      schema_version: "3.0.0".to_owned(),
+      version: "1".to_owned(),
+      params,
+      minimizers,
+      references: vec![ref_info("ref0"), ref_info("ref1"), ref_info("ref2")],
+      normalization: vec![],
+      other: Value::Null,
+    };
+
+    // Keep every reaching reference so raw hit counts are observable: accept low hit counts and
+    // scores, and disable the score-gap truncation that would otherwise drop the lower-scoring ref1.
+    let search_params = NextcladeSeqSortParams {
+      min_hits: 1,
+      min_score: 0.0,
+      max_score_gap: f64::INFINITY,
+      all_matches: true,
+      ..NextcladeSeqSortParams::default()
+    };
+
+    let result = run_minimizer_search(&record, &index, &search_params).unwrap();
+    let hits = |name: &str| result.datasets.iter().find(|d| d.name == name).map(|d| d.n_hits);
+
+    assert_eq!(
+      Some(n as u64),
+      hits("ref0"),
+      "ref0 must be hit by every distinct minimizer"
+    );
+    assert_eq!(
+      Some(half as u64),
+      hits("ref1"),
+      "ref1 must be hit by exactly the shared half"
+    );
+    assert_eq!(None, hits("ref2"), "ref2 carries no minimizer and must not be reported");
+  }
 }

--- a/packages/nextclade/src/sort/minimizer_search.rs
+++ b/packages/nextclade/src/sort/minimizer_search.rs
@@ -48,8 +48,12 @@ pub fn run_minimizer_search(
   let mut hit_counts = vec![0; n_refs];
   for m in minimizers {
     if let Some(mz) = index.minimizers.get(&m) {
-      for (ri, hit_count) in hit_counts.iter_mut().enumerate() {
-        if mz.contains(&ri) {
+      // Each map entry `mz` already lists exactly the references carrying minimizer `m`, so we
+      // increment those directly. Scanning all `n_refs` and testing `mz.contains(&ri)` for each
+      // (a linear `Vec` scan) is `O(n_refs * mz.len())` per hit; direct iteration is `O(mz.len())`.
+      // `get_mut` skips any out-of-range reference index, matching the previous `0..n_refs` bound.
+      for &ri in mz {
+        if let Some(hit_count) = hit_counts.get_mut(ri) {
           *hit_count += 1;
         }
       }


### PR DESCRIPTION
- Related to: #1772

The `sort` dataset-suggestion step hashes each query into minimizers and looks them up against a shared index. Raising a dataset's `minimizerIndex.cutoff` widens the global `params.cutoff` (the client hashes each query once, before it knows which dataset matches, so it must hash at the widest cutoff any dataset uses). The wider cutoff admits several times more query k-mers and slows this step for every query and every dataset, not only the one that raised its cutoff. Where that added cost came from was unverified: extra `BTreeMap::get` lookups, a larger key span in the map, or something else.

This fixes two hot-path inefficiencies in `run_minimizer_search`, together cutting its time by 18% at the default cutoff and 22% at the widest, with byte-identical `sort` output at both cutoffs.

### What was fixed

- **Deduplication.** `get_ref_search_minimizers` deduplicated the surviving query minimizers with `Itertools::unique`, which fills a hash set that grows with the wider cutoff. It now sorts the small per-query list and drops adjacent duplicates instead [[src](https://github.com/nextstrain/nextclade/blob/a02b07a87a07806283958157401c75bd3ff8ab31/packages/nextclade/src/sort/minimizer_search.rs#L303-L304)]. The consumer needs only the distinct set, so iteration order is irrelevant.
- **Hit counting.** For every matched query minimizer, the old code scanned all references and tested membership with a linear `Vec::contains`, costing `O(references * entries)` per hit. Each map entry already lists exactly the references carrying that minimizer, so it now increments those directly, `O(entries)` per hit [[src](https://github.com/nextstrain/nextclade/blob/a02b07a87a07806283958157401c75bd3ff8ab31/packages/nextclade/src/sort/minimizer_search.rs#L49-L61)].

Both are behavior-preserving: the counted hits and the distinct minimizer set are identical, so `sort` output is unchanged (verified byte-identical at both cutoffs).

### How it was measured

Single-threaded `sort` on one production index (103 references, 44508 entries, k=17), varying only `params.cutoff` (`1<<28` vs `1<<31`) so the stored index is identical between runs. Two independent methods agree:

1. A differential benchmark: criterion on `run_minimizer_search` [[src](https://github.com/nextstrain/nextclade/blob/a02b07a87a07806283958157401c75bd3ff8ab31/packages/nextclade/src/sort/minimizer_search.rs#L40)], isolated from CLI startup and IO, splitting each query into the hashing/dedup stage and the map-lookup/hit-count stage. `cargo bench --bench bench_minimizer_search` reproduces the split and a `BTreeMap`-vs-`HashMap` lookup comparison.
2. A sampling profiler: `samply`/`perf` on a release build with debug symbols, before and after the fix, for symbol-level confirmation.

### Findings

Full `run_minimizer_search` time (criterion, mixed query set, ms):

| Build  | cutoff 1<<28 | cutoff 1<<31 | wider-cutoff penalty |
| ------ | ------------ | ------------ | -------------------- |
| before | 446          | 536          | +89 (+20%)           |
| after  | 365 (-18%)   | 419 (-22%)   | +54 (+15%)           |

End-to-end CLI wall-clock (includes startup and index parse): default cutoff 0.84 s -> 0.75 s, widest cutoff 1.04 s -> 0.82 s.

The wider-cutoff penalty was not the map lookups. Splitting the pre-fix +89 ms by stage (both cutoffs pre-fix):

| Stage                  | 1<<28    | 1<<31    | delta        |
| ---------------------- | -------- | -------- | ------------ |
| hashing + dedup        | 351.8 ms | 432.5 ms | **+80.7 ms** |
| map lookup + hit count | 94.7 ms  | 103.3 ms | +8.6 ms      |

90% of the added cost is in `get_ref_search_minimizers`. The per-k-mer hashing runs for every k-mer regardless of cutoff, so the cutoff-scaling cost is deduplicating the several-times-larger set of surviving minimizers: `Itertools::unique` stores seen values in a `HashSet` [[doc](https://docs.rs/itertools/0.11.0/itertools/trait.Itertools.html#method.unique)] keyed with the standard-library default `SipHash`, and that set grows with the number of surviving minimizers. The profiler confirms it (inclusive share of samples at cutoff `1<<31`, `run_minimizer_search` at ~95%):

| Symbol                                        | before | after  |
| --------------------------------------------- | ------ | ------ |
| `Itertools::unique` dedup (SipHash `HashSet`) | 14%    | **0%** |
| ...`hashbrown` resize/rehash                  | 9%     | -      |
| ...`SipHash` hashing                          | 6%     | -      |
| `BTreeMap::get` (lookup)                      | 10%    | 12%    |
| `get_hash` (per-k-mer, cutoff-independent)    | 57%    | 72%    |

The `HashSet` spends most of its time in `hashbrown` reserve/rehash as it grows. `BTreeMap::get` is a stable 10-12%, secondary and independent of key magnitude (`O(log n)` in entry count, which barely changes when a single dataset raises its cutoff).

### Remaining cost

After the fix, the dominant cost is the intrinsic per-k-mer `get_hash` (the char-membership `"ACGT".contains` path), which is cutoff-independent and is the target of the bit-packing in #1649. Because the wider-cutoff penalty was the dedup rather than anything fundamental to hashing more k-mers, wider cutoffs are now cheap, and scoping the client cost per dataset is unnecessary.

### Work items

- [x] Deduplicate query minimizers by sorting instead of `Itertools::unique`
- [x] Count hits by iterating each matched entry's references instead of scanning all references
- [x] Add unit tests for the sorted-unique invariant and multi-reference hit counting
- [x] Add a criterion benchmark attributing search cost across cutoff and lookup structure
- [x] Add a host sampling-profiler script (`dev/profile`)
- [x] File proposal: [perf-minimizer-search-lookup-map.md](https://github.com/nextstrain/nextclade/blob/a02b07a87a07806283958157401c75bd3ff8ab31/kb/tickets/perf-minimizer-search-lookup-map.md): profiling findings and hash-map lookup follow-up

### Possible improvements

- [ ] Replace the search-time `BTreeMap` lookups with a hash map, measured -44% on the lookup stage ([perf-minimizer-search-lookup-map.md](https://github.com/nextstrain/nextclade/blob/a02b07a87a07806283958157401c75bd3ff8ab31/kb/tickets/perf-minimizer-search-lookup-map.md))
