### PR TITLE
docs: clarify private mutation window count

### DIFF
--- a/docs/user/algorithm/06-quality-control.md
+++ b/docs/user/algorithm/06-quality-control.md
@@ -45,7 +45,7 @@ Ambiguous nucleotides (such as `R`, `Y`, etc) are often indicative of contaminat
 
 ### Mutation clusters (C)
 
-To be more sensitive for quality problems in a narrow area of a genome, the mutation cluster rule counts the number of private within all possible 100-nucleotide windows (`windowSize`).
+To be more sensitive for quality problems in a narrow area of a genome, the mutation cluster rule counts the number of private mutations within all possible 100-nucleotide windows (`windowSize`).
 If that number exceeds 6 (`clusterCutOff`), this counts as an SNP cluster.
 The quality score is the number of clusters times 50 (`scoreWeight`), hence 1 cluster will cause the cluster rule to be mediocre.
 


### PR DESCRIPTION
`docs/fix-private-mutation-window-wording` -> `master`

The mutation cluster description leaves the counted quantity grammatically incomplete. [[doc](https://github.com/nextstrain/nextclade/blob/2ebe64f92daf8056e7817051991589f64074bba9/docs/user/algorithm/06-quality-control.md#L48)]

### Work items

- [x] Clarify that the rule counts private mutations within every possible 100-nucleotide window. [[doc](https://github.com/nextstrain/nextclade/blob/6167b4290f3c1408932feb6c5e7e461ced996d6f/docs/user/algorithm/06-quality-control.md#L48)]
