### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/bioconda.yml
+++ b/.github/workflows/bioconda.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true

--- a/.github/workflows/builder-docker-image.yml
+++ b/.github/workflows/builder-docker-image.yml
@@ -29,19 +29,19 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Free disk space"
         uses: ./.github/actions/free-disk-space
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: nextstrainbot
@@ -52,7 +52,7 @@ jobs:
         run: echo "checksum=$(./scripts/docker_build_checksum.sh)" >> $GITHUB_OUTPUT
 
       - name: "Setup cache for Docker buildx"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .cache/docker/buildx
           key: cache-v1-buildx-${{ runner.os }}-${{ steps.docker-build-checksum.outputs.checksum }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -55,13 +55,13 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Free disk space"
         uses: ./.github/actions/free-disk-space
@@ -86,7 +86,7 @@ jobs:
         run: echo "checksum=$(./scripts/docker_build_checksum.sh)" >> $GITHUB_OUTPUT
 
       - name: "Setup cache for Docker buildx (${{ matrix.arch }})"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .cache/docker/buildx
           key: cache-v1-buildx-${{ runner.os }}-${{ matrix.arch }}-${{ steps.docker-build-checksum.outputs.checksum }}
@@ -97,7 +97,7 @@ jobs:
             cache-v1-buildx-${{ runner.os }}-
 
       - name: "Setup cache for Rust and Cargo"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .cache/docker/.cargo
@@ -130,7 +130,7 @@ jobs:
           sed -i -e "s|DATA_FULL_DOMAIN=https://data.master.clades.nextstrain.org/v3|DATA_FULL_DOMAIN=${DATA_FULL_DOMAIN}|g" .env
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: nextstrainbot
@@ -145,7 +145,7 @@ jobs:
           CROSS="${{ matrix.arch }}" ./docker/dev build-release
 
       - name: "Upload build artifacts (${{ matrix.arch }})"
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: out-${{ matrix.arch }}
           path: ./.out/*
@@ -159,13 +159,13 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Free disk space"
         uses: ./.github/actions/free-disk-space
@@ -175,7 +175,7 @@ jobs:
         run: echo "checksum=$(./scripts/docker_build_checksum.sh)" >> $GITHUB_OUTPUT
 
       - name: "Setup cache for Docker buildx"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .cache/docker/buildx
           key: cache-v1-buildx-unit-tests-${{ runner.os }}-${{ steps.docker-build-checksum.outputs.checksum }}
@@ -184,7 +184,7 @@ jobs:
             cache-v1-buildx-unit-tests-${{ runner.os }}-
 
       - name: "Setup cache for Rust and Cargo"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .cache/docker/.cargo
@@ -213,13 +213,13 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Free disk space"
         uses: ./.github/actions/free-disk-space
@@ -229,7 +229,7 @@ jobs:
         run: echo "checksum=$(./scripts/docker_build_checksum.sh)" >> $GITHUB_OUTPUT
 
       - name: "Setup cache for Docker buildx"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .cache/docker/buildx
           key: cache-v1-buildx-lints-${{ runner.os }}-${{ steps.docker-build-checksum.outputs.checksum }}
@@ -238,7 +238,7 @@ jobs:
             cache-v1-buildx-lints-${{ runner.os }}-
 
       - name: "Setup cache for Rust and Cargo"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .cache/docker/.cargo
@@ -267,7 +267,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -284,7 +284,7 @@ jobs:
           curl -sSL "https://github.com/shenwei356/seqkit/releases/download/v${SEQKIT_VERSION}/seqkit_linux_amd64.tar.gz" | tar -C "${HOME}/bin" -xz "seqkit"
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: out-*
           merge-multiple: true
@@ -308,13 +308,13 @@ jobs:
   #
   #    steps:
   #      - name: "Checkout code"
-  #        uses: actions/checkout@v5
+  #        uses: actions/checkout@v7
   #        with:
   #          fetch-depth: 1
   #          submodules: true
   #
   #      - name: "Download build artifacts"
-  #        uses: actions/download-artifact@v6
+  #        uses: actions/download-artifact@v8
   #        with:
   #          name: "out"
   #          path: ".out"
@@ -332,19 +332,19 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Free disk space"
         uses: ./.github/actions/free-disk-space
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: out-*
           merge-multiple: true
@@ -363,7 +363,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -372,7 +372,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: out-*
           merge-multiple: true
@@ -395,13 +395,13 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: out-*
           merge-multiple: true
@@ -435,13 +435,13 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: out-*
           merge-multiple: true
@@ -454,10 +454,10 @@ jobs:
           curl -fsSL "https://github.com/TomWright/dasel/releases/download/v${DASEL_VERSION}/dasel_linux_amd64" -o "${HOME}/bin/dasel" && chmod +x "${HOME}/bin/dasel"
 
       - name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Build and test Docker images"
         run: |
@@ -473,13 +473,13 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: out-*
           merge-multiple: true
@@ -492,17 +492,17 @@ jobs:
           curl -fsSL "https://github.com/TomWright/dasel/releases/download/v${DASEL_VERSION}/dasel_linux_amd64" -o "${HOME}/bin/dasel" && chmod +x "${HOME}/bin/dasel"
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: nextstrainbot
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Build and publish Docker container images to Docker Hub"
         run: |

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Free disk space"
         run: |
@@ -104,7 +104,7 @@ jobs:
           echo "PLAUSIBLE_IO_DOMAIN=master.clades.nextstrain.org" >> $GITHUB_ENV
 
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -114,7 +114,7 @@ jobs:
         run: echo "checksum=$(./scripts/docker_build_checksum.sh)" >> $GITHUB_OUTPUT
 
       - name: "Setup cache for Docker buildx"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .cache/docker/buildx
           key: cache-v1-buildx-${{ runner.os }}-wasm32-unknown-unknown-${{ steps.docker-build-checksum.outputs.checksum }}
@@ -125,7 +125,7 @@ jobs:
             cache-v1-buildx-${{ runner.os }}-
 
       - name: "Setup cache for Rust and Cargo"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .build/
@@ -138,7 +138,7 @@ jobs:
             cache-v1-cargo-${{ runner.os }}-
 
       - name: "Setup cache for web app"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             packages/nextclade-web/.build/production/tmp/cache
@@ -157,7 +157,7 @@ jobs:
           sed -i -e "s|DATA_FULL_DOMAIN=https://data.master.clades.nextstrain.org/v3|DATA_FULL_DOMAIN=${DATA_FULL_DOMAIN}|g" .env
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: nextstrainbot
@@ -188,7 +188,7 @@ jobs:
           ./docker/dev lint-ci
 
       - name: "Upload build artifacts"
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: out
           path: "packages/nextclade-web/.build/production/web"
@@ -229,13 +229,13 @@ jobs:
           echo "AWS_S3_BUCKET=${{ secrets.MASTER_AWS_S3_BUCKET }}" >> $GITHUB_ENV
 
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
       - name: "Download build artifacts"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: "out"
           path: "packages/nextclade-web/.build/production/web"
@@ -284,12 +284,12 @@ jobs:
     needs: [ build-web ]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: out
           path: out

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@
 \.Trashes
 \.vscode/*
 ehthumbs.db
-node_modules/
+node_modules
 Thumbs.db


### PR DESCRIPTION
CI logs emit Node 20 deprecation warnings on nearly every job. Several pinned actions still declare `runs.using: node20` in their `action.yml`, so GitHub forces them onto Node 24 and warns that Node 20 support is being removed.

This bumps each affected action to a release that runs on Node 24. Where a nextstrain sibling repository already uses the action, this adopts the same major it runs; otherwise it takes the latest major. The Docker actions are not used by the sibling repositories, so they move to their latest major.

The versions are safe to adopt as-is: the sibling repositories run these exact majors in production, and every action input in use here (`fetch-depth`, `submodules`, `cache` path/key/restore-keys, artifact upload and download) is unchanged across the bump. The `upload-artifact` v7 and `download-artifact` v8 pair share the v4 artifact backend and are compatible.

### Work items

- [x] Bump `actions/checkout` to v7 and `actions/cache` to v6
- [x] Bump `actions/upload-artifact` to v7 and `actions/download-artifact` to v8
- [x] Bump `docker/setup-buildx-action`, `docker/login-action`, and `docker/setup-qemu-action` to v4
- [x] Drop the trailing slash from the `node_modules` `.gitignore` pattern so it also ignores the symlink that worktrees create